### PR TITLE
Fhem integration

### DIFF
--- a/.templates/fhem/service.yml
+++ b/.templates/fhem/service.yml
@@ -3,6 +3,6 @@
     image: fhem/fhem
     restart: unless-stopped
     ports:
-      - "8083:8083"
+      - "8082:8083"
     volumes:
       - ./volumes/fhem:/opt/fhem

--- a/.templates/fhem/service.yml
+++ b/.templates/fhem/service.yml
@@ -1,0 +1,8 @@
+  fhem:
+    container_name: fhem
+    image: fhem/fhem
+    restart: unless-stopped
+    ports:
+      - "8083:8083"
+    volumes:
+      - ./volumes/fhem:/opt/fhem

--- a/menu.sh
+++ b/menu.sh
@@ -52,6 +52,7 @@ declare -A cont_array=(
 	[domoticz]="Domoticz"
 	[dozzle]="Dozzle"
 	[wireguard]="Wireguard"
+    [fhem]="Fhem"
 	# add yours here
 )
 
@@ -90,6 +91,7 @@ declare -a armhf_keys=(
 	"domoticz"
 	"dozzle"
 	"wireguard"
+    "fhem"
 	# add yours here
 )
 sys_arch=$(uname -m)


### PR DESCRIPTION
This adds FHEM to the stack. Using the official fhem/fhem container. Moved to port 8082 as port 8083 is already taken by influxdb