### PR TITLE
Migrate heimdall environment variables to service definition

### DIFF
--- a/.templates/heimdall/heimdall.env
+++ b/.templates/heimdall/heimdall.env
@@ -1,3 +1,0 @@
-PUID=1000
-PGID=1000
-TZ=Europe/Paris

--- a/.templates/heimdall/service.yml
+++ b/.templates/heimdall/service.yml
@@ -1,8 +1,10 @@
 heimdall:
   image: ghcr.io/linuxserver/heimdall
   container_name: heimdall
-  env_file:
-    - ./services/heimdall/heimdall.env
+  environment:
+    - PUID=1000
+    - PGID=1000
+    - TZ=Europe/Paris
   volumes:
     - ./volumes/heimdall/config:/config
   ports:


### PR DESCRIPTION
"New menu" has not yet moved environment variables from `heimdall.env`
into `service.yml`.

The `env_file` reference is still present in the service definition
but the target file is not being copied into the `./services/heimdall`
directory because there is no `build.py`.

This causes new-menu builds to fail.