### PR TITLE
Pull Request 1 of 2 (this is for master branch)

### DIFF
--- a/.templates/dozzle/service.yml
+++ b/.templates/dozzle/service.yml
@@ -3,7 +3,7 @@ dozzle:
   image: amir20/dozzle:latest 
   restart: unless-stopped
   network_mode: host
-  ports:
-    - "8888:8080"
+  #ports:
+  # - "8888:8080"
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock

--- a/.templates/home_assistant/service.yml
+++ b/.templates/home_assistant/service.yml
@@ -7,5 +7,5 @@ home_assistant:
   volumes:
     - /etc/localtime:/etc/localtime:ro
     - ./volumes/home_assistant:/config
-  network_mode: host
+  #network_mode: host
 

--- a/.templates/homebridge/service.yml
+++ b/.templates/homebridge/service.yml
@@ -10,6 +10,6 @@ homebridge:
     - HOMEBRIDGE_CONFIG_UI_PORT=%WUIPort%
   volumes:
     - ./volumes/homebridge:/homebridge
-  ports:
-    - "4040:4040"
+  #ports:
+  #  - "4040:4040"
   network_mode: host

--- a/.templates/openhab/service.yml
+++ b/.templates/openhab/service.yml
@@ -3,9 +3,9 @@ openhab:
   container_name: openhab
   restart: unless-stopped
   network_mode: host
-  ports:
-  - "4050:4050"
-  - "4051:4051"
+  #ports:
+  #- "4050:4050"
+  #- "4051:4051"
   volumes:
     - "/etc/localtime:/etc/localtime:ro"
     - "/etc/timezone:/etc/timezone:ro"

--- a/.templates/webthings_gateway/service.yml
+++ b/.templates/webthings_gateway/service.yml
@@ -2,9 +2,9 @@ webthingsio_gateway:
   image: webthingsio/gateway:latest
   container_name: webthingsio_gateway
   network_mode: host
-  ports:
-  - "4060:4060"
-  - "4061:4061"
+  #ports:
+  #- "4060:4060"
+  #- "4061:4061"
   volumes:
     - ./volumes/webthingsio_gateway/share:/home/node/.mozilla-iot
 


### PR DESCRIPTION
The [compose specification](https://github.com/compose-spec/compose-spec/blob/master/spec.md#ports)
says:

> Port mapping MUST NOT be used with network_mode: host and doing so
MUST result in a runtime error.

This rule is being enforced by current versions of docker-compose, and
is, in turn causing compose-time errors to appear
(eg [Discord post](https://discord.com/channels/638610460567928832/638610461109256194/825336297828777995)).

This Pull Request resolves the conflict by commenting-out:

* port definitions for dozzle, homebridge, openhab and
webthings_gateway; and
* the `network_mode: host` directive for home_assistant. Research
suggests that Home Assistant only needs host mode to sniff for
"Amazon Dash" buttons. According to the
[Wikipedia article](https://en.wikipedia.org/wiki/Amazon_Dash)
on the topic, the product series was discontinued in 2019.

Note. Most services that define host mode either omit ports entirely
or already comment them out. This Pull Request is harmonising the
remainder.

Signed-off-by: Phill Kelley <pmk.57t49@lgosys.com>