### PR TITLE
Update to Blynk local server including config files

### DIFF
--- a/.templates/blynk_server/Dockerfile
+++ b/.templates/blynk_server/Dockerfile
@@ -1,11 +1,11 @@
 FROM adoptopenjdk/openjdk11
-MAINTAINER Graham Garner <garner.gc@gmail.com>
+MAINTAINER 877dev <877dev@gmail.com>
 
 #RUN apt-get update 
 #RUN apt-get install -y apt-utils
 #RUN apt-get install -y default-jdk curl
 
-ENV BLYNK_SERVER_VERSION 0.41.10
+ENV BLYNK_SERVER_VERSION 0.41.14
 RUN mkdir /blynk
 RUN curl -L https://github.com/blynkkk/blynk-server/releases/download/v${BLYNK_SERVER_VERSION}/server-${BLYNK_SERVER_VERSION}.jar > /blynk/server.jar
 
@@ -22,4 +22,5 @@ VOLUME ["/config", "/data/backup"]
 EXPOSE 8080 9443
 
 WORKDIR /data
-ENTRYPOINT ["java", "-jar", "/blynk/server.jar", "-dataFolder", "/data", "-serverConfig", "/config/server.properties"]
+ENTRYPOINT ["java", "-jar", "/blynk/server.jar", "-dataFolder", "/data", "-serverConfig", "/config/server.properties", "-mailConfig", "/config/mail.properties"]
+

--- a/.templates/blynk_server/Dockerfile
+++ b/.templates/blynk_server/Dockerfile
@@ -1,7 +1,7 @@
-FROM adoptopenjdk/openjdk11
+FROM adoptopenjdk/openjdk14
 MAINTAINER 877dev <877dev@gmail.com>
 
-#RUN apt-get update 
+#RUN apt-get update
 #RUN apt-get install -y apt-utils
 #RUN apt-get install -y default-jdk curl
 
@@ -23,4 +23,3 @@ EXPOSE 8080 9443
 
 WORKDIR /data
 ENTRYPOINT ["java", "-jar", "/blynk/server.jar", "-dataFolder", "/data", "-serverConfig", "/config/server.properties", "-mailConfig", "/config/mail.properties"]
-

--- a/.templates/blynk_server/directoryfix.sh
+++ b/.templates/blynk_server/directoryfix.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # Create config files for Blynk custom server
-# 877dev
 
 #current user
 u=$(whoami)
@@ -15,10 +14,10 @@ if [ ! -d ./volumes/blynk_server/data/config ]; then
 	#cd ~/IOTstack/volumes/blynk_server/data/config
     sudo touch ./volumes/blynk_server/data/config/server.properties
     sudo touch ./volumes/blynk_server/data/config/mail.properties
-
+    
     #Give permissions:
     sudo chown -R $u:$u ./volumes/blynk_server/data/config
-
+    
     #Populate the server.properties file:
     sudo echo "hardware.mqtt.port=8440
     http.port=8080
@@ -76,6 +75,16 @@ if [ ! -d ./volumes/blynk_server/data/config ]; then
     echo "Sample properties files created in ~/IOTstack/volumes/blynk_server/data/config"
     echo "Make sure you edit the files with your details, and restart the container to take effect."
 
-
+	
 
 fi
+
+
+
+
+
+
+
+
+
+

--- a/.templates/blynk_server/directoryfix.sh
+++ b/.templates/blynk_server/directoryfix.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Create config files for Blynk custom server
+# 877dev
+
+#current user
+u=$(whoami)
+
+#Check if the config directory already exists:
+if [ ! -d ./volumes/blynk_server/data/config ]; then
+	#Create the config directory
+    sudo mkdir -p ./volumes/blynk_server/data/config
+
+    #Create the properties files:
+	#cd ~/IOTstack/volumes/blynk_server/data/config
+    sudo touch ./volumes/blynk_server/data/config/server.properties
+    sudo touch ./volumes/blynk_server/data/config/mail.properties
+
+    #Give permissions:
+    sudo chown -R $u:$u ./volumes/blynk_server/data/config
+
+    #Populate the server.properties file:
+    sudo echo "hardware.mqtt.port=8440
+    http.port=8080
+    force.port.80.for.csv=false
+    force.port.80.for.redirect=true
+    https.port=9443
+    data.folder=./data
+    logs.folder=./logs
+    log.level=info
+    user.devices.limit=10
+    user.tags.limit=100
+    user.dashboard.max.limit=100
+    user.widget.max.size.limit=20
+    user.message.quota.limit=100
+    notifications.queue.limit=2000
+    blocking.processor.thread.pool.limit=6
+    notifications.frequency.user.quota.limit=5
+    webhooks.frequency.user.quota.limit=1000
+    webhooks.response.size.limit=96
+    user.profile.max.size=128
+    terminal.strings.pool.size=25
+    map.strings.pool.size=25
+    lcd.strings.pool.size=6
+    table.rows.pool.size=100
+    profile.save.worker.period=60000
+    stats.print.worker.period=60000
+    web.request.max.size=524288
+    csv.export.data.points.max=43200
+    hard.socket.idle.timeout=10
+    enable.db=false
+    enable.raw.db.data.store=false
+    async.logger.ring.buffer.size=2048
+    allow.reading.widget.without.active.app=false
+    allow.store.ip=true
+    initial.energy=1000000
+    admin.rootPath=/admin
+    restore.host=blynk-cloud.com
+    product.name=Blynk
+    admin.email=admin@blynk.cc
+    admin.pass=admin
+    " > ./volumes/blynk_server/data/config/server.properties
+
+    #Populate the mail.properties file:
+    sudo echo "mail.smtp.auth=true
+    mail.smtp.starttls.enable=true
+    mail.smtp.host=smtp.gmail.com
+    mail.smtp.port=587
+    mail.smtp.username=YOUR_GMAIL@gmail.com
+    mail.smtp.password=YOUR_GMAIL_APP_PASSWORD
+    mail.smtp.connectiontimeout=30000
+    mail.smtp.timeout=120000
+    " > ./volumes/blynk_server/data/config/mail.properties
+
+    #Information messages:
+    echo "Sample properties files created in ~/IOTstack/volumes/blynk_server/data/config"
+    echo "Make sure you edit the files with your details, and restart the container to take effect."
+
+
+
+fi

--- a/.templates/blynk_server/service.yml
+++ b/.templates/blynk_server/service.yml
@@ -3,9 +3,9 @@
     container_name: blynk_server
     restart: unless-stopped
     ports:
-      - 8180:8080
-      - 8441:8441
-      - 9443:9443
+      - "8180:8080"
+      - "8441:8441"
+      - "9443:9443"
     volumes:
       - ./volumes/blynk_server/data:/data
       - ./volumes/blynk_server/data/config:/config

--- a/.templates/blynk_server/service.yml
+++ b/.templates/blynk_server/service.yml
@@ -3,8 +3,9 @@
     container_name: blynk_server
     restart: unless-stopped
     ports:
-      - "8180:8080"
-      - "8441:8441"
-      - "9443:9443"
+      - 8180:8080
+      - 8441:8441
+      - 9443:9443
     volumes:
       - ./volumes/blynk_server/data:/data
+      - ./volumes/blynk_server/data/config:/config


### PR DESCRIPTION
The original version did not create any config files and did not support email.

This commit fixes that, by making use of  `directoryfix.sh` to create the config folder,
which contains two config files, `server.properties` and `mail.properties`.
Note that if they already exist they are not overwritten.

The Dockerfile has been updated to use the latest version 0.41.14,
and a parameter to use a custom `mail.properties`.

`server.properties` should work "as is" for most people, but can be changed as required.
`mail.properties` requires editing to add gmail credentials.
`service.yml` updated to map the configs to the volumes folder.

A new readme guide has been produced which needs adding to the main webpage, this can be found [here](https://gist.github.com/877dev/cfa52044336e1e44d74156ce8b1458aa#file-blynk-setup-guide-md)