### PR TITLE
Add Heimdall Application Dashboard

### DIFF
--- a/.templates/heimdall/heimdall.env
+++ b/.templates/heimdall/heimdall.env
@@ -1,0 +1,3 @@
+PUID=1000
+PGID=1000
+TZ=Europe/Paris

--- a/.templates/heimdall/service.yml
+++ b/.templates/heimdall/service.yml
@@ -1,0 +1,11 @@
+  heimdall:
+    image: ghcr.io/linuxserver/heimdall
+    container_name: heimdall
+    env_file:
+      - ./services/heimdall/heimdall.env
+    volumes:
+      - ./volumes/heimdall/config:/config
+    ports:
+      - 8880:80
+      - 8883:443
+    restart: unless-stopped

--- a/docs/Containers/Heimdall.md
+++ b/docs/Containers/Heimdall.md
@@ -1,0 +1,16 @@
+# Heimdall
+
+## References 
+* [Homepage](https://heimdall.site/)
+* [Docker](https://hub.docker.com/r/linuxserver/heimdall/)
+
+## Web Interface
+The web UI can be found on `"your_ip":8880`
+
+## About *Heimdall*
+
+From the [Heimdall website](https://heimdall.site/):
+
+> Heimdall Application Dashboard is a dashboard for all your web applications. It doesn't need to be limited to applications though, you can add links to anything you like. There are no iframes here, no apps within apps, no abstraction of APIs. if you think something should work a certain way, it probably does.
+
+Within the context of IOTstack, the Heimdall Application Dashboard can help you organize your deployed services.

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -39,6 +39,7 @@ The README is moving to the Wiki, It's easier to add content and example to the 
 * [Blynk Server](https://sensorsiot.github.io/IOTstack/Containers/Blynk_server)
 * [diyHue](https://sensorsiot.github.io/IOTstack/Containers/diyHue)
 * [Python](https://sensorsiot.github.io/IOTstack/Containers/Python)
+* [Heimdall](https://sensorsiot.github.io/IOTstack/Containers/Heimdall)
 * [Custom containers](https://sensorsiot.github.io/IOTstack/Containers/Custom)
 
 ***

--- a/menu.sh
+++ b/menu.sh
@@ -52,6 +52,7 @@ declare -A cont_array=(
 	[domoticz]="Domoticz"
 	[dozzle]="Dozzle"
 	[wireguard]="Wireguard"
+	[heimdall]="Heimdall Application Dashboard"
 	# add yours here
 )
 
@@ -90,6 +91,7 @@ declare -a armhf_keys=(
 	"domoticz"
 	"dozzle"
 	"wireguard"
+	"heimdall"
 	# add yours here
 )
 sys_arch=$(uname -m)


### PR DESCRIPTION
This PR will add the [Heimdall Application Dashboard](https://heimdall.site/) to the menu. This dashboard can be used for non-IOTstack-related purposes, but it's also useful for all the deployed IOTstack services.

I tested it locally on my Ubuntu WSL2 and it works, but do please let me know if I made any noob mistakes.