### PR TITLE
fix wireguard config file being replaced on every setup

### DIFF
--- a/.templates/wireguard/build.sh
+++ b/.templates/wireguard/build.sh
@@ -5,7 +5,9 @@ WG_CONF_DEST_PATH=./services/wireguard/config
 
 if [[ ! -f $WG_CONF_TEMPLATE_PATH ]]; then
     echo "[Wireguard] Warning: $WG_CONF_TEMPLATE_PATH does not exist."
-  else
-    [ -d $WG_CONF_DEST_PATH ] || mkdir -p $WG_CONF_DEST_PATH
-    cp -r $WG_CONF_TEMPLATE_PATH $WG_CONF_DEST_PATH
+else 
+    if [[ ! -d $WG_CONF_DEST_PATH ]]; then
+        mkdir -p $WG_CONF_DEST_PATH
+        cp -r $WG_CONF_TEMPLATE_PATH $WG_CONF_DEST_PATH
+    fi;
 fi


### PR DESCRIPTION
Every time you setup your system (menu.sh) the wg0.conf is being replaced by template causing the lost of your previously configuration