### PR TITLE
Added deCONZ to stack 

### DIFF
--- a/.templates/deconz/service.yml
+++ b/.templates/deconz/service.yml
@@ -4,18 +4,18 @@
     restart: unless-stopped
     network_mode: bridge
     ports:
-      - '80:80'
-      - '443:443'
+      - '8090:80'
+      - '4439:443'
       - '5901:5900'
     volumes:
        - ./volumes/deconz/:/root/.local/share/dresden-elektronik/deCONZ
     devices:
-      #ConBee II:
-      - /dev/ttyACM0
-      #ConBee:
-      # - /dev/ttyUSB0
-      #RaspBee: 
-      # - /dev/ttyAMA0 or /dev/ttyS0
+      #ConBee II uncomment next line
+      #- /dev/ttyACM0
+      #ConBee uncomment next line
+      #- /dev/ttyUSB0
+      #RaspBee uncomment next line
+      #- /dev/ttyAMA0 or /dev/ttyS0
     environment:
       - DECONZ_VNC_MODE=1
       - DECONZ_VNC_PASSWORD=changeme

--- a/.templates/deconz/service.yml
+++ b/.templates/deconz/service.yml
@@ -9,7 +9,7 @@
       - '5901:5900'
     volumes:
        - ./volumes/deconz/:/root/.local/share/dresden-elektronik/deCONZ
-    devices:
+    #devices:
       #ConBee II uncomment next line
       #- /dev/ttyACM0
       #ConBee uncomment next line

--- a/.templates/deconz/service.yml
+++ b/.templates/deconz/service.yml
@@ -6,7 +6,7 @@
     ports:
       - '80:80'
       - '443:443'
-      - '5901:5901'
+      - '5901:5900'
     volumes:
        - ./volumes/deconz/:/root/.local/share/dresden-elektronik/deCONZ
     devices:
@@ -17,10 +17,7 @@
       #RaspBee: 
       # - /dev/ttyAMA0 or /dev/ttyS0
     environment:
-      - DECONZ_WEB_PORT=80
-      - DECONZ_WS_PORT=443
       - DECONZ_VNC_MODE=1
-      - DECONZ_VNC_PORT=5901
       - DECONZ_VNC_PASSWORD=changeme
       - DEBUG_INFO=1
       - DEBUG_APS=0

--- a/.templates/deconz/service.yml
+++ b/.templates/deconz/service.yml
@@ -1,4 +1,4 @@
-deconz:
+  deconz:
     image: marthoc/deconz
     container_name: deconz
     restart: unless-stopped

--- a/.templates/deconz/service.yml
+++ b/.templates/deconz/service.yml
@@ -1,0 +1,29 @@
+deconz:
+    image: marthoc/deconz
+    container_name: deconz
+    restart: unless-stopped
+    network_mode: bridge
+    ports:
+      - '80:80'
+      - '443:443'
+      - '5901:5901'
+    volumes:
+       - ./volumes/deconz/:/root/.local/share/dresden-elektronik/deCONZ
+    devices:
+      #ConBee II:
+      - /dev/ttyACM0
+      #ConBee:
+      # - /dev/ttyUSB0
+      #RaspBee: 
+      # - /dev/ttyAMA0 or /dev/ttyS0
+    environment:
+      - DECONZ_WEB_PORT=80
+      - DECONZ_WS_PORT=443
+      - DECONZ_VNC_MODE=1
+      - DECONZ_VNC_PORT=5901
+      - DECONZ_VNC_PASSWORD=changeme
+      - DEBUG_INFO=1
+      - DEBUG_APS=0
+      - DEBUG_ZCL=0
+      - DEBUG_ZDP=0
+      - DEBUG_OTAU=0

--- a/.templates/nodered/build.sh
+++ b/.templates/nodered/build.sh
@@ -35,6 +35,7 @@ node_selection=$(whiptail --title "Node-RED nodes" --checklist --separate-output
 	"node-red-contrib-owntracks" " " "OFF" \
 	"node-red-contrib-alexa-local" " " "OFF" \
 	"node-red-contrib-heater-controller" " " "OFF" \
+	"node-red-contrib-deconz" " " "OFF" \
 	3>&1 1>&2 2>&3)
 
 ##echo "$check_selection"

--- a/menu.sh
+++ b/menu.sh
@@ -15,6 +15,7 @@ declare -A cont_array=(
 	[adminer]="Adminer"
 	[openhab]="openHAB"
 	[zigbee2mqtt]="zigbee2mqtt"
+	[deconz]="deCONZ"
 	[pihole]="Pi-Hole"
 	[plex]="Plex media server"
 	[tasmoadmin]="TasmoAdmin"
@@ -31,7 +32,7 @@ declare -A cont_array=(
 
 )
 declare -a armhf_keys=("portainer" "nodered" "influxdb" "grafana" "mosquitto" "telegraf" "mariadb" "postgres"
-	"adminer" "openhab" "zigbee2mqtt" "pihole" "plex" "tasmoadmin" "rtl_433" "espruinohub"
+	"adminer" "openhab" "zigbee2mqtt" "deconz" "pihole" "plex" "tasmoadmin" "rtl_433" "espruinohub"
 	"motioneye" "webthings_gateway" "blynk_server" "nextcloud" "diyhue" "homebridge" "python")
 
 sys_arch=$(uname -m)


### PR DESCRIPTION
Added deCONZ docker image from https://github.com/marthoc/docker-deconz

Also added node-red-contrib-deconz as an option for the Node-RED nodes checklist

Tested on Raspberry Pi 3B and 3B+ with Conbee II, Node-RED (including node-red-contrib-deconz) and Home Assistant.

Hardware (Conbee I/II or Rasbee) must be plugged in when stack is being composed.

Fixes gcgarner#145
