### PR TITLE
Correct path specifications in transmission volumes.yml

### DIFF
--- a/.templates/transmission/build.sh
+++ b/.templates/transmission/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # create directories for named volumes
-TRANSMISSION_BASEDIR=.volumes/transmission
+TRANSMISSION_BASEDIR=./volumes/transmission
 mkdir -p $TRANSMISSION_BASEDIR/downloads
 mkdir -p $TRANSMISSION_BASEDIR/watch
 mkdir -p $TRANSMISSION_BASEDIR/config

--- a/.templates/transmission/volumes.yml
+++ b/.templates/transmission/volumes.yml
@@ -4,18 +4,18 @@
     driver_opts:
        o: bind
        type: none
-       device: .volumes/transmission/downloads
+       device: ./volumes/transmission/downloads
 
   transm_watch_volume:
     driver: local
     driver_opts:
        o: bind
        type: none
-       device: .volumes/transmission/watch
+       device: ./volumes/transmission/watch
 
   transm_config_volume:
     driver: local
     driver_opts:
        o: bind
        type: none
-       device: .volumes/transmission/config
+       device: ./volumes/transmission/config


### PR DESCRIPTION
Issue #91 described a problem which was traced to three mal-formed path
specifications in the `volumes.yml` template for `transmission`.

The following three lines:

```
device: .volumes/transmission/downloads
device: .volumes/transmission/watch
device: .volumes/transmission/config
```

need to be written as:

```
device: ./volumes/transmission/downloads
device: ./volumes/transmission/watch
device: ./volumes/transmission/config
```

User @ApricotFarm has tested this fix and confirms that it works.