### PR TITLE
Mosquitto - make security persistent + extend documentation - followup

### DIFF
--- a/.templates/mosquitto/terminal.sh
+++ b/.templates/mosquitto/terminal.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 echo "you are about to enter the shell for mosquitto"
-echo "to add a password: mosquitto_passwd -c /mosquitto/config/pwfile MYUSER"
-echo "the command will ask for you password and confirm"
-echo "to exit: exit"
+echo "the documentation explains how to secure mosquitto with a username and password."
 
 docker exec -it mosquitto sh


### PR DESCRIPTION
In preparing PR #69 I did not realise that:

```
~/IOTstack/.templates/mosquitto/terminal.sh
```

contained a reference to the `pwfile` with the old (non-persistent)
path. I have changed the text in `terminal.sh` to remove the reference
to the `pwfile` and instead direct the user to the documentation.

The logic is:

* Just changing the path in `terminal.sh` perpetuates the maintenance
problem;
* Most users will only want to set the password once so chucking up the
reminder every time `terminal.sh` is run could become annoying; and
* by reading the documentation, the user would get a better appreciation
for how the password is implemented **and** how to roll it back if
Mosquitto gets into a restart loop.