### PR TITLE
Pin InfluxDB to version 1.8.4 (PR 1 of 2)

### DIFF
--- a/.templates/influxdb/service.yml
+++ b/.templates/influxdb/service.yml
@@ -1,6 +1,6 @@
 influxdb:
   container_name: influxdb
-  image: "influxdb:latest"
+  image: "influxdb:1.8.4"
   restart: unless-stopped
   ports:
     - "8086:8086"


### PR DESCRIPTION
See:

* [Issue 279](https://github.com/SensorsIot/IOTstack/issues/279)
* [Discord 2021-02-25](https://discord.com/channels/638610460567928832/638610461109256194/814324313754173472)

Those are both from 2021-02-25. It appears that allowing Influx to
update to "latest" results in an error:

```
$ PULL
Pulling influxdb     ... pulling from library/influxdb

ERROR: for influxdb  no matching manifest for linux/arm/v7 in the manifest list entries
ERROR: no matching manifest for linux/arm/v7 in the manifest list entries
```

The solution is to pin to the last known-good version.