### PR TITLE
Add Nginx Reverse proxy

### DIFF
--- a/.templates/adminer/service.yml
+++ b/.templates/adminer/service.yml
@@ -4,3 +4,6 @@
     restart: unless-stopped
     ports:
       - 9080:8080
+    environment:
+      - VIRTUAL_HOST=~^adminer\..*\.xip\.io
+      - VIRTUAL_PORT=9080

--- a/.templates/blynk_server/service.yml
+++ b/.templates/blynk_server/service.yml
@@ -8,4 +8,7 @@
       - 9443:9443
     volumes:
       - ./volumes/blynk_server/data:/data
+    environment:
+      - VIRTUAL_HOST=~^blynk\..*\.xip\.io
+      - VIRTUAL_PORT=8180
 

--- a/.templates/diyhue/service.yml
+++ b/.templates/diyhue/service.yml
@@ -9,6 +9,9 @@
       # - "443:443/tcp"
     env_file:
       - ./services/diyhue/diyhue.env
+    environment:
+      - VIRTUAL_HOST=~^diyhue\..*\.xip\.io
+      - VIRTUAL_PORT=8070
     volumes:
        - ./volumes/diyhue/:/opt/hue-emulator/export/
     restart: unless-stopped

--- a/.templates/grafana/service.yml
+++ b/.templates/grafana/service.yml
@@ -7,6 +7,9 @@
       - 3000:3000
     env_file:
       - ./services/grafana/grafana.env
+    environment:
+      - VIRTUAL_HOST=~^grafana\..*\.xip\.io
+      - VIRTUAL_PORT=3000
     volumes:
       - ./volumes/grafana/data:/var/lib/grafana
       - ./volumes/grafana/log:/var/log/grafana

--- a/.templates/homebridge/service.yml
+++ b/.templates/homebridge/service.yml
@@ -2,7 +2,11 @@
     container_name: homebridge
     image: oznu/homebridge:no-avahi-arm32v6
     restart: unless-stopped
-    network_mode: host
+    ports:
+      - 8380:8080
     env_file: ./services/homebridge/homebridge.env
+    environment:
+      - VIRTUAL_HOST=~^homebridge\..*\.xip\.io
+      - VIRTUAL_PORT=8380
     volumes:
       - ./volumes/homebridge:/homebridge

--- a/.templates/influxdb/service.yml
+++ b/.templates/influxdb/service.yml
@@ -8,6 +8,9 @@
       - 2003:2003
     env_file:
       - ./services/influxdb/influxdb.env
+    environment:
+      - VIRTUAL_HOST=~^influxdb\..*\.xip\.io
+      - VIRTUAL_PORT=8086
     volumes:
       - ./volumes/influxdb/data:/var/lib/influxdb
       - ./backups/influxdb/db:/var/lib/influxdb/backup

--- a/.templates/nextcloud/service.yml
+++ b/.templates/nextcloud/service.yml
@@ -10,6 +10,9 @@
       - nextcloud_db
     links:
       - nextcloud_db
+    environment:
+      - VIRTUAL_HOST=~^nextcloud\..*\.xip\.io
+      - VIRTUAL_PORT=9321
 
   nextcloud_db:
     image: linuxserver/mariadb

--- a/.templates/nginx-proxy/directoryfix.sh
+++ b/.templates/nginx-proxy/directoryfix.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+if [ ! -d ./volumes/nginx-proxy/nginx-conf ]; then
+	sudo mkdir -p ./volumes/nginx-proxy/nginx-conf
+	sudo chown -R pi:pi ./volumes/nginx-proxy/nginx-conf
+fi
+
+if [ ! -d ./volumes/nginx-proxy/nginx-vhost ]; then
+	sudo mkdir -p ./volumes/nginx-proxy/nginx-vhost
+	sudo chown -R pi:pi ./volumes/nginx-proxy/nginx-vhost
+fi
+
+if [ ! -d ./volumes/nginx-proxy/html ]; then
+	sudo mkdir -p ./volumes/nginx-proxy/html
+	sudo chown -R pi:pi ./volumes/nginx-proxy/html
+fi
+
+if [ ! -d ./volumes/nginx-proxy/certs ]; then
+	sudo mkdir -p ./volumes/nginx-proxy/certs
+	sudo chown -R pi:pi ./volumes/nginx-proxy/certs
+fi
+
+if [ ! -d ./volumes/nginx-proxy/log ]; then
+	sudo mkdir -p ./volumes/nginx-proxy/log
+	sudo chown -R pi:pi ./volumes/nginx-proxy/log
+fi
+
+cp ./services/nginx-proxy//nginx.tmpl ./volumes/nginx-proxy

--- a/.templates/nginx-proxy/nginx.tmpl
+++ b/.templates/nginx-proxy/nginx.tmpl
@@ -1,0 +1,402 @@
+{{ $CurrentContainer := where $ "ID" .Docker.CurrentContainerID | first }}
+
+{{ $external_http_port := coalesce $.Env.HTTP_PORT "80" }}
+{{ $external_https_port := coalesce $.Env.HTTPS_PORT "443" }}
+
+{{ define "upstream" }}
+	{{ if .Address }}
+		{{/* If we got the containers from swarm and this container's port is published to host, use host IP:PORT */}}
+		{{ if and .Container.Node.ID .Address.HostPort }}
+			# {{ .Container.Node.Name }}/{{ .Container.Name }}
+			server {{ .Container.Node.Address.IP }}:{{ .Address.HostPort }};
+		{{/* If there is no swarm node or the port is not published on host, use container's IP:PORT */}}
+		{{ else if .Network }}
+			# {{ .Container.Name }}
+			server {{ .Network.IP }}:{{ .Address.Port }};
+		{{ end }}
+	{{ else if .Network }}
+		# {{ .Container.Name }}
+		{{ if .Network.IP }}
+			server {{ .Network.IP }} down;
+		{{ else }}
+			server 127.0.0.1 down;
+		{{ end }}
+	{{ end }}
+
+{{ end }}
+
+{{ define "ssl_policy" }}
+	{{ if eq .ssl_policy "Mozilla-Modern" }}
+		ssl_protocols TLSv1.3;
+		{{/* nginx currently lacks ability to choose ciphers in TLS 1.3 in configuration, see https://trac.nginx.org/nginx/ticket/1529 /*}}
+		{{/* a possible workaround can be modify /etc/ssl/openssl.cnf to change it globally (see https://trac.nginx.org/nginx/ticket/1529#comment:12 ) /*}}
+		{{/* explicitly set ngnix default value in order to allow single servers to override the global http value */}}
+		ssl_ciphers HIGH:!aNULL:!MD5;
+		ssl_prefer_server_ciphers off;
+	{{ else if eq .ssl_policy "Mozilla-Intermediate" }}
+		ssl_protocols TLSv1.2 TLSv1.3;
+		ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384';
+		ssl_prefer_server_ciphers off;
+	{{ else if eq .ssl_policy "Mozilla-Old" }}
+		ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+		ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA';
+		ssl_prefer_server_ciphers on;
+	{{ else if eq .ssl_policy "AWS-TLS-1-2-2017-01" }}
+		ssl_protocols TLSv1.2 TLSv1.3;
+		ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:AES128-GCM-SHA256:AES128-SHA256:AES256-GCM-SHA384:AES256-SHA256';
+		ssl_prefer_server_ciphers on;
+	{{ else if eq .ssl_policy "AWS-TLS-1-1-2017-01" }}
+		ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
+		ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA';
+		ssl_prefer_server_ciphers on;
+	{{ else if eq .ssl_policy "AWS-2016-08" }}
+		ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+		ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA';
+		ssl_prefer_server_ciphers on;
+	{{ else if eq .ssl_policy "AWS-2015-05" }}
+		ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+		ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:DES-CBC3-SHA';
+		ssl_prefer_server_ciphers on;
+	{{ else if eq .ssl_policy "AWS-2015-03" }}
+		ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+		ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:DHE-DSS-AES128-SHA:DES-CBC3-SHA';
+		ssl_prefer_server_ciphers on;
+	{{ else if eq .ssl_policy "AWS-2015-02" }}
+		ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
+		ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:DHE-DSS-AES128-SHA';
+		ssl_prefer_server_ciphers on;
+	{{ end }}
+{{ end }}
+
+# If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
+# scheme used to connect to this server
+map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+  default $http_x_forwarded_proto;
+  ''      $scheme;
+}
+
+# If we receive X-Forwarded-Port, pass it through; otherwise, pass along the
+# server port the client connected to
+map $http_x_forwarded_port $proxy_x_forwarded_port {
+  default $http_x_forwarded_port;
+  ''      $server_port;
+}
+
+# If we receive Upgrade, set Connection to "upgrade"; otherwise, delete any
+# Connection header that may have been passed to this server
+map $http_upgrade $proxy_connection {
+  default upgrade;
+  '' close;
+}
+
+# Apply fix for very long server names
+server_names_hash_bucket_size 128;
+
+# Default dhparam
+{{ if (exists "/etc/nginx/dhparam/dhparam.pem") }}
+ssl_dhparam /etc/nginx/dhparam/dhparam.pem;
+{{ end }}
+
+# Set appropriate X-Forwarded-Ssl header
+map $scheme $proxy_x_forwarded_ssl {
+  default off;
+  https on;
+}
+
+gzip_types text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+log_format vhost '$host $remote_addr - $remote_user [$time_local] '
+                 '"$request" $status $body_bytes_sent '
+                 '"$http_referer" "$http_user_agent"';
+
+access_log off;
+
+{{/* Get the SSL_POLICY defined by this container, falling back to "Mozilla-Intermediate" */}}
+{{ $ssl_policy := or ($.Env.SSL_POLICY) "Mozilla-Intermediate" }}
+{{ template "ssl_policy" (dict "ssl_policy" $ssl_policy) }}
+
+{{ if $.Env.RESOLVERS }}
+resolver {{ $.Env.RESOLVERS }};
+{{ end }}
+
+{{ if (exists "/etc/nginx/proxy.conf") }}
+include /etc/nginx/proxy.conf;
+{{ else }}
+# HTTP 1.1 support
+proxy_http_version 1.1;
+proxy_buffering off;
+proxy_set_header Host $http_host;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection $proxy_connection;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+proxy_set_header X-Forwarded-Ssl $proxy_x_forwarded_ssl;
+proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
+
+# Mitigate httpoxy attack (see README for details)
+proxy_set_header Proxy "";
+{{ end }}
+
+{{ $access_log := (or (and (not $.Env.DISABLE_ACCESS_LOGS) "access_log /var/log/nginx/access.log vhost;") "") }}
+
+{{ $enable_ipv6 := eq (or ($.Env.ENABLE_IPV6) "") "true" }}
+server {
+	server_name _; # This is just an invalid value which will never trigger on a real hostname.
+	listen {{ $external_http_port }};
+	{{ if $enable_ipv6 }}
+	listen [::]:{{ $external_http_port }};
+	{{ end }}
+	{{ $access_log }}
+	return 503;
+}
+
+{{ if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
+server {
+	server_name _; # This is just an invalid value which will never trigger on a real hostname.
+	listen {{ $external_https_port }} ssl http2;
+	{{ if $enable_ipv6 }}
+	listen [::]:{{ $external_https_port }} ssl http2;
+	{{ end }}
+	{{ $access_log }}
+	return 503;
+
+	ssl_session_cache shared:SSL:50m;
+	ssl_session_tickets off;
+	ssl_certificate /etc/nginx/certs/default.crt;
+	ssl_certificate_key /etc/nginx/certs/default.key;
+}
+{{ end }}
+
+{{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
+
+{{ $host := trim $host }}
+{{ $is_regexp := hasPrefix "~" $host }}
+{{ $upstream_name := when $is_regexp (sha1 $host) $host }}
+
+# {{ $host }}
+upstream {{ $upstream_name }} {
+
+{{ range $container := $containers }}
+	{{ $addrLen := len $container.Addresses }}
+
+	{{ range $knownNetwork := $CurrentContainer.Networks }}
+		{{ range $containerNetwork := $container.Networks }}
+			{{ if (and (ne $containerNetwork.Name "ingress") (or (eq $knownNetwork.Name $containerNetwork.Name) (eq $knownNetwork.Name "host"))) }}
+				## Can be connected with "{{ $containerNetwork.Name }}" network
+
+				{{/* If only 1 port exposed, use that */}}
+				{{ if eq $addrLen 1 }}
+					{{ $address := index $container.Addresses 0 }}
+					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
+				{{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var, falling back to standard web port 80 */}}
+				{{ else }}
+					{{ $port := coalesce $container.Env.VIRTUAL_PORT "80" }}
+					{{ $address := where $container.Addresses "Port" $port | first }}
+					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
+				{{ end }}
+			{{ else }}
+				# Cannot connect to network of this container
+				server 127.0.0.1 down;
+			{{ end }}
+		{{ end }}
+	{{ end }}
+{{ end }}
+}
+
+{{ $default_host := or ($.Env.DEFAULT_HOST) "" }}
+{{ $default_server := index (dict $host "" $default_host "default_server") $host }}
+
+{{/* Get the VIRTUAL_PROTO defined by containers w/ the same vhost, falling back to "http" */}}
+{{ $proto := trim (or (first (groupByKeys $containers "Env.VIRTUAL_PROTO")) "http") }}
+
+{{/* Get the NETWORK_ACCESS defined by containers w/ the same vhost, falling back to "external" */}}
+{{ $network_tag := or (first (groupByKeys $containers "Env.NETWORK_ACCESS")) "external" }}
+
+{{/* Get the HTTPS_METHOD defined by containers w/ the same vhost, falling back to "redirect" */}}
+{{ $https_method := or (first (groupByKeys $containers "Env.HTTPS_METHOD")) "redirect" }}
+
+{{/* Get the SSL_POLICY defined by containers w/ the same vhost, falling back to empty string (use default) */}}
+{{ $ssl_policy := or (first (groupByKeys $containers "Env.SSL_POLICY")) "" }}
+
+{{/* Get the HSTS defined by containers w/ the same vhost, falling back to "max-age=31536000" */}}
+{{ $hsts := or (first (groupByKeys $containers "Env.HSTS")) "max-age=31536000" }}
+
+{{/* Get the VIRTUAL_ROOT By containers w/ use fastcgi root */}}
+{{ $vhost_root := or (first (groupByKeys $containers "Env.VIRTUAL_ROOT")) "/var/www/public" }}
+
+
+{{/* Get the first cert name defined by containers w/ the same vhost */}}
+{{ $certName := (first (groupByKeys $containers "Env.CERT_NAME")) }}
+
+{{/* Get the best matching cert  by name for the vhost. */}}
+{{ $vhostCert := (closest (dir "/etc/nginx/certs") (printf "%s.crt" $host))}}
+
+{{/* vhostCert is actually a filename so remove any suffixes since they are added later */}}
+{{ $vhostCert := trimSuffix ".crt" $vhostCert }}
+{{ $vhostCert := trimSuffix ".key" $vhostCert }}
+
+{{/* Use the cert specified on the container or fallback to the best vhost match */}}
+{{ $cert := (coalesce $certName $vhostCert) }}
+
+{{ $is_https := (and (ne $https_method "nohttps") (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) }}
+
+{{ if $is_https }}
+
+{{ if eq $https_method "redirect" }}
+server {
+	server_name {{ $host }};
+	listen {{ $external_http_port }} {{ $default_server }};
+	{{ if $enable_ipv6 }}
+	listen [::]:{{ $external_http_port }} {{ $default_server }};
+	{{ end }}
+	{{ $access_log }}
+	
+	# Do not HTTPS redirect Let'sEncrypt ACME challenge
+	location /.well-known/acme-challenge/ {
+		auth_basic off;
+		allow all;
+		root /usr/share/nginx/html;
+		try_files $uri =404;
+		break;
+	}
+	
+	location / {
+		return 301 https://$host$request_uri;
+	}
+}
+{{ end }}
+
+server {
+	server_name {{ $host }};
+	listen {{ $external_https_port }} ssl http2 {{ $default_server }};
+	{{ if $enable_ipv6 }}
+	listen [::]:{{ $external_https_port }} ssl http2 {{ $default_server }};
+	{{ end }}
+	{{ $access_log }}
+
+	{{ if eq $network_tag "internal" }}
+	# Only allow traffic from internal clients
+	include /etc/nginx/network_internal.conf;
+	{{ end }}
+
+	{{ template "ssl_policy" (dict "ssl_policy" $ssl_policy) }}
+
+	ssl_session_timeout 5m;
+	ssl_session_cache shared:SSL:50m;
+	ssl_session_tickets off;
+
+	ssl_certificate /etc/nginx/certs/{{ (printf "%s.crt" $cert) }};
+	ssl_certificate_key /etc/nginx/certs/{{ (printf "%s.key" $cert) }};
+
+	{{ if (exists (printf "/etc/nginx/certs/%s.dhparam.pem" $cert)) }}
+	ssl_dhparam {{ printf "/etc/nginx/certs/%s.dhparam.pem" $cert }};
+	{{ end }}
+
+	{{ if (exists (printf "/etc/nginx/certs/%s.chain.pem" $cert)) }}
+	ssl_stapling on;
+	ssl_stapling_verify on;
+	ssl_trusted_certificate {{ printf "/etc/nginx/certs/%s.chain.pem" $cert }};
+	{{ end }}
+
+	{{ if (not (or (eq $https_method "noredirect") (eq $hsts "off"))) }}
+	add_header Strict-Transport-Security "{{ trim $hsts }}" always;
+	{{ end }}
+
+	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
+	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
+	{{ else if (exists "/etc/nginx/vhost.d/default") }}
+	include /etc/nginx/vhost.d/default;
+	{{ end }}
+
+	location / {
+		{{ if eq $proto "uwsgi" }}
+		include uwsgi_params;
+		uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
+		{{ else if eq $proto "fastcgi" }}
+		root   {{ trim $vhost_root }};
+		include fastcgi_params;
+		fastcgi_pass {{ trim $upstream_name }};
+		{{ else if eq $proto "grpc" }}
+		grpc_pass {{ trim $proto }}://{{ trim $upstream_name }};
+		{{ else }}
+		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
+		{{ end }}
+
+		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
+		auth_basic	"Restricted {{ $host }}";
+		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+		{{ end }}
+		{{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
+		include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
+		{{ else if (exists "/etc/nginx/vhost.d/default_location") }}
+		include /etc/nginx/vhost.d/default_location;
+		{{ end }}
+	}
+}
+
+{{ end }}
+
+{{ if or (not $is_https) (eq $https_method "noredirect") }}
+
+server {
+	server_name {{ $host }};
+	listen {{ $external_http_port }} {{ $default_server }};
+	{{ if $enable_ipv6 }}
+	listen [::]:80 {{ $default_server }};
+	{{ end }}
+	{{ $access_log }}
+
+	{{ if eq $network_tag "internal" }}
+	# Only allow traffic from internal clients
+	include /etc/nginx/network_internal.conf;
+	{{ end }}
+
+	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
+	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
+	{{ else if (exists "/etc/nginx/vhost.d/default") }}
+	include /etc/nginx/vhost.d/default;
+	{{ end }}
+
+	location / {
+		{{ if eq $proto "uwsgi" }}
+		include uwsgi_params;
+		uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
+		{{ else if eq $proto "fastcgi" }}
+		root   {{ trim $vhost_root }};
+		include fastcgi_params;
+		fastcgi_pass {{ trim $upstream_name }};
+		{{ else if eq $proto "grpc" }}
+		grpc_pass {{ trim $proto }}://{{ trim $upstream_name }};
+		{{ else }}
+		proxy_pass {{ trim $proto }}://{{ trim $upstream_name }};
+		{{ end }}
+		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
+		auth_basic	"Restricted {{ $host }}";
+		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+		{{ end }}
+		{{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
+		include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
+		{{ else if (exists "/etc/nginx/vhost.d/default_location") }}
+		include /etc/nginx/vhost.d/default_location;
+		{{ end }}
+	}
+}
+
+{{ if (and (not $is_https) (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
+server {
+	server_name {{ $host }};
+	listen {{ $external_https_port }} ssl http2 {{ $default_server }};
+	{{ if $enable_ipv6 }}
+	listen [::]:{{ $external_https_port }} ssl http2 {{ $default_server }};
+	{{ end }}
+	{{ $access_log }}
+	return 500;
+
+	ssl_certificate /etc/nginx/certs/default.crt;
+	ssl_certificate_key /etc/nginx/certs/default.key;
+}
+{{ end }}
+
+{{ end }}
+{{ end }}

--- a/.templates/nginx-proxy/service.yml
+++ b/.templates/nginx-proxy/service.yml
@@ -1,0 +1,49 @@
+ # As described in https://github.com/nginx-proxy/nginx-proxy. We use separate containers.
+ # The HTTPS implementation as documented here: https://medium.com/@francoisromain/host-multiple-websites-with-https-inside-docker-containers-on-a-single-server-18467484ab95
+ # We are using xip.io to be able make subdomains for IP address. So the nodered service can be accessed:
+ #   nodered.X.X.X.X.xip.org where X.X.X.X is the IP address of IOTstack. Any other domain can be used, on that case please
+ # replace VIRTUAL_HOST env variable of the given instance with the coresponding value.
+
+  nginx-proxy:
+    image: nginx
+    container_name: nginx-proxy
+    network_mode: host
+    restart: unless-stopped  # Always restart container
+    ports:
+      - "80:80"      # Port mappings in format host:container
+      - "443:443"
+    labels:
+      - "com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy"   # Label needed for Let's Encrypt companion container
+    volumes:   # Volumes needed for container to configure proixes and access certificates genereated by Let's Encrypt companion container
+      - "./volumes/nginx-proxy/nginx-conf:/etc/nginx/conf.d"
+      - "./volumes/nginx-proxy/nginx-vhost:/etc/nginx/vhost.d"
+      - "./volumes/nginx-proxy/html:/usr/share/nginx/html"
+      - "./volumes/nginx-proxy/certs:/etc/nginx/certs:ro"
+      - "./volumes/nginx-proxy/log:/var/log/nginx"
+
+  nginx-gen:
+    image: ajoubert/docker-gen-arm
+    command: -notify-sighup nginx-proxy -watch -wait 5s:30s /etc/docker-gen/templates/nginx.tmpl /etc/nginx/conf.d/default.conf
+    container_name: nginx-gen
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - "./volumes/nginx-proxy/nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl:ro"
+      - "./volumes/nginx-proxy/nginx-conf:/etc/nginx/conf.d"
+      - "./volumes/nginx-proxy/nginx-vhost:/etc/nginx/vhost.d"
+      - "./volumes/nginx-proxy/html:/usr/share/nginx/html"
+      - "./volumes/nginx-proxy/certs:/etc/nginx/certs:ro"
+
+  nginx-letsencrypt:
+    image: budry/jrcs-letsencrypt-nginx-proxy-companion-arm
+    container_name: nginx-letsencrypt
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - "./volumes/nginx-proxy/nginx-conf:/etc/nginx/conf.d"
+      - "./volumes/nginx-proxy/nginx-vhost:/etc/nginx/vhost.d"
+      - "./volumes/nginx-proxy/html:/usr/share/nginx/html"
+      - "./volumes/nginx-proxy/certs:/etc/nginx/certs:rw"
+    environment:
+      NGINX_DOCKER_GEN_CONTAINER: "nginx-gen"
+      NGINX_PROXY_CONTAINER: "nginx-proxy"

--- a/.templates/nodered/service.yml
+++ b/.templates/nodered/service.yml
@@ -5,6 +5,9 @@
     user: "0"
     privileged: true
     env_file: ./services/nodered/nodered.env
+    environment:
+      - VIRTUAL_HOST=~^nodered\..*\.xip\.io
+      - VIRTUAL_PORT=1880
     ports:
       - 1880:1880
     volumes:

--- a/.templates/openhab/service.yml
+++ b/.templates/openhab/service.yml
@@ -1,8 +1,8 @@
   openhab:
-    image: "openhab/openhab:2.4.0"
+    image: "openhab/openhab:2.5.3"
     container_name: openhab
     restart: unless-stopped
-    network_mode: host
+#    network_mode: host
 #    cap_add:
 #      - NET_ADMIN
 #      - NET_RAW
@@ -16,6 +16,10 @@
       OPENHAB_HTTP_PORT: "8080"
       OPENHAB_HTTPS_PORT: "8443"
       EXTRA_JAVA_OPTS: "-Duser.timezone=Europe/Berlin"
+    environment:
+      - VIRTUAL_HOST=~^openhab\..*\.xip\.io
+      - VIRTUAL_PORT=8080
+
 #    # The command node is very important. It overrides
 #    # the "gosu openhab tini -s ./start.sh" command from Dockerfile and runs as root!
 #    command: "tini -s ./start.sh server"

--- a/.templates/pihole/service.yml
+++ b/.templates/pihole/service.yml
@@ -9,6 +9,9 @@
       #- "443:443/tcp"
     env_file:
       - ./services/pihole/pihole.env
+    environment:
+      - VIRTUAL_HOST=~^pihole\..*\.xip\.io
+      - VIRTUAL_PORT=8089
     volumes:
        - ./volumes/pihole/etc-pihole/:/etc/pihole/
        - ./volumes/pihole/etc-dnsmasq.d/:/etc/dnsmasq.d/

--- a/.templates/portainer/service.yml
+++ b/.templates/portainer/service.yml
@@ -4,6 +4,9 @@
     restart: unless-stopped
     ports:
       - 9000:9000
+    environment:
+      - VIRTUAL_HOST=~^portainer\..*\.xip\.io
+      - VIRTUAL_PORT=9000
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./volumes/portainer/data:/data

--- a/.templates/tasmoadmin/service.yml
+++ b/.templates/tasmoadmin/service.yml
@@ -6,4 +6,7 @@
       - "8088:80"
     volumes:
       - ./volumes/tasmoadmin/data:/data
+    environment:
+      - VIRTUAL_HOST=~^tasmoadmin\..*\.xip\.io
+      - VIRTUAL_PORT=8088
       

--- a/.templates/webthings_gateway/service.yml
+++ b/.templates/webthings_gateway/service.yml
@@ -7,6 +7,9 @@
     # - 4443:4443
     #devices:
     # - /dev/ttyACM0:/dev/ttyACM0
+    #environment:
+    #  - VIRTUAL_HOST=~^webthings\..*\.xip\.io
+    #  - VIRTUAL_PORT=8080
     volumes:
       - ./volumes/webthings_gateway/share:/home/node/.mozilla-iot
 

--- a/menu.sh
+++ b/menu.sh
@@ -5,6 +5,7 @@ pushd ~/IOTstack
 
 declare -A cont_array=(
 	[portainer]="Portainer"
+	[nginx-proxy]="Nginx Reverse Proxy"
 	[nodered]="Node-RED"
 	[influxdb]="InfluxDB"
 	[telegraf]="Telegraf (Requires InfluxDB and Mosquitto)"
@@ -30,7 +31,7 @@ declare -A cont_array=(
 	[python]="Python 3"
 
 )
-declare -a armhf_keys=("portainer" "nodered" "influxdb" "grafana" "mosquitto" "telegraf" "mariadb" "postgres"
+declare -a armhf_keys=("portainer" "nginx-proxy" "nodered" "influxdb" "grafana" "mosquitto" "telegraf" "mariadb" "postgres"
 	"adminer" "openhab" "zigbee2mqtt" "pihole" "plex" "tasmoadmin" "rtl_433" "espruinohub"
 	"motioneye" "webthings_gateway" "blynk_server" "nextcloud" "diyhue" "homebridge" "python")
 


### PR DESCRIPTION
Add support of nginx reverse proxy. It tracking all container where VIRTUAL_HOST env is defined, 
automatically generate nginx proxy config for it.

As described in https://github.com/nginx-proxy/nginx-proxy. We use separate containers.
The HTTPS implementation as documented here: https://medium.com/@francoisromain/host-multiple-websites-with-https-inside-docker-containers-on-a-single-server-18467484ab95

By default the xip.io is used to be able make subdomains for IP address. So for example the nodered service can be accessed:

nodered.X.X.X.X.xip.io 

where X.X.X.X is the IP address of IOTstack. 

Any other domain can be used, on that case please replace VIRTUAL_HOST env variable of the given instance with the coresponding value.

HTTPS can be used, but xip.io method is not suitable for that, so as the links describes any container can be exposed with the definition of HTTPS proto, but some domain have to be defined.

