### PR TITLE
Docs updates - remove gcgarner references - related improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,56 @@
 # IOT Stack
+
 IOTstack is a builder for docker-compose to easily make and maintain IoT stacks on the Raspberry Pi.
 
+## Getting started
 
-## Documentation for the project: 
+See [Getting Started](https://sensorsiot.github.io/IOTstack/Getting-Started) in the Wiki. It includes:
 
-https://sensorsiot.github.io/IOTstack/
+* A link to Andreas Spiess video #295.
+* How to download the project (including constraints you need to observe).
+* Running the menu to install Docker and set up your containers.
+* Useful Docker commands (start \& stop the stack, manage containers).
 
+See also the [documentation home page](https://sensorsiot.github.io/IOTstack/).
 
-## Video
-https://youtu.be/a6mjt8tWUws
+## Migrating from the old repo?
 
-
-## Installation
-1. On the (RPi) lite image you will need to install git first
+If you have been running IOTstack from [gcgarner/IOTstack](https://github.com/gcgarner/IOTstack) and want to migrate to this repository (SensorsIot/IOTstack), do the following:
 
 ```
-sudo apt-get install git -y
-```
-
-2. Download the repository with:
-```
-git clone https://github.com/SensorsIot/IOTstack.git ~/IOTstack
-```
-
-Due to some script restraints, this project needs to be stored in ~/IOTstack
-
-3. To enter the directory and run menu for installation options:
-```
-cd ~/IOTstack && bash ./menu.sh
-```
-
-4. Install docker with the menu, restart your system.
-
-5. Run menu again to select your build options, then start docker-compose with
-```
-docker-compose up -d
+$ cd ~/IOTstack
+$ git remote set-url origin https://github.com/SensorsIot/IOTstack.git
+$ git pull origin master
+$ git checkout master
+$ docker-compose down
+$ ./menu.sh
+$ docker-compose up -d
 ```
 
 ## Experimental Features
+
 Want to have the latest and greatest features? Switch to the experimental branch:
+
 ```
-git pull && git checkout experimental
-./menu.sh
+$ cd ~/IOTstack
+$ git pull origin master
+$ git checkout experimental
+$ ./menu.sh
 ```
 
-Do note that the experimental branch may be broken, or may break your setup, so ensure you have a good backup, and please report any issues.
+Do note that the experimental branch may be broken, or may break your setup, so ensure you have a good backup, and please report any issues. The way back is:
 
-## Migrating from the old repo?
 ```
-cd ~/IOTstack/
-git remote set-url origin https://github.com/SensorsIot/IOTstack.git
-git pull origin master
-docker-compose down
-./menu.sh
-docker-compose up -d
+$ cd ~/IOTstack
+$ git pull origin master
+$ git checkout master
+$ ./menu.sh
 ```
+
+## Contributions
+
+Please use the [issues](https://github.com/SensorsIot/IOTstack/issues) tab to report issues.
+
+Join the [IOTstack Discord channel](https://discord.gg/W45tD83) if you want to comment on features, suggest new container types, or ask the IOTstack community for help.
+
+If you use some of the tools in the project please consider donating or contributing on their projects. It doesn't have to be monetary. Reporting bugs and creating Pull Requests helps improve the projects for everyone.

--- a/docs/Backups.md
+++ b/docs/Backups.md
@@ -43,7 +43,7 @@ The "volumes" directory contains all the persistent data necessary to recreate t
 
 ## Added your Dropbox token incorrectly or aborted the install at the token screen
 
-Make sure you are running the latest version of the project [link](https://github.com/gcgarner/IOTstack/wiki/Updating-the-Project).
+Make sure you are running the latest version of the project [link](https://sensorsiot.github.io/IOTstack/Updating-the-Project/).
 
 Run `~/Dropbox-Uploader/dropbox_uploader.sh unlink` and if you have added it key then it will prompt you to confirm its removal. If no key was found it will ask you for a new key.
 

--- a/docs/Containers/EspruinoHub.md
+++ b/docs/Containers/EspruinoHub.md
@@ -1,12 +1,13 @@
 # Espruinohub
+
 This is a testing container
 
 I tried it however the container keeps restarting `docker logs espruinohub` I get "BLE Broken?" but could just be i dont have any BLE devices nearby
 
 web interface is on "{your_Pis_IP}:1888"
 
-see https://github.com/espruino/EspruinoHub#status--websocket-mqtt--espruino-web-ide for other details
+see [EspruinoHub#status--websocket-mqtt--espruino-web-ide](https://github.com/espruino/EspruinoHub#status--websocket-mqtt--espruino-web-ide) for other details.
 
 there were no recommendations for persistent data volumes. so `docker-compose down` may destroy all you configurations so use `docker-compose stop` in stead 
 
-please let me know about your success or issues [here](https://github.com/gcgarner/IOTstack/issues/84)
+Please [check existing issues](https://github.com/SensorsIot/IOTstack/issues) if you encounter a problem, and then open a new issue if your problem has not been reported.

--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -1,83 +1,393 @@
 # Getting started
+
+## Introduction to IOTstack - video
+
+Andreas Spiess video #295
+
+[![#295 Raspberry Pi Server](http://img.youtube.com/vi/a6mjt8tWUws/0.jpg)](https://www.youtube.com/watch?v=a6mjt8tWUws)
+
 ## Download the project
 
-On the lite image you will need to install git first 
+You may need to install these support tools first:
+ 
 ```
-sudo apt-get install git
+$ sudo apt install -y git curl
 ```
-Then download with
-```
-git clone https://github.com/gcgarner/IOTstack.git ~/IOTstack
-```
-Due to some script restraints, this project needs to be stored in ~/IOTstack
 
-To enter the directory run:
+> It does no harm to re-install a package that is already installed. The command either behaves as an update or does nothing, as appropriate.
+
+IOTstack makes the following assumptions (the first three are Raspberry Pi defaults on a clean installation):
+
+1. You are logged-in as the user "pi"
+2. User "pi" has the user ID 1000
+3. The home directory for user "pi" is `/home/pi/`
+4. IOTstack is installed at `/home/pi/IOTstack` (with that exact spelling)
+
+Download IOTstack like this:
+
 ```
-cd ~/IOTstack
+$ cd
+$ git clone https://github.com/SensorsIot/IOTstack.git IOTstack
 ```
+
 ## The Menu
-I've added a menu to make things easier. It is good however to familiarise yourself with how things are installed.
-The menu can be used to install docker and then build the docker-compose.yml file necessary for starting the stack and it runs a few common commands. I do recommend you start to learn the docker and docker-compose commands if you plan using docker in the long run. I've added several helper scripts, have a look inside.
 
-Navigate to the project folder and run `./menu.sh`
+The menu is used to install Docker and then build the `docker-compose.yml` file which is necessary for starting the stack.
 
-### Installing from the menu
-Select the first option and follow the prompts
+> The menu is only an aid. It is a good idea to learn the `docker` and `docker-compose` commands if you plan on using Docker in the long run.
 
-### Build the docker-compose file
-docker-compose uses the `docker-compose.yml` file to configure all the services. Run through the menu to select the options you want to install.
+### Menu item: Install Docker
 
-### Docker commands
-This menu executes shell scripts in the root of the project. It is not necessary to run them from the menu. Open up the shell script files to see what is inside and what they do
+Please do **not** try to install `docker` and `docker-compose` via `sudo apt install`. There's more to it than that. Docker needs to be installed by `menu.sh`, like this:
 
-### Miscellaneous commands
-Some helpful commands have been added like disabling swap
+```
+$ cd ~/IOTstack
+$ ./menu.sh
+Select "Install Docker"
+```
 
-## Running Docker commands
-From this point on make sure you are executing the commands from inside the project folder. Docker-compose commands need to be run from the folder where the docker-compose.yml is located. If you want to move the folder make sure you move the whole project folder.
+Follow the prompts. The process finishes by asking you to reboot. Do that!
 
-### Starting and Stopping containers
-to start the stack navigate to the project folder containing the docker-compose.yml file
+### Menu item: Build Stack
 
-To start the stack run:
-`docker-compose up -d` or `./scripts/start.sh`
+`docker-compose` uses a `docker-compose.yml` file to configure all your services. The `docker-compose.yml` file is created by the menu:
 
-To stop:
-`docker-compose stop` stops without removing containers
+```
+$ cd ~/IOTstack
+$ ./menu.sh
+Select "Build Stack"
+```
 
-To remove the stack: 
-`docker-compose down` stops containers, deletes them and removes the network
+Follow the on-screen prompts and select the containers you need.
 
-The first time you run 'start' the stack docker will download all the images for the web. Depending on how many containers you selected and your internet speed this can take a long while.
+> The best advice we can give is "start small". Limit yourself to the core containers you actually need (eg Mosquitto, Node-Red, InfluxDB, Grafana, Portainer). You can always add more containers later. Some users have gone overboard with their initial selections and have run into what seem to be Raspberry Pi OS limitations.
 
-### Persistent data
-Docker allows you to map folders inside your containers to folders on the disk. This is done with the "volume" key. There are two types of volumes. Any modification to the container reflects in the volume.
+The process finishes by asking you to bring up the stack:
 
-#### Sharing files between the Pi and containers
-Have a look a the wiki on how to share files between Node-RED and the Pi. [Wiki](https://github.com/gcgarner/IOTstack/wiki/Node-RED#sharing-files-between-node-red-and-the-host)
+```
+$ cd ~/IOTstack
+$ docker-compose up -d
+```
 
-### Updating the images
-If a new version of a container image is available on docker hub it can be updated by a pull command.
+The first time you run `up` the stack docker will download all the images from Dockerhub. How long this takes will depend on how many containers you selected and the speed of your internet connection.
 
-Use the `docker-compose stop` command to stop the stack
+Some containers also need to be built locally. Node-Red is an example. Depending on the Node-Red nodes you select, building the image can also take a very long time. This is especially true if you select the SQLite node.
 
-Pull the latest version from docker hub with one of the following command
+Be patient (and ignore the huge number of warnings).
 
-`docker-compose pull` or the script `./scripts/update.sh`
+### Menu item: Docker commands
 
-Start the new stack based on the updated images
+The commands in this menu execute shell scripts in the root of the project.
 
-`docker-compose up -d`
+It is not necessary to run the scripts from the menu. You can also look inside:
 
-### Node-RED error after modifications to setup files
-The Node-RED image differs from the rest of the images in this project. It uses the "build" key. It uses a dockerfile for the setup to inject the nodes for pre-installation. If you get an error for Node-RED run `docker-compose build` then `docker-compose up -d`
+```
+~/IOTstack/scripts
+```
 
-### Deleting containers, volumes and images
+and examine the files to see what they do.
 
-`./prune-images.sh` will remove all images not associated with a container. If you run it while the stack is up it will ignore any in-use images. If you run this while you stack is down it will delete all images and you will have to redownload all images from scratch. This command can be helpful to reclaim disk space after updating your images, just make sure to run it while your stack is running as not to delete the images in use. (your data will still be safe in your volume mapping)
+### Menu item: Miscellaneous commands
 
-### Deleting folder volumes
-If you want to delete the influxdb data folder run the following command `sudo rm -r volumes/influxdb/`. Only the data folder is deleted leaving the env file intact. review the docker-compose.yml file to see where the file volumes are stored.
+Some helpful commands have been added like disabling swap.
 
-You can use git to delete all files and folders to return your folder to the freshly cloned state, AS IN YOU WILL LOSE ALL YOUR DATA.
-`sudo git clean -d -x -f` will return the working tree to its clean state. USE WITH CAUTION!
+## Useful commands: docker \& docker-compose
+
+Handy rules:
+
+* `docker` commands can be executed from anywhere, but
+* `docker-compose` commands need to be executed from within `~/IOTstack`
+
+### Starting your IOTstack
+
+To start the stack:
+
+```
+$ cd ~/IOTstack
+$ docker-compose up -d
+```
+
+Once the stack has been brought up, it will stay up until you take it down. This includes shutdowns and reboots of your Raspberry Pi. If you do not want the stack to start automatically after a reboot, you need to stop the stack before you issue the reboot command.
+
+### Stopping your IOTstack
+
+Stopping aka "downing" the stack stops and deletes all containers, and removes the internal network:
+ 
+```
+$ cd ~/IOTstack
+$ docker-compose down
+``` 
+
+To stop the stack without removing containers, run:
+
+```
+$ cd ~/IOTstack
+$ docker-compose stop
+```
+
+`stop` can also be used to stop individual containers, like this:
+
+```
+$ cd ~/IOTstack
+$ docker-compose stop nodered
+```
+
+> there is no equivalent of `down` for a single container.
+
+### Checking container status
+
+You can check the status of containers with:
+
+```
+$ docker ps
+```
+
+or
+
+```
+$ cd ~/IOTstack
+$ docker-compose ps
+```
+
+### Viewing container logs
+
+You can inspect the logs of most containers like this:
+
+```
+$ docker logs «container»
+```
+
+for example:
+
+```
+$ docker logs nodered
+```
+
+You can also follow a container's log as new entries are added by using the `-f` flag:
+
+```
+$ docker logs -f nodered
+```
+
+Terminate with a Control+C. Note that restarting a container will also terminate a followed log.
+
+### Restarting a container
+
+You can restart a container in several ways:
+
+```
+$ cd ~/IOTstack
+$ docker-compose restart «container»
+```
+
+where «container» is the name of the container you want to restart, like this:
+
+```
+$ docker-compose restart nodered
+```
+
+This kind of restart is the least-powerful form of restart. A good way to think of it is "the container is only restarted, it is not rebuilt".
+
+If you change a `docker-compose.yml` setting for a container and/or an environment variable file referenced by `docker-compose.yml` then a `restart` is usually not enough to bring the change into effect. You need to make `docker-compose` notice the change:
+
+```
+$ cd ~/IOTstack
+$ docker-compose up -d «container»
+```
+
+This type of "restart" rebuilds the container.
+
+Alternatively, to force a container to rebuild (without changing either `docker-compose.yml` or an environment variable file):
+
+```
+$ cd ~/IOTstack
+$ docker-compose stop «container»
+$ docker-compose rm -f «container»
+$ docker-compose up -d «container»
+```
+
+## Persistent data
+
+Docker allows a container's designer to map folders inside a container to a folder on your disk (SD, SSD, HD). This is done with the "volumes" key in `docker-compose.yml`. Consider the following snippet for Node-Red:
+
+```
+    volumes:
+      - ./volumes/nodered/data:/data
+```
+
+You read this as two paths, separated by a colon. The:
+
+* external path is `./volumes/nodered/data`
+* internal path is `/data`
+
+In this context, the leading "." means "the folder containing `docker-compose.yml`, so the external path is actually:
+
+* `~/IOTstack/volumes/nodered/data`
+
+If a process running **inside** the container modifies any file or folder within `/data`, the change is mirrored **outside** the container at the same relative path within `./volumes/nodered/data` 
+
+The same is true in reverse. Any change made to any file or folder within `./volumes/nodered/data` **outside** the container is is mirrored in the same file or folder at `/data` **inside** the container.
+
+### Deleting persistent data
+
+If you need a "clean slate" for a container, you can delete its volumes. Using InfluxDB as an example:
+
+```
+$ cd ~/IOTstack
+$ docker-compose stop influxdb
+$ sudo rm -rf ./volumes/influxdb
+$ docker-compose up -d influxdb
+```
+
+When `docker-compose` tries to bring up InfluxDB, it will notice this volume mapping in `docker-compose.yml`:
+
+```
+    volumes:
+      - ./volumes/influxdb/data:/var/lib/influxdb
+```
+
+and check to see whether `./volumes/influxdb/data` is present. Finding it not there, it does the equivalent of:
+
+```
+$ sudo mkdir -p ./volumes/influxdb/data
+```
+
+When InfluxDB starts, it sees that the folder on right-hand-side of the volumes mapping (`/var/lib/influxdb`) is empty and initialises new databases.
+
+This is how **most** containers behave. But there are exceptions. A good example of an exception is Mosquitto. You can work out whether a container might be an exception by inspecting its services directory, like this:
+
+```
+$ ls ~/IOTstack/services/mosquitto
+directoryfix.sh  filter.acl  mosquitto.conf  service.yml  terminal.sh
+$
+```
+
+The presence of `directoryfix.sh` is an *indication* that you *may* need to do a bit more than just erase a volumes directory. In the case of Mosquitto, simply running the `directoryfix.sh` will suffice, as in:
+
+```
+$ cd ~/IOTstack
+$ docker-compose stop mosquitto
+$ sudo rm -rf ./volumes/mosquitto
+$ ./services/mosquitto/directoryfix.sh
+$ docker-compose up -d mosquitto
+```
+
+`directoryfix.sh` recreates the folder structure expected by Mosquitto and gives it the correct permissions and ownership.
+
+### Sharing files between the Pi and containers
+
+Have a look a the [Wiki](https://sensorsiot.github.io/IOTstack/Containers/Node-RED/#sharing-files-between-node-red-and-the-host) on how to share files between Node-RED and the Pi.
+
+## Updating Docker images
+
+If a new version of a container image becomes available on Dockerhub, your local IOTstack can be updated by a pull command:
+
+```
+$ cd ~/IOTstack
+$ docker-compose pull
+$ docker-compose up -d
+```
+
+The `pull` downloads any new images. It does this without disrupting the running stack.
+
+The `up -d` notices any newly-downloaded images, builds new containers, and swaps old-for-new. There is barely any downtime for affected containers.
+
+### Updating images built from Dockerfiles
+
+Some containers are built by downloading a *base* image from DockerHub, and then applying a Dockerfile to build a *local* image. Node-Red is a good example of this.
+
+You can check if a container uses a Dockerfile by looking in its services directory:
+
+```
+$ ls ~/IOTstack/services/«container»
+```
+
+The directory will either contain a Dockerfile or it won't.
+
+> You can also find out if a container is built using a Dockerfile by inspecting `docker-compose.yml` to see if the `build` key is present in the container's definition. 
+
+To update a container that is built from a *local* image using a Dockerfile, proceed like this.
+
+First, figure out the name of the *base* image. Using Node-Red as the example, there are two candidates:
+
+```
+$ docker images
+REPOSITORY               TAG                 IMAGE ID            CREATED             SIZE
+iotstack_nodered         latest              a38d38605ed4        22 hours ago        531MB
+nodered/node-red         latest              fa3bc6f20464        2 months ago        376MB
+```
+
+It's practically guaranteed that the older image (the one created "2 months ago") is the *base* but you can confirm it by examining the first part of the Dockerfile:
+
+```
+$ head -1 ~/IOTstack/services/nodered/Dockerfile 
+FROM nodered/node-red:latest
+```
+
+The image mentioned in the Dockerfile ("nodered/node-red") is the *base* image, while the other candidate ("iotstack_nodered") is the *local* image.
+
+To rebuild a *local* image, you usually need to remove the *base* image and then use a special form of the `up` command. Using Node-Red as the example:
+
+```
+$ cd ~/IOTstack
+$ docker rmi "nodered/node-red"
+$ docker-compose up --build -d
+```
+
+This pulls down the updated *base* image, builds a new *local* image by running the Dockerfile, creates the new container and swaps old-for-new. There is barely any downtime for the Node-Red service.
+
+#### Node-RED error after modifications to setup files
+
+If you get an error after you modify Node-Red's environment, it is because of how it is built (via Dockerfile). You can usually resolve the problem with:
+
+```
+$ cd ~/IOTstack
+$ docker-compose up --build -d
+```
+
+## Deleting unused images
+
+As your system evolves and new images come down from Dockerhub, you may find that more disk space is being occupied than you expected. Try running:
+
+```
+$ docker system prune
+```
+
+This recovers anything no longer in use.
+
+If you add a container via `menu.sh` and later remove it (either manually or via `menu.sh`), the associated images(s) will probably persist. You can check which images are installed via:
+
+```
+$ docker images
+
+REPOSITORY               TAG                 IMAGE ID            CREATED             SIZE
+influxdb                 latest              1361b14bf545        5 days ago          264MB
+grafana/grafana          latest              b9dfd6bb8484        13 days ago         149MB
+iotstack_nodered         latest              21d5a6b7b57b        2 weeks ago         540MB
+portainer/portainer-ce   latest              5526251cc61f        5 weeks ago         163MB
+eclipse-mosquitto        latest              4af162db6b4c        6 weeks ago         8.65MB
+nodered/node-red         latest              fa3bc6f20464        2 months ago        376MB
+portainer/portainer      latest              dbf28ba50432        2 months ago        62.5MB
+```
+
+Both "Portainer CE" and "Portainer" are in that list. Assuming "Portainer" is no longer in use, it can be removed by using either its repository name or its Image ID. In other words, the following two commands are synonyms:
+
+```
+$ docker rmi portainer/portainer
+$ docker rmi dbf28ba50432
+```
+
+In general, you can use the repository name to remove an image but the Image ID is sometimes needed. The most common situation where you are likely to need the Image ID is after an image has been updated on Dockerhub and pulled down to your Raspberry Pi. You will find two containers with the same name. One will be tagged "latest" (the running version) while the other will be tagged "<none>" (the prior version). You use the Image ID to resolve the ambiguity.
+
+## The nuclear option - use with caution
+
+You can use Git to delete all files and folders to return your folder to the freshly cloned state.
+
+Warning: **YOU WILL LOSE ALL YOUR DATA**.
+
+```
+$ cd ~/IOTstack
+$ sudo git clean -d -x -f
+```
+
+This is probably the **only** time you should ever need to use `sudo` in conjunction with `git` for IOTstack.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,65 +1,56 @@
 # IOT Stack
+
 IOTstack is a builder for docker-compose to easily make and maintain IoT stacks on the Raspberry Pi.
 
+## Getting started
 
-## Documentation for the project: 
+See [Getting Started](https://sensorsiot.github.io/IOTstack/Getting-Started) in the Wiki. It includes:
 
-https://sensorsiot.github.io/IOTstack/
+* A link to Andreas Spiess video #295.
+* How to download the project (including constraints you need to observe).
+* Running the menu to install Docker and set up your containers.
+* Useful Docker commands (start \& stop the stack, manage containers).
 
+See also the [documentation home page](https://sensorsiot.github.io/IOTstack/).
 
-## Video
-[![#295 Raspberry Pi Server based on Docker, with VPN, Dropbox backup, Influx, Grafana, etc.](http://img.youtube.com/vi/a6mjt8tWUws/0.jpg)](https://www.youtube.com/watch?v=a6mjt8tWUws "#295 Raspberry Pi Server based on Docker, with VPN, Dropbox backup, Influx, Grafana, etc.")
-**Andreas Spiess | #295 Raspberry Pi Server based on Docker, with VPN, Dropbox backup, Influx, Grafana, etc.**
+## Migrating from the old repo?
 
-
-## Installation
-1. On the (RPi) lite image you will need to install git first
+If you have been running IOTstack from [gcgarner/IOTstack](https://github.com/gcgarner/IOTstack) and want to migrate to this repository (SensorsIot/IOTstack), do the following:
 
 ```
-sudo apt-get install git -y
-```
-
-2. Download the repository with:
-```
-git clone https://github.com/SensorsIot/IOTstack.git ~/IOTstack
-```
-
-Due to some script restraints, this project needs to be stored in ~/IOTstack
-
-3. To enter the directory and run menu for installation options:
-```
-cd ~/IOTstack && bash ./menu.sh
-```
-
-4. Install docker with the menu, restart your system.
-
-5. Run menu again to select your build options, then start docker-compose with
-```
-docker-compose up -d
+$ cd ~/IOTstack
+$ git remote set-url origin https://github.com/SensorsIot/IOTstack.git
+$ git pull origin master
+$ git checkout master
+$ docker-compose down
+$ ./menu.sh
+$ docker-compose up -d
 ```
 
 ## Experimental Features
+
 Want to have the latest and greatest features? Switch to the experimental branch:
+
 ```
-git pull && git checkout experimental
-./menu.sh
+$ cd ~/IOTstack
+$ git pull origin master
+$ git checkout experimental
+$ ./menu.sh
 ```
 
-Do note that the experimental branch may be broken, or may break your setup, so ensure you have a good backup, and please report any issues.
+Do note that the experimental branch may be broken, or may break your setup, so ensure you have a good backup, and please report any issues. The way back is:
 
-## Migrating from the old repo?
 ```
-cd ~/IOTstack/
-git remote set-url origin https://github.com/SensorsIot/IOTstack.git
-git pull origin master
-docker-compose down
-./menu.sh
-docker-compose up -d
+$ cd ~/IOTstack
+$ git pull origin master
+$ git checkout master
+$ ./menu.sh
 ```
-## Add to the project
-
-Feel free to add your comments on features or images that you think should be added.
 
 ## Contributions
 
-If you use some of the tools in the project please consider donating or contributing on their projects. It doesn't have to be monetary, reporting bugs and PRs help improve the projects for everyone.
+Please use the [issues](https://github.com/SensorsIot/IOTstack/issues) tab to report issues.
+
+Join the [IOTstack Discord channel](https://discord.gg/W45tD83) if you want to comment on features, suggest new container types, or ask the IOTstack community for help.
+
+If you use some of the tools in the project please consider donating or contributing on their projects. It doesn't have to be monetary. Reporting bugs and creating Pull Requests helps improve the projects for everyone.


### PR DESCRIPTION
Found all references to gcgarner. Resolved in favour of SensorsIot.

`README.md` instructed users to clone SensorsIot (correct) while `docs/Getting-Started.md` instructed users to clone gcgarner (incorrect).

The gcgarner URL was the reason why several users complained about not receiving updates (see [Issue 132](https://github.com/SensorsIot/IOTstack/issues/132)). Duplicate material is the progenitor of inconsistency so I resolved this by treating `docs/Getting-Started.md` as authoritative, and having `README.md` refer to it.

Ditto other material previously common to both `README.md` and `docs/Getting-Started.md`. It is now all in the latter. A side-effect is to give "Migrating from the old repo?" slightly more prominence. With any luck this will help people who occasionally complain about not being able to find the migration instructions.

Also extended `docs/Getting-Started.md` with new material. 

`docs/index.md` appeared to be **intended** to be a copy of `README.md` but it was out-of-sync. I brought the two files back into sync by copying the revised `README.md` over the top of `docs/index.md`.

> I understand **why** an `index.md` (and, therefore, an `index.html`) is a good idea but we might want to give thought to whether synchronisation can be automated, rather than relying on whoever updates `README.md` remembering to make the same changes in `index.md`.

In all files touched by this PR, I have:

1. adopted the "$ command" convention to indicate "this is a CLI command".
2. replaced any instances of "sudo apt-get" with "sudo apt".
