### PR TITLE
Fix wireguard causing permission denied errors

### DIFF
--- a/.templates/wireguard/directoryfix.sh
+++ b/.templates/wireguard/directoryfix.sh
@@ -1,0 +1,9 @@
+WG_CONF_TEMPLATE_PATH=./.templates/wireguard/wg0.conf
+WG_CONF_DEST_PATH=./services/wireguard/config
+
+if [[ ! -f $WG_CONF_TEMPLATE_PATH ]]; then
+    echo "[Wireguard] Warning: $WG_CONF_TEMPLATE_PATH does not exist."
+  else
+    [ -d $WG_CONF_DEST_PATH ] || mkdir -p $WG_CONF_DEST_PATH
+    cp -r $WG_CONF_TEMPLATE_PATH $WG_CONF_DEST_PATH
+fi

--- a/.templates/wireguard/service.yml
+++ b/.templates/wireguard/service.yml
@@ -15,7 +15,7 @@
       - PEERDNS=auto #optional
       - INTERNAL_SUBNET=100.64.0.0/24 #optional
     volumes:
-      - ./volumes/wireguard/config:/config
+      - ./services/wireguard/config:/config
       - /lib/modules:/lib/modules
     ports:
       - 51820:51820/udp

--- a/volumes/wireguard/wg0.conf
+++ b/volumes/wireguard/wg0.conf
@@ -1,1 +1,0 @@
-will be generated


### PR DESCRIPTION
This fixes the permissions error described in https://github.com/SensorsIot/IOTstack/issues/126