### PR TITLE
Pull Request 2 of 2 (this is for old-menu branch)

### DIFF
--- a/.templates/nodered/build.sh
+++ b/.templates/nodered/build.sh
@@ -51,12 +51,11 @@ nr_dfile=./services/nodered/Dockerfile
 sqliteflag=0
 
 touch $nr_dfile
-echo "FROM nodered/node-red:latest" >$nr_dfile
+echo "FROM nodered/node-red:latest-12" >$nr_dfile
 
 echo "USER root" >>$nr_dfile
-echo "RUN apk update" >>$nr_dfile
-echo "RUN apk upgrade" >>$nr_dfile
-echo "RUN apk add --no-cache eudev-dev" >>$nr_dfile
+echo "RUN apk update && apk add --no-cache eudev-dev" >>$nr_dfile
+echo "USER node-red" >>$nr_dfile
 
 #node red install script inspired from https://tech.scargill.net/the-script/
 echo "RUN for addonnodes in \\" >>$nr_dfile


### PR DESCRIPTION
Running [hadolint](https://github.com/hadolint/hadolint) against a NodeRed Dockerfile generated by IOTstack produces these messages:

```
Dockerfile:2 DL3002 warning: Last USER should not be root
Dockerfile:3 DL3017 error: Do not use apk upgrade
```

This Pull Request makes the following changes to the build.sh script:

* makes the default build select node.js version 12 (instead of version 10).
* coalesces the `RUN apk` commands into a single line, omitting the `apk upgrade`.
* restores the current user to "node-red" after the `apk` commands rather than leaving it at root.

> I added the `RUN apk` commands and `USER root` directive so I should probably be the one to correct these mistakes.

References:

* [docker docs - how to keep your images small](https://docs.docker.com/develop/dev-best-practices/#how-to-keep-your-images-small)
* [docker docs - dockerfile best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run)
* [sysdig - dockerfile-best-practices](https://sysdig.com/blog/dockerfile-best-practices/)