### PR TITLE
update menu.sh for hassio

### DIFF
--- a/menu.sh
+++ b/menu.sh
@@ -406,7 +406,7 @@ case $mainmenu_selection in
 		"tinker" " " \
 		3>&1 1>&2 2>&3)
 	if [ -n "$hassio_machine" ]; then
-		curl -sL https://raw.githubusercontent.com/home-assistant/hassio-installer/master/hassio_install.sh | sudo bash -s -- -m $hassio_machine
+		curl -sL https://raw.githubusercontent.com/home-assistant/supervised-installer/master/installer.sh | sudo bash -s -- -m $hassio_machine
 	else
 		echo "no selection"
 		exit


### PR DESCRIPTION
The url for the supervised HASSIO is changed, because the old one is resulting with error 404 and you cannot finish the installation

This is from: gcgarner#169 Contributor: @peyanski