### PR TITLE
Switch gitea from kapdap/gitea-rpi to kunde21/gitea-arm

### DIFF
--- a/.templates/gitea/service.yml
+++ b/.templates/gitea/service.yml
@@ -1,11 +1,13 @@
   gitea:
     container_name: gitea
-    image: kapdap/gitea-rpi
+    image: "kunde21/gitea-arm:latest"
     restart: unless-stopped
-    user: "0"
     ports:
       - "7920:3000/tcp"
       - "2222:22/tcp"
+    environment:
+      - USER_UID=1000
+      - USER_GID=1000
     env_file:
       - ./services/gitea/gitea.env
     volumes:


### PR DESCRIPTION
kapdap/gitea-rpi has not been updated for two years. kunde21/gitea-arm
is being maintained (most-recent update is 8 weeks ago). I have been
running kunde21/gitea-arm since June and it seems quite stable so I
recommend IOTstack switches to it.

kunde21/gitea-arm also runs as user pi (kapdap/gitea-rpi ran as root):

```
$ ps -C gitea -o euser,ruser,suser,fuser,comm
EUSER    RUSER    SUSER    FUSER    COMMAND
pi       pi       pi       pi       gitea
```

The changes required to service.yml are:

1. Change the image definition to "kunde21/gitea-arm:latest"
2. Add `USER_UID` and `USER_GID` keys to the environment section, each
with the value 1000 (user pi).