### PR TITLE
Add a random delay before duckdns request

### DIFF
--- a/docs/Accessing-your-Device-from-the-internet.md
+++ b/docs/Accessing-your-Device-from-the-internet.md
@@ -17,7 +17,7 @@ first test the script to make sure it works `sudo ~/IOTstack/duck/duck.sh` then 
 Create a cron job by running the following command `crontab -e`
 
 You will be asked to use an editor option 1 for nano should be fine
-paste the following in the editor `*/5 * * * * sudo ~/IOTstack/duck/duck.sh >/dev/null 2>&1` then ctrl+s and ctrl+x to save
+paste the following in the editor `*/5 * * * * ~/IOTstack/duck/duck.sh` then ctrl+s and ctrl+x to save
 
 Your Public IP should be updated every five minutes
 

--- a/duck/duck.sh
+++ b/duck/duck.sh
@@ -5,6 +5,6 @@ DOMAINS="YOUR_DOMAINS"
 DUCKDNS_TOKEN="YOUR_DUCKDNS_TOKEN"
 
 # A random delay to avoid every client contacting the duckdns server at the same moment
-sleep $((RANDOM % 30))
+sleep $((RANDOM % 60))
 # Request duckdns to update your domain name with your public IP address
 curl --silent --max-time 10 --output /dev/null "https://www.duckdns.org/update?domains=${DOMAINS}&token=${DUCKDNS_TOKEN}&ip="

--- a/duck/duck.sh
+++ b/duck/duck.sh
@@ -3,4 +3,8 @@
 DOMAINS="YOUR_DOMAINS"
 # Your DuckDNS Token
 DUCKDNS_TOKEN="YOUR_DUCKDNS_TOKEN"
-curl -k -o /var/log/duck.log "https://www.duckdns.org/update?domains=${DOMAINS}&token=${DUCKDNS_TOKEN}&ip="
+
+# A random delay to avoid every client contacting the duckdns server at the same moment
+sleep $((RANDOM % 30))
+# Request duckdns to update your domain name with your public IP address
+curl --silent --max-time 10 --output /dev/null "https://www.duckdns.org/update?domains=${DOMAINS}&token=${DUCKDNS_TOKEN}&ip="


### PR DESCRIPTION
Minor changes to the duckdns script based on [this discussion](https://github.com/SensorsIot/IOTstack/issues/271):

* There's a random delay before the curl command to avoid every client contacting duckdns at the same instance.
* It still sometimes hangs so I think it's good to have the timeout.
* It doesn't write `/var/log/duck.log`. I think it's not needed and requires us to run the script with root privileges. Another option would be to write to some file in home directory.