### PR TITLE
Remove environment file reference from domoticz template

### DIFF
--- a/.templates/domoticz/service.yml
+++ b/.templates/domoticz/service.yml
@@ -7,8 +7,6 @@ domoticz:
     - "1443:1443"
   volumes:
     - ./volumes/domoticz/data:/config
-  env_file:
-    - ./services/domoticz/domoticz.env      
   restart: unless-stopped
   network_mode: bridge
   environment:


### PR DESCRIPTION
New menu has moved environment variables from `domoticz.env` into
`service.yml` but the `env_file` reference is still present. This
causes new-menu builds to fail.