### PR TITLE
Fix menu.sh issue #169

### DIFF
--- a/menu.sh
+++ b/menu.sh
@@ -454,7 +454,7 @@ case $mainmenu_selection in
 
 		#check selection
 		if [ -f ./services/selection.txt ]; then
-			[ $(grep "$index" ./services/selection.txt) ] && entry_options+=("ON") || entry_options+=("OFF")
+			[ $(grep --line-regexp "$index" ./services/selection.txt) ] && entry_options+=("ON") || entry_options+=("OFF")
 		else
 			entry_options+=("OFF")
 		fi


### PR DESCRIPTION
The build stack function in menu.sh was getting a match on a partial line in ./services/selection.txt. For example portainer would be considered selected if portainer-ce had been selected. The solution is to force grep to do a full line match.