### PR TITLE
Mosquitto 2.x incompatible with default IOTstack config file

### DIFF
--- a/.templates/mosquitto/mosquitto.conf
+++ b/.templates/mosquitto/mosquitto.conf
@@ -1,12 +1,17 @@
+# required by https://mosquitto.org/documentation/migrating-to-2-0/
+listener 1883
+
 persistence true
 persistence_location /mosquitto/data/
 #log_dest file /mosquitto/log/mosquitto.log
 # To avoid flash wearing
 log_dest stdout
 
-#Uncomment to enable passwords
+# To enable passwords:
+# 1. Uncomment "password_file"; and
+# 2. Change "allow_anonymous" to "false"
 #password_file /mosquitto/pwfile/pwfile
-#allow_anonymous false
+allow_anonymous true
 
 #Uncomment to enable filters
 #acl_file /mosquitto/config/filter.acl


### PR DESCRIPTION
References:

* [Mosquitto doc](https://mosquitto.org/documentation/migrating-to-2-0/)
* [Workaround](https://github.com/SensorsIot/IOTstack/issues/265)
* [IOTstack new menu breaks Mosquitto configs](https://github.com/SensorsIot/IOTstack/issues/258#issuecomment-772978755)
* [Pull Request on gcgarner/IOTstack](https://github.com/gcgarner/IOTstack/pull/228)

Mosquitto 2.x has introduced a requirement for a `listener` in the
config file. If this is absent, Mosquitto will bind to the loopback
interface. When Mosquitto is running in a container, this implies no
connectivity.

Mosquitto 2.x has also changed the security defaults. Earlier versions
permitted passwordless access out-of-the box. The new version assumes
a password scheme will be implemented and requires passwordless
access to be an explicit configuration choice.

This PR maintains the IOTstack status quo by:

1. Adding `listener 1883`; and
2. Activating `allow_anonymous` with the value `true`.

Anyone who has already set up a password scheme will need to import
the `listener` line but, presumably, their `allow_anonymous` will
already be active and set to `false`, and that will not need to change.