### PR TITLE
Add exclusions for Visual Studio Code to IOTstack git ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ compose-override.yml
 .outofdate
 
 !.gitkeep
+
+.vscode
+*.code-workspace
+


### PR DESCRIPTION
Followup to [Issue 166](https://github.com/SensorsIot/IOTstack/issues/166) to include the following lines in .gitignore:

```
.vscode
*.code-workspace
```