### PR TITLE
Docker version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ https://sensorsiot.github.io/IOTstack/
 https://youtu.be/a6mjt8tWUws
 
 ## Installation
-1. On the (PRi) lite image you will need to install git first
+1. On the (RPi) lite image you will need to install git first
 
 ```
 sudo apt-get install git -y

--- a/menu.sh
+++ b/menu.sh
@@ -181,6 +181,25 @@ else
 fi
 
 #---------------------------------------------------------------------------------------------------
+# Docker updates
+echo "checking docker version"
+SERVER_VERSION=$(docker version -f "{{.Server.Version}}")
+SERVER_VERSION_MAJOR=$(echo "$SERVER_VERSION"| cut -d'.' -f 1)
+SERVER_VERSION_MINOR=$(echo "$SERVER_VERSION"| cut -d'.' -f 2)
+SERVER_VERSION_BUILD=$(echo "$SERVER_VERSION"| cut -d'.' -f 3)
+
+if [ "${SERVER_VERSION_MAJOR}" -ge 18 ] && \
+	[ "${SERVER_VERSION_MINOR}" -ge 2 ]  && \
+	[ "${SERVER_VERSION_BUILD}" -ge 0 ]; then
+	echo "Docker version >= 18.2.0. You are good to go."
+else
+	echo ""
+	echo "Docker version less than 18.02.0 consider upgrading or you may experience issues"
+	echo "Upgrade by typing: 'sudo apt upgrade docker docker-compose'"
+	sleep 2
+fi
+
+#---------------------------------------------------------------------------------------------------
 # Menu system starts here
 # Display main menu
 mainmenu_selection=$(whiptail --title "Main Menu" --menu --notags \


### PR DESCRIPTION
Add in docker version check on menu startup.

Tested on RPi4
![image](https://user-images.githubusercontent.com/6442613/79835723-0b6ecb00-8364-11ea-8c5d-683539e98e11.png)
After the first run, I set the major version to be `28` to produce the warning message