### PR TITLE
Update menu.sh

### DIFF
--- a/menu.sh
+++ b/menu.sh
@@ -231,7 +231,7 @@ case $mainmenu_selection in
 	#if no container is selected then dont overwrite the docker-compose.yml file
 	if [ -n "$container_selection" ]; then
 		touch docker-compose.yml
-		echo "version: '2'" >docker-compose.yml
+		echo "version: '3.7'" >docker-compose.yml
 		echo "services:" >>docker-compose.yml
 
 		#set the ACL for the stack

--- a/menu.sh
+++ b/menu.sh
@@ -231,7 +231,7 @@ case $mainmenu_selection in
 	#if no container is selected then dont overwrite the docker-compose.yml file
 	if [ -n "$container_selection" ]; then
 		touch docker-compose.yml
-		echo "version: '3.7'" >docker-compose.yml
+		echo "version: '3.6'" >docker-compose.yml
 		echo "services:" >>docker-compose.yml
 
 		#set the ACL for the stack


### PR DESCRIPTION
Version "2" of the docker-compose.yml cannot use "Healthcheck" instructions.  Only 2.1+ can do this.  I propose we upgrade the version to at least 3 so we can incorporate HealthCheck commands and any other new features as appropriate.  We're running the latest version of docker - the latest version of the docker-compose.yml is 3.7 - unless there's a really, really good reason to use an older format of the docker-compose.yml, can we please update it to at least 3.0, preferably 3.7?

This is from: gcgarner#139 Contributor: @RavHilton