### PR TITLE
Zigbee2MQTT - IOTstack-friendliness - PR 1 of 2 (master branch)

### DIFF
--- a/.templates/zigbee2mqtt/Dockerfile
+++ b/.templates/zigbee2mqtt/Dockerfile
@@ -1,0 +1,12 @@
+# Download base image
+FROM koenkk/zigbee2mqtt
+
+# change default configuration.yaml to be IOTstack-friendly
+# 1. expect the MQTT service to be in the Mosquitto container
+# 2. enable the web front end on port 8080
+RUN sed -i.bak \
+   -e 's/mqtt:\/\/localhost/mqtt:\/\/mosquitto/' \
+   -e '$s/$/\n\nfrontend:\n  port: 8080\n/' \
+   /app/configuration.yaml
+
+# EOF

--- a/.templates/zigbee2mqtt/service.yml
+++ b/.templates/zigbee2mqtt/service.yml
@@ -1,10 +1,16 @@
 zigbee2mqtt:
   container_name: zigbee2mqtt
-  image: koenkk/zigbee2mqtt
+  build: ./.templates/zigbee2mqtt/.
+  environment:
+    - TZ=Etc/UTC
+  ports:
+    - "8080:8080"
   volumes:
     - ./volumes/zigbee2mqtt/data:/app/data
   devices:
-    - /dev/ttyAMA0:/dev/ttyACM0
-    #- /dev/ttyUSB0:/dev/ttyACM0 # Electrolama zig-a-zig-ah! (zzh!) maybe other as well
+    - /dev/ttyAMA0:/dev/ttyACM0 # should work even if no adapter
+   #- /dev/ttyACM0:/dev/ttyACM0 # should work if CC2531 connected
+   #- /dev/ttyUSB0:/dev/ttyACM0 # Electrolama zig-a-zig-ah! (zzh!) maybe other as well
   restart: unless-stopped
-  network_mode: host
+  networks:
+    - iotstack_nw

--- a/.templates/zigbee2mqtt_assistant/service.yml
+++ b/.templates/zigbee2mqtt_assistant/service.yml
@@ -8,4 +8,6 @@ zigbee2mqtt_assistant:
     - VIRTUAL_HOST=~^zigbee2mqtt_assistant\..*\.xip\.io
     - Z2MA_SETTINGS__MQTTSERVER=mosquitto
     - VIRTUAL_PORT=8880
+  networks:
+    - iotstack_nw
 

--- a/docs/Containers/Zigbee2MQTT.md
+++ b/docs/Containers/Zigbee2MQTT.md
@@ -1,27 +1,221 @@
 # Zigbee2MQTT
-* [Web Guide](https://www.zigbee2mqtt.io/information/docker.html)
 
-## First startup
+* [Web Guide](https://www.zigbee2mqtt.io)
+* [Flashing the CC2531](https://www.zigbee2mqtt.io/information/flashing_the_cc2531.html)
+* [Figuring-out your device identifier](https://www.zigbee2mqtt.io/getting_started/running_zigbee2mqtt.html)
 
-After starting the stack check to see if there is an error due to missing device. This is because the devices are mapped differently on the Pi. If your device is not showing in the container then you can also follow the followings steps.
+## Service definition change - April 2021
 
-If you get a startup failure open the docker-compose.yml file and under zigbee2mqtt change device to map to container (uncomment one of alternatives):
+The IOTstack service definition for Zigbee2MQTT is at the following path:
 
-```yml
- devices:
-      - /dev/ttyAMA0:/dev/ttyACM0
-      #- /dev/ttyACM0:/dev/ttyACM0
-      #- /dev/ttyUSB0:/dev/ttyACM0 # Electrolama zig-a-zig-ah! (zzh!) maybe other as well
+```
+~/IOTstack/.templates/zigbee2mqtt/service.yml
 ```
 
-and run docker-compose up -d again
+As of April 2021, the service definition changed:
 
-If the container starts then run `docker logs zigbee2mqtt` so see the log output and if your device is recognised. You may need to reset the device for docker to see it.
+1. The Zigbee2MQTT container no longer runs in host mode.
+2. Adds timezone support.
+3. Builds the container from a Dockerfile providing appropriate defaults for IOTstack.
+4. Re-adds a port mapping for port 8080 (the Zigbee2MQTT web UI).
 
-To edit the configuration file `sudo nano volumes/zigbee2mqtt/data/configuration.yaml` you many need to restart the container for changes to take affect `docker-compose restart zigbee2mqtt`
+If you were running the Zigbee2MQTT service before this change, you may wish to compare and contrast your active service definition (in `docker-compose.yml`) with the revised template.
 
-Please follow instructions on https://www.zigbee2mqtt.io/
+Note:
 
-## terminal access
+* You may need to `git pull` to update your local copy of the IOTstack repository against GitHub.
 
-To access the terminal run `docker exec -it zigbee2mqtt /bin/sh`
+## First startup with CC2531 adapter
+
+The service definition includes:
+
+```
+  devices:
+    - /dev/ttyAMA0:/dev/ttyACM0 # should work even if no adapter
+   #- /dev/ttyACM0:/dev/ttyACM0 # should work if CC2531 connected
+   #- /dev/ttyUSB0:/dev/ttyACM0 # Electrolama zig-a-zig-ah! (zzh!) maybe other as well
+```
+
+The default device (`/dev/ttyAMA0`) probably will **not** work for any Zigbee adapter. It is only there because `/dev/ttyAMA0` exists on Raspberry Pis. Its presence permits the container to come up even though it will not actually be able to connect to an adapter.
+
+If you have a CC2531, properly flashed and connected to a USB port, you should be able to see it:
+
+```
+$ ls -l /dev/ttyACM0
+crw-rw---- 1 root dialout 166, 0 Apr  7 09:38 /dev/ttyACM0
+``` 
+
+> If you see the error "No such file or directory", you will need to first figure out why your device is not visible.
+
+Assuming your CC2531 is visible:
+
+1. Change the device mapping in `docker-compose.yml` to deactivate `ttyAMA0` in favour of activating `ttyACM0`:
+
+	```
+	  devices:
+	   #- /dev/ttyAMA0:/dev/ttyACM0 # should work even if no adapter
+	    - /dev/ttyACM0:/dev/ttyACM0 # should work if CC2531 connected
+	   #- /dev/ttyUSB0:/dev/ttyACM0 # Electrolama zig-a-zig-ah! (zzh!) maybe other as well
+	```
+
+2. Bring up the container:
+
+	```
+	$ cd ~/IOTstack
+	$ docker-compose up -d zigbee2mqtt
+	```
+
+You can also follow the instructions in the Zigbee2MQTT documentation to [work out the identifier of your device](https://www.zigbee2mqtt.io/getting_started/running_zigbee2mqtt.html) and use that instead of `/dev/ttyACM0`. Then, your `docker-compose.yml` might look something like this:
+
+```
+  devices:
+   #- /dev/ttyAMA0:/dev/ttyACM0 # should work even if no adapter
+   #- /dev/ttyACM0:/dev/ttyACM0 # should work if CC2531 connected
+   #- /dev/ttyUSB0:/dev/ttyACM0 # Electrolama zig-a-zig-ah! (zzh!) maybe other as well
+    - "/dev/serial/by-id/usb-Texas_Instruments_TI_CC2531_USB_CDC___xxx:/dev/ttyACM0"
+```
+
+## First startup with other adapters
+
+Similar principles apply if you use other adapters. You must work out how the adapter presents itself on your Raspberry Pi and then map it to `/dev/ttyACM0` **inside** the container (ie the common right hand side of every device definition).
+
+## Configuration file
+
+### Active configuration file
+
+Under IOTstack, the **active** configuration file for Zigbee2MQTT appears at the following path:
+
+```
+~/IOTstack/volumes/zigbee2mqtt/data/configuration.yaml
+```
+
+After you make any changes to the configuration file (using `sudo`), you need to inform the running container by:
+
+```
+$ cd ~/IOTstack
+$ docker-compose restart zigbee2mqtt
+```
+
+### Default configuration file
+
+The IOTstack version of Zigbee2MQTT is built using a Dockerfile located at:
+
+```
+~/IOTstack/.templates/zigbee2mqtt/Dockerfile
+```
+
+The Dockerfile downloads the **base** `koenkk/zigbee2mqtt` image from DockerHub and then alters the **default** configuration file as it builds a **local** image to:
+
+* change the default MQTT server URL from "mqtt://localhost" to "mqtt://mosquitto"; and
+* activate the Zigbee2MQTT web interface on port 8080.
+
+Those changes are intended to help new IOTstack installations get started with a minimum of fuss.
+
+However, the **default** configuration file will only become the **active** configuration file in two situations:
+
+* On a first install of Zigbee2MQTT; or
+* If you erase the container's persistent storage area. For example:
+
+	```
+	$ cd ~/IOTstack
+	$ docker-compose stop zigbee2mqtt
+	$ docker-compose rm -f zigbee2mqtt
+	$ sudo rm -rf ./volumes/zigbee2mqtt
+	$ docker-compose up -d zigbee2mqtt
+	```
+	
+In either of those situations, the **active** configuration file will be initialised by copying the **default** configuration file into place as the container comes up.
+
+### If you have an existing configuration file
+
+If you have an existing **active** Zigbee2MQTT configuration file, you may need to make two changes:
+
+1. Alter the Mosquitto URL:
+
+	- *before:*
+	
+		```
+		server: 'mqtt://localhost'
+		```
+	- *after:*
+	
+		```
+		server: 'mqtt://mosquitto'
+		```
+		
+2. Enable the web interface (if necessary):
+
+	- *append:*
+	
+		```
+		frontend:
+		  port: 8080
+		```
+
+## Checking that the container is working
+
+### Checking status
+
+```
+$ docker ps --format "table {{.Names}}\t{{.RunningFor}}\t{{.Status}}" --filter name="zigbee2mqtt"
+NAMES         CREATED       STATUS
+zigbee2mqtt   2 hours ago   Up 2 hours
+```
+
+You are looking for signs that the container is restarting (ie the "Status" column only ever shows a low number of seconds).
+
+### Checking the log
+
+```
+$ docker logs zigbee2mqtt
+```
+
+You are looking for evidence of malfunction.
+
+### Checking that Zigbee2MQTT is able to communicate with Mosquitto
+
+If you have the Mosquitto clients installed (`sudo apt install -y mosquitto-clients`), you can run the following command:
+
+```
+$ mosquitto_sub -v -h "localhost" -t "zigbee2mqtt/#" -F "%I %t %p"
+```
+
+One of two things will happen:
+
+* *silence,* indicating that Zigbee2MQTT is **not** able to communicate with Mosquitto.
+* *chatter,* proving that Zigbee2MQTT **can** communicate with Mosquitto.
+
+Terminate the `mosquitto_sub` command with a Control-C.
+
+### Checking that the Zigbee2MQTT web GUI is working
+
+Open a browser, and point it to port 8080 on your Raspberry Pi. You should see the Zigbee2MQTT interface.
+
+### terminal access inside the container
+
+To access the terminal run:
+
+```
+$ docker exec -it zigbee2mqtt ash
+```
+
+> `ash` is **not** a typo!
+
+When you want to leave the container, either type `exit` and press return, or press Control-D.
+
+## Container maintenance
+
+Because the Zigbee2MQTT container is built from a Dockerfile, a normal `pull` command will not automatically download any updates released on DockerHub.
+
+When you become aware of a new version of Zigbee2MQTT being released on DockerHub, do the following:
+
+```
+$ cd ~IOTstack
+$ docker-compose build --no-cache --pull zigbee2mqtt
+$ docker-compose up -d zigbee2mqtt
+$ docker system prune
+```
+
+Note:
+
+* Sometimes it is necessary to repeat the `docker system prune` command.


### PR DESCRIPTION
Changes Zigbee2MQTT service definition:

1. Moves container out of host mode.
2. Re-adds port 8080:8080 mapping (web UI).
3. Adds TZ environment variable (to make it clear container supports this).
4. More comments on devices list.
5. Adds new-menu network (iotstack_nw).
6. Builds container from Dockerfile to support sensible IOTstack defaults:
	* Referencing Mosquitto by container name rather than localhost
	* Enables Zigbee2MQTT web UI by default
7. Expands documentation.

First-time users should only ever have to work out how their adapter presents itself and define it appropriately in the device list.

Dockerfile-based build will not be picked up unless user recreates the service from its template.

Changes to internal default configuration file will not overwrite existing configuration files. Internal defaults will only become active on first install or if persistent storage area is erased.

Also changes service definition for Zigbee2MQTT_Assistant:

1. Adds new-menu network (iotstack_nw).