### PR TITLE
Harmonises service.yml file usage of quote marks around port mappings

### DIFF
--- a/.templates/adminer/service.yml
+++ b/.templates/adminer/service.yml
@@ -3,4 +3,4 @@
     image: adminer
     restart: unless-stopped
     ports:
-      - 9080:8080
+      - "9080:8080"

--- a/.templates/blynk_server/service.yml
+++ b/.templates/blynk_server/service.yml
@@ -3,9 +3,8 @@
     container_name: blynk_server
     restart: unless-stopped
     ports:
-      - 8180:8080
-      - 8441:8441
-      - 9443:9443
+      - "8180:8080"
+      - "8441:8441"
+      - "9443:9443"
     volumes:
       - ./volumes/blynk_server/data:/data
-

--- a/.templates/dozzle/service.yml
+++ b/.templates/dozzle/service.yml
@@ -4,6 +4,6 @@
     restart: unless-stopped
     network_mode: host
     ports:
-      - 8888:8080
+      - "8888:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/.templates/grafana/service.yml
+++ b/.templates/grafana/service.yml
@@ -4,7 +4,7 @@
     restart: unless-stopped
     user: "0"
     ports:
-      - 3000:3000
+      - "3000:3000"
     env_file:
       - ./services/grafana/grafana.env
     volumes:

--- a/.templates/influxdb/service.yml
+++ b/.templates/influxdb/service.yml
@@ -3,9 +3,9 @@
     image: "influxdb:latest"
     restart: unless-stopped
     ports:
-      - 8086:8086
-      - 8083:8083
-      - 2003:2003
+      - "8086:8086"
+      - "8083:8083"
+      - "2003:2003"
     env_file:
       - ./services/influxdb/influxdb.env
     volumes:

--- a/.templates/mariadb/service.yml
+++ b/.templates/mariadb/service.yml
@@ -6,6 +6,5 @@
     volumes:
       - ./volumes/mariadb/config:/config
     ports:
-      - 3306:3306
+      - "3306:3306"
     restart: unless-stopped
-

--- a/.templates/mosquitto/service.yml
+++ b/.templates/mosquitto/service.yml
@@ -4,11 +4,10 @@
     restart: unless-stopped
     user: "1883"
     ports:
-      - 1883:1883
-      - 9001:9001
+      - "1883:1883"
+      - "9001:9001"
     volumes:
       - ./volumes/mosquitto/data:/mosquitto/data
       - ./volumes/mosquitto/log:/mosquitto/log
       - ./services/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf
       - ./services/mosquitto/filter.acl:/mosquitto/config/filter.acl
-

--- a/.templates/motioneye/service.yml
+++ b/.templates/motioneye/service.yml
@@ -3,12 +3,11 @@
     container_name: "motioneye"
     restart: unless-stopped
     ports:
-      - 8765:8765 
-      - 8081:8081
+      - "8765:8765"
+      - "8081:8081"
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ./volumes/motioneye/etc_motioneye:/etc/motioneye
       - ./volumes/motioneye/var_lib_motioneye:/var/lib/motioneye
     #devices:
     #  - "/dev/video0:/dev/video0"
-

--- a/.templates/nextcloud/service.yml
+++ b/.templates/nextcloud/service.yml
@@ -2,7 +2,7 @@
     image: nextcloud
     container_name: nextcloud
     ports:
-      - 9321:80
+      - "9321:80"
     volumes:
       - ./volumes/nextcloud/html:/var/www/html
     restart: unless-stopped
@@ -22,4 +22,3 @@
       - MYSQL_DATABASE=nextcloud
       - MYSQL_USER=nextcloud
     restart: unless-stopped
-

--- a/.templates/nodered/service.yml
+++ b/.templates/nodered/service.yml
@@ -6,6 +6,6 @@
     privileged: true
     env_file: ./services/nodered/nodered.env
     ports:
-      - 1880:1880
+      - "1880:1880"
     volumes:
       - ./volumes/nodered/data:/data

--- a/.templates/portainer/service.yml
+++ b/.templates/portainer/service.yml
@@ -3,7 +3,7 @@
     image: portainer/portainer
     restart: unless-stopped
     ports:
-      - 9000:9000
+      - "9000:9000"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./volumes/portainer/data:/data

--- a/.templates/postgres/service.yml
+++ b/.templates/postgres/service.yml
@@ -5,6 +5,6 @@
     env_file:
       - ./services/postgres/postgres.env
     ports:
-      - 5432:5432
+      - "5432:5432"
     volumes:
       - ./volumes/postgres/data:/var/lib/postgresql/data

--- a/.templates/rtl_433/service.yml
+++ b/.templates/rtl_433/service.yml
@@ -6,4 +6,3 @@
     devices:
       - /dev/bus/usb
     restart: unless-stopped
-    

--- a/.templates/tasmoadmin/service.yml
+++ b/.templates/tasmoadmin/service.yml
@@ -6,4 +6,3 @@
       - "8088:80"
     volumes:
       - ./volumes/tasmoadmin/data:/data
-      

--- a/.templates/timescaledb/service.yml
+++ b/.templates/timescaledb/service.yml
@@ -5,6 +5,6 @@
     env_file:
       - ./services/timescaledb/timescaledb.env
     ports:
-      - 5432:5432
+      - "5432:5432"
     volumes:
       - ./volumes/timescaledb/data:/var/lib/postgresql/data

--- a/.templates/transmission/service.yml
+++ b/.templates/transmission/service.yml
@@ -10,7 +10,7 @@
       - transm_download_volume:/downloads
       - transm_watch_volume:/watch
     ports:
-      - 9091:9091
-      - 51413:51413
-      - 51413:51413/udp
+      - "9091:9091"
+      - "51413:51413"
+      - "51413:51413/udp"
     restart: unless-stopped

--- a/.templates/webthings_gateway/service.yml
+++ b/.templates/webthings_gateway/service.yml
@@ -9,5 +9,3 @@
     # - /dev/ttyACM0:/dev/ttyACM0
     volumes:
       - ./volumes/webthings_gateway/share:/home/node/.mozilla-iot
-
-      


### PR DESCRIPTION
The [Docker Compose file reference](https://docs.docker.com/compose/compose-file/#ports) says:

> When mapping ports in the HOST:CONTAINER format, you may experience
erroneous results when using a container port lower than 60,
because YAML parses numbers in the format xx:yy as a base-60 value.
For this reason, we recommend always explicitly specifying your port
mappings as strings.

This PR adopts the recommendation on all `service.yml` files in the
`.templates` directory. That way, IOTstack uses who work by copying
an existing example will be less likely to strike this problem should
they need to specify a container port less than 60.

I also removed some extraneous blank lines at the ends of `service.yml`
files that were causing sub-optimal layout in `docker-compose.yml`.