### PR TITLE
Pull Request 2 of 2 (this is for old-menu branch)

### DIFF
--- a/.templates/dozzle/service.yml
+++ b/.templates/dozzle/service.yml
@@ -3,7 +3,7 @@
     image: amir20/dozzle:latest 
     restart: unless-stopped
     network_mode: host
-    ports:
-      - "8888:8080"
+    #ports:
+    #  - "8888:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
The [compose specification](https://github.com/compose-spec/compose-spec/blob/master/spec.md#ports)
says:

> Port mapping MUST NOT be used with network_mode: host and doing so
MUST result in a runtime error.

This rule is being enforced by current versions of docker-compose, and
is, in turn causing compose-time errors to appear
(eg [Discord post](https://discord.com/channels/638610460567928832/638610461109256194/825336297828777995)).

This Pull Request resolves the conflict by commenting-out:

* port definitions for dozzle.

Note. Most services that define host mode either omit ports entirely or
already comment them out. This Pull Request is harmonising dozzle.