### PR TITLE
Mosquitto 2.x incompatible with default IOTstack old-menu config file

### DIFF
--- a/.templates/mosquitto/mosquitto.conf
+++ b/.templates/mosquitto/mosquitto.conf
@@ -1,12 +1,17 @@
+# required by https://mosquitto.org/documentation/migrating-to-2-0/
+listener 1883
+
 persistence true
 persistence_location /mosquitto/data/
 #log_dest file /mosquitto/log/mosquitto.log
 # To avoid flash wearing
 log_dest stdout
 
-#Uncomment to enable passwords
+# To enable passwords:
+# 1. Uncomment "password_file"; and
+# 2. Change "allow_anonymous" to "false"
 #password_file /mosquitto/pwfile/pwfile
-#allow_anonymous false
+allow_anonymous true
 
 #Uncomment to enable filters
 #acl_file /mosquitto/config/filter.acl


### PR DESCRIPTION
This is an attempt at proposing a PR to apply to the old-menu branch
to implement the same changes as proposed for the master branch in
[PR266](https://github.com/SensorsIot/IOTstack/pull/266).