### PR TITLE
Mosquitto service definition - 2 of 2 - old-menu branch

### DIFF
--- a/.templates/mosquitto/directoryfix.sh
+++ b/.templates/mosquitto/directoryfix.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# should not run as root
+[ "$EUID" -eq 0 ] && echo "This script should NOT be run using sudo" && exit -1
+
+# expects to run from IOTstack
+[ $(basename "$PWD") = "IOTstack" ] || echo -e \
+"Warning: This script expects to be run from ~/IOTstack.\n" \
+"        The script will continue but may produce unexpected results."
+
 [ -d ./volumes/mosquitto ] || sudo mkdir -p ./volumes/mosquitto
 
 #check user 1883

--- a/.templates/mosquitto/mosquitto.conf
+++ b/.templates/mosquitto/mosquitto.conf
@@ -1,19 +1,33 @@
 # required by https://mosquitto.org/documentation/migrating-to-2-0/
+#
 listener 1883
 
+# persistence enabled for remembering retain flag across restarts
+#
 persistence true
-persistence_location /mosquitto/data/
-#log_dest file /mosquitto/log/mosquitto.log
-# To avoid flash wearing
-log_dest stdout
+persistence_location /mosquitto/data
 
-# To enable passwords:
-# 1. Uncomment "password_file"; and
-# 2. Change "allow_anonymous" to "false"
+# logging options:
+#   enable one of the following (stdout = less wear on SD cards but
+#   logs do not persist across restarts)
+#log_dest file /mosquitto/log/mosquitto.log
+log_dest stdout
+log_timestamp_format %Y-%m-%dT%H:%M:%S
+
+# password handling:
+#   password_file commented-out allow_anonymous true =
+#     open access
+#   password_file commented-out allow_anonymous false =
+#     no access
+#   password_file activated     allow_anonymous true =
+#     passwords omitted is permitted but
+#     passwords provided must match pwfile
+#   password_file activated     allow_anonymous false =
+#     no access without passwords
+#     passwords provided must match pwfile
+#
 #password_file /mosquitto/pwfile/pwfile
 allow_anonymous true
 
-#Uncomment to enable filters
+# Uncomment to enable filters
 #acl_file /mosquitto/config/filter.acl
-
-log_timestamp_format %Y-%m-%dT%H:%M:%S

--- a/.templates/mosquitto/service.yml
+++ b/.templates/mosquitto/service.yml
@@ -9,5 +9,4 @@
       - ./volumes/mosquitto/data:/mosquitto/data
       - ./volumes/mosquitto/log:/mosquitto/log
       - ./volumes/mosquitto/pwfile:/mosquitto/pwfile
-      - ./services/mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf
-      - ./services/mosquitto/filter.acl:/mosquitto/config/filter.acl
+      - ./services/mosquitto:/mosquitto/config:ro


### PR DESCRIPTION
Changes `service.yml` to coalesce **file** volume references to
`mosquitto.conf` and `filter.acl` into a single **directory** volume
reference to the `services` directory, and to flag the access as
read-only. See also extended discussion at
[Issue 269](https://github.com/SensorsIot/IOTstack/issues/269).

Changes `mosquitto.conf` to:

1. Improve layout, including grouping like controls.
2. Extend comments on password handling.
3. Fix small typo/bug by removing trailing "/" from
`persistence_location` path (this was showing up in the Mosquitto
log as "//").

Adds checking preamble to `directoryfix.sh` to mitigate two common
mistakes:

1. Prevents invocation from `sudo`; and
2. Warns if the working directory does not appear to be called
"IOTstack".