### PR TITLE
Pull Request 1 of 2 (this is for master branch)

### DIFF
--- a/.templates/nodered/Dockerfile.template
+++ b/.templates/nodered/Dockerfile.template
@@ -1,7 +1,6 @@
-FROM nodered/node-red:latest
+FROM nodered/node-red:latest-12
 USER root
-RUN apk update
-RUN apk upgrade
-RUN apk add --no-cache eudev-dev
+RUN apk update && apk add --no-cache eudev-dev
+USER node-red
 
 %run npm install modules list%


### PR DESCRIPTION
Running [hadolint](https://github.com/hadolint/hadolint) against a NodeRed Dockerfile generated by IOTstack produces these messages:

```
Dockerfile:2 DL3002 warning: Last USER should not be root
Dockerfile:3 DL3017 error: Do not use apk upgrade
```

This Pull Request makes the following changes to the Dockerfile template:

* makes the default build select node.js version 12 (instead of version 10).
* coalesces the `RUN apk` commands into a single line, omitting the `apk upgrade`.
* restores the current user to "node-red" after the `apk` commands rather than leaving it at root.

> I added the `RUN apk` commands and `USER root` directive so I should probably be the one to correct these mistakes.

References:

* [docker docs - how to keep your images small](https://docs.docker.com/develop/dev-best-practices/#how-to-keep-your-images-small)
* [docker docs - dockerfile best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run)
* [sysdig - dockerfile-best-practices](https://sysdig.com/blog/dockerfile-best-practices/)