### PR TITLE
Removes pin of Grafana to version 6.3.6.

### DIFF
--- a/.templates/grafana/service.yml
+++ b/.templates/grafana/service.yml
@@ -1,6 +1,6 @@
   grafana:
     container_name: grafana
-    image: grafana/grafana:6.3.6
+    image: grafana/grafana
     restart: unless-stopped
     user: "0"
     ports:


### PR DESCRIPTION
Grafana is pinned to version 6.3.6. There is no obvious reason.

I removed the pinning and Grafana advanced to 6.7.3. Some of the
Grafana user interface had moved around (eg the top level contained
a panel for the Grafana blog rather than the list of installed panels)
but things like that are to be expected. There were one or two cosmetic
changes in some of my dashboards (eg font size changes in bar charts)
but the panels all worked out-of-the-box and there was nothing that
suggested any need for caution in removing the pinning to 6.3.6.