### PR TITLE
Bugfix for rtl_433 (docker) needs to run with iotstack_nw network to see mosquitto

### DIFF
--- a/.templates/rtl_433/Dockerfile
+++ b/.templates/rtl_433/Dockerfile
@@ -5,6 +5,7 @@ ENV MQTT_PORT 1883
 ENV MQTT_USER ""
 ENV MQTT_PASSWORD ""
 ENV MQTT_TOPIC RTL_433
+ENV RTL_PARAMS "-C si"
 
 RUN apt-get update && apt-get install -y  git libtool libusb-1.0.0-dev librtlsdr-dev rtl-sdr cmake automake && \
 	git clone https://github.com/merbanan/rtl_433.git /tmp/rtl_433 && \
@@ -15,4 +16,4 @@ RUN apt-get update && apt-get install -y  git libtool libusb-1.0.0-dev librtlsdr
 	make && \
 	make install
 
-CMD ["sh", "-c", "rtl_433 -F mqtt://${MQTT_ADDRESS}:${MQTT_PORT},events=${MQTT_TOPIC},user=${MQTT_USER},pass=${MQTT_PASSWORD}"]
+CMD ["sh", "-c", "rtl_433 ${RTL_PARAMS} -F mqtt://${MQTT_ADDRESS}:${MQTT_PORT},events=${MQTT_TOPIC},user=${MQTT_USER},pass=${MQTT_PASSWORD}"]

--- a/.templates/rtl_433/service.yml
+++ b/.templates/rtl_433/service.yml
@@ -10,4 +10,6 @@ rtl_433:
     - MQTT_TOPIC=RTL_433
   devices:
     - /dev/bus/usb
+  networks:
+    - iotstack_nw
   restart: unless-stopped


### PR DESCRIPTION
Hello Maintainers,

When trying to use the rtl_433 from within docker, I figured out that the servise must be defined such that it uses the _iotstack_nw_ network, otherwise you cannot send messages to _mosquitto_ (by service name). Furthermore, I suggest to introduce another generic parameter field for the rtl_433 call, which I e.g. use to convert all results to SI units.

Thanks & Best Regards,

Frank