### PR TITLE
blynk_server dockerfile has been updated to latest version 0.41.15

### DIFF
--- a/.templates/blynk_server/Dockerfile
+++ b/.templates/blynk_server/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER 877dev <877dev@gmail.com>
 #RUN apt-get install -y apt-utils
 #RUN apt-get install -y default-jdk curl
 
-ENV BLYNK_SERVER_VERSION 0.41.14
+ENV BLYNK_SERVER_VERSION 0.41.15
 RUN mkdir /blynk
 RUN curl -L https://github.com/blynkkk/blynk-server/releases/download/v${BLYNK_SERVER_VERSION}/server-${BLYNK_SERVER_VERSION}.jar > /blynk/server.jar
 


### PR DESCRIPTION
Changes in 0.41.15 are:

Sometimes timer is not removed issue fixed
Dependencies updated
Added property to disable certificate renewal
Fixed NPE in mqtt handler
Added property to support only TLSv1.3 and TLSv1.2
Increased pool size for the DB and getServer command
Fixed OTA after netty libraries updated