### PR TITLE
Adds template and documentation for Portainer-ce

### DIFF
--- a/.templates/portainer-ce/directoryfix.sh
+++ b/.templates/portainer-ce/directoryfix.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This script is intended as a simplistic one-time migration aid. The
+# script checks for:
+#
+# 1. the PRESENCE of the (old) portainer (assumed 1.24.1) persistent
+#    storage directory; and
+# 2. the ABSENCE of the (new) portainer-ce (assumed 2.0.0) persistent
+#    storage directory.
+#
+# If both conditions are met, the old persistent storage directory
+# is copied to become the new persistent storage directory.
+#
+# The first time portainer-ce runs it is then in the same situation as
+# if docker-compose.yml had been changed from:
+#
+#   image: portainer/portainer
+#
+# to:
+#
+#   image: portainer/portainer-ce
+#
+# portainer-ce can then perform any first-launch migration steps while
+# preserving the admin password and the like.
+
+OLD="./volumes/portainer"
+NEW="./volumes/portainer-ce"
+
+if [ -d "$OLD" -a ! -d "$NEW" ] ; then
+
+   echo "$OLD exists but $NEW does not - auto-cloning"
+
+   sudo cp -Rp "$OLD" "$NEW"
+
+fi
+

--- a/.templates/portainer-ce/service.yml
+++ b/.templates/portainer-ce/service.yml
@@ -1,0 +1,10 @@
+  portainer-ce:
+    container_name: portainer-ce
+    image: portainer/portainer-ce
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+      - "9002:9000"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./volumes/portainer-ce/data:/data

--- a/docs/Containers/Portainer-ce.md
+++ b/docs/Containers/Portainer-ce.md
@@ -1,0 +1,155 @@
+# Portainer CE
+
+## References
+ 
+- [Docker](https://hub.docker.com/r/portainer/portainer-ce/)
+- [Website](https://www.portainer.io/portainer-ce/)
+
+## Definition
+
+- "#yourip" means any of the following:
+
+	- the IP address of your Raspberry Pi (eg `192.168.1.10`)
+	- the multicast domain name of your Raspberry Pi (eg `iot-hub.local`)
+	- the domain name of your Raspberry Pi (eg `iot-hub.mydomain.com`) 
+
+## About *Portainer CE*
+
+*Portainer CE* (Community Edition) is an application for managing Docker. It is a successor to *Portainer*. According to [the *Portainer CE* documentation](https://www.portainer.io/2020/08/portainer-ce-2-0-what-to-expect/)
+
+> Portainer 1.24.x will continue as a separate code branch, released as portainer/portainer:latest, and will receive ongoing security updates until at least 1st Sept 2021. No new features will be added beyond what was available in 1.24.1.
+
+From that it should be clear that *Portainer* is deprecated and that *Portainer CE* is the way forward.
+
+## *Portainer CE* coexistence with *Portainer*
+
+IOTstack has been set up so that *Portainer CE* and *Portainer* can coexist. This is intended as a short-term migration aid rather than a long-term proposition.
+
+If you are a first-time user of IOTstack, you should choose *Portainer CE* and forget about *Portainer*.
+
+## Installing *Portainer CE*
+
+Run the menu:
+
+```
+$ cd ~/IOTstack
+$ ./menu.sh
+```
+
+Choose "Build Stack", select "Portainer-ce", press [TAB] then "\<Ok\>" and follow through to the end of the menu process, typically choosing "Do not overwrite" for any existing services. When the menu finishes:
+
+```
+$ docker-compose up -d
+```
+
+Ignore any message like this:
+
+> WARNING: Found orphan containers (portainer) for this project …
+
+### <a name="MigrationNote"> Migration note </a>
+
+*Portainer CE* and *Portainer* use different locations for their persistent data:
+
+Edition      | Persistent Data Directory       | Reference
+-------------|---------------------------------|:---------:
+Portainer    | ~/IOTstack/volumes/portainer    | [A]
+Portainer CE | ~/IOTstack/volumes/portainer-ce | [B]
+
+If you have been running *Portainer* but have **never** run *Portainer CE* then:
+
+* [A] will exist, but
+* [B] will not exist.
+
+Whenever "Portainer-ce" is enabled in `menu.sh`, a check is made for the **presence** of [A] combined with the **absence** [B]. If and only if that situation exists, [B] is initialised as a copy of [A].
+
+This one-time copy is intended to preserve your *Portainer* settings and admin user password for use in *Portainer CE*. Thereafter, any settings you change in *Portainer CE* will not be reflected in *Portainer*, nor vice versa.
+
+## Port Number = 9002
+
+Both *Portainer CE* and *Portainer* are usually configured to listen to port 9000 but, in the IOTstack implementation:
+
+* *Portainer CE* uses port 9002; and
+* *Portainer* uses port 9000.
+
+> You can always change the port numbers in your `docker-compose.yml`.  
+
+## First run of *Portainer CE*
+
+In your web browser navigate to `#yourip:9002/`.
+
+* If you are migrating from *Portainer*:
+
+	- review the [Migration note](#MigrationNote) which explains why your *Portainer* credentials will likely apply to *Portainer CE*, and then
+	- supply your *Portainer* credentials.
+
+* <a name="NewAccount"> If you are **not** migrating from *Portainer*: </a>
+
+	- the first screen will suggest a username of "admin" and ask for a password. Supply those credentials and click "Create User".
+	- the second screen will ask you to select a connection method. For IOTstack, "Docker (Manage the local Docker environment)" is usually appropriate so click that and then click "Connect".
+
+From there, you can click on the "Local" group and take a look around. One of the things *Portainer CE* can help you do is find unused containers but beware of reading too much into this because, sometimes, an "unused" container is actually the base for another container (eg Node-Red).
+
+There are 'Quick actions' to view logs and other stats. This can all be done from terminal commands but *Portainer CE* makes it easier. 
+
+## Ceasing use of Portainer
+
+As soon as you are happy that *Portainer CE* meets your needs, you can dispense with *Portainer*. IOTstack only has limited support for getting rid of unwanted services so you should do the following.
+
+1. Stop Portainer from running and remove its image:
+
+	```
+	$ cd ~/IOTstack
+	$ docker-compose stop portainer
+	$ docker-compose rm -f portainer
+	$ docker rmi portainer/portainer
+	```
+	
+2. Either:
+
+	- run `menu.sh`
+	- choose "Build Stack"
+	- de-select "portainer", and
+	- follow through to the end choosing "Do not overwrite" for existing services,
+
+	or:
+	
+	- edit `docker-compose.yml` and remove these lines:
+
+		```
+		  portainer:
+		    container_name: portainer
+		    image: portainer/portainer
+		    restart: unless-stopped
+		    ports:
+		      - "9000:9000"
+		    volumes:
+		      - /var/run/docker.sock:/var/run/docker.sock
+		      - ./volumes/portainer/data:/data
+		```
+		
+	- edit `services/selection.txt` and remove this line:
+	
+		```
+		portainer
+		```
+	
+3. Tidy-up:
+
+	```
+	$ cd ~/IOTstack
+	$ rm -rf ./services/portainer
+	$ sudo rm -rf ./volumes/portainer
+	```
+	
+## If you forget your password
+
+If you forget the password you created for *Portainer CE*, you can recover by doing the following:
+
+```
+$ cd ~/IOTstack
+$ docker-compose stop portainer-ce
+$ sudo rm -r ./volumes/portainer-ce
+$ docker-compose start portainer-ce
+```
+
+Then use your browser to navigate to `#yourip:9002/` and follow the steps in [if you are **not** migrating from *Portainer*](#NewAccount).

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -18,6 +18,7 @@ The README is moving to the Wiki, It's easier to add content and example to the 
 
 # Containers
 * [Portainer](https://sensorsiot.github.io/IOTstack/Containers/Portainer)
+* [Portainer-ce](https://sensorsiot.github.io/IOTstack/Containers/Portainer-ce)
 * [Portainer Agent](https://sensorsiot.github.io/IOTstack/Containers/Portainer-agent)
 * [Node-RED](https://sensorsiot.github.io/IOTstack/Containers/Node-RED)
 * [Grafana](https://sensorsiot.github.io/IOTstack/Containers/Grafana)

--- a/menu.sh
+++ b/menu.sh
@@ -18,6 +18,7 @@ REQ_PYYAML_VERSION=5.3.1
 
 declare -A cont_array=(
 	[portainer]="Portainer"
+	[portainer-ce]="Portainer-ce"
 	[portainer_agent]="Portainer agent"
 	[nodered]="Node-RED"
 	[influxdb]="InfluxDB"
@@ -56,6 +57,7 @@ declare -A cont_array=(
 
 declare -a armhf_keys=(
 	"portainer"
+	"portainer-ce"
 	"portainer_agent"
 	"nodered"
 	"influxdb"


### PR DESCRIPTION
This PR proposes supporting Portainer and Portainer CE 2.0 in parallel.
See also [Issue 132](https://github.com/SensorsIot/IOTstack/issues/132).

According to [Portainer documentation]
(https://www.portainer.io/2020/08/portainer-ce-2-0-what-to-expect/):

> Portainer 1.24.x will continue as a separate code branch, released as
> portainer/portainer:latest, and will receive ongoing security updates
> until at least 1st Sept 2021. No new features will be added beyond
> what was available in 1.24.1

The template for Portainer CE:

- Maps external port 9002 to internal port 9000. This is so Portainer CE can coexist with Portainer.
- Maps external port 8000 to internal port 8000. Portainer did not expose port 8000.

[Portainer documentation](https://www.portainer.io/2019/07/how-does-the-edge-agent-work/) defines Port 8000:

> Port 8000 is a SSH tunnel server and is used to create a secure tunnel
> between the agent and the Portainer instance.

The template for Portainer CE includes `directoryfix.sh` which copies:

```
~/IOTstack/volumes/portainer
```

to:

```
~/IOTstack/volumes/portainer-ce
```

if and only if the former exists **and** the latter does not exist. This
is intended as a one-time assist for users migrating between Portainer
and Portainer-CE.

Also includes documentation page for Portainer-CE.