### PR TITLE
Fix dependency check, when PyYAML is not installed.

### DIFF
--- a/scripts/python_deps_check.py
+++ b/scripts/python_deps_check.py
@@ -1,10 +1,8 @@
 import sys
-import yaml
-import blessed
-import ruamel.yaml
 
 if sys.argv[1] == "--pyyaml-version":
   try:
+    import yaml
     print("pyyaml", yaml.__version__)
     sys.exit(0)
   except SystemExit:
@@ -15,6 +13,7 @@ if sys.argv[1] == "--pyyaml-version":
 
 if sys.argv[1] == "--pyaml-version":
   try:
+    import ruamel.yaml
     print("ruamel.yaml", ruamel.yaml.__version__)
     sys.exit(0)
   except SystemExit:
@@ -25,6 +24,7 @@ if sys.argv[1] == "--pyaml-version":
 
 if sys.argv[1] == "--blessed-version":
   try:
+    import blessed
     print("blessed", blessed.__version__)
     sys.exit(0)
   except SystemExit:


### PR DESCRIPTION
`menu.sh` checks whether the dependencies ruamel.yaml and blessed are installed. The script `python_deps_check.py` is used to check the versions of the installed modules. Apparently PyYAML is not a dependency (it's version is not checked), but it's nevertheless imported. If PyYAML is not installed, the script crashes in import error. In this case, `menu.sh` fails to obtain the version number of any of the dependencies, and always prompts the user with a question whether the dependencies should be installed.

This small fix imports only the modules whose version is checked. `menu.sh` will detect the version numbers correctly, even if PyYAML is not installed.
