### PR TITLE
Added Portainer Agent

### DIFF
--- a/.templates/portainer_agent/service.yml
+++ b/.templates/portainer_agent/service.yml
@@ -1,0 +1,9 @@
+  portainer_agent:
+    image: portainer/agent
+    container_name: agent
+    ports:
+      - 9002:9001
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/lib/docker/volumes:/var/lib/docker/volumes
+    restart: always

--- a/menu.sh
+++ b/menu.sh
@@ -5,6 +5,7 @@ pushd ~/IOTstack
 
 declare -A cont_array=(
 	[portainer]="Portainer"
+	[portainer_agent]="Portainer agent"
 	[nodered]="Node-RED"
 	[influxdb]="InfluxDB"
 	[telegraf]="Telegraf (Requires InfluxDB and Mosquitto)"
@@ -32,7 +33,7 @@ declare -A cont_array=(
 )
 declare -a armhf_keys=("portainer" "nodered" "influxdb" "grafana" "mosquitto" "telegraf" "mariadb" "postgres"
 	"adminer" "openhab" "zigbee2mqtt" "pihole" "plex" "tasmoadmin" "rtl_433" "espruinohub"
-	"motioneye" "webthings_gateway" "blynk_server" "nextcloud" "diyhue" "homebridge" "python")
+	"motioneye" "webthings_gateway" "blynk_server" "nextcloud" "diyhue" "homebridge" "python" "portainer_agent")
 
 sys_arch=$(uname -m)
 


### PR DESCRIPTION
Added Portainer Agent this allows you to connect your stack to a other Portainer instance/ server

This is from: https://github.com/gcgarner/IOTstack/pull/123 Contributor: @Willem-Dekker

Setup process for the agent: https://portainer.readthedocs.io/en/stable/agent.html