### PR TITLE
Adds restart option for telegraf template

### DIFF
--- a/.templates/telegraf/service.yml
+++ b/.templates/telegraf/service.yml
@@ -1,6 +1,7 @@
   telegraf:
     container_name: telegraf
     image: telegraf
+    restart: unless-stopped
     volumes:
       - ./services/telegraf/telegraf.conf:/etc/telegraf/telegraf.conf:ro
     depends_on:


### PR DESCRIPTION
[Issue 163](https://github.com/SensorsIot/IOTstack/issues/163), reported that the template for telegraf did not include:

```
  restart: unless-stopped
```

This seems like an oversight.