### PR TITLE
Zigbee2MQTT - IOTstack-friendliness - PR 2 of 2 (old-menu branch)

### DIFF
--- a/.templates/zigbee2mqtt/Dockerfile
+++ b/.templates/zigbee2mqtt/Dockerfile
@@ -1,0 +1,12 @@
+# Download base image
+FROM koenkk/zigbee2mqtt
+
+# change default configuration.yaml to be IOTstack-friendly
+# 1. expect the MQTT service to be in the Mosquitto container
+# 2. enable the web front end on port 8080
+RUN sed -i.bak \
+   -e 's/mqtt:\/\/localhost/mqtt:\/\/mosquitto/' \
+   -e '$s/$/\n\nfrontend:\n  port: 8080\n/' \
+   /app/configuration.yaml
+
+# EOF

--- a/.templates/zigbee2mqtt/service.yml
+++ b/.templates/zigbee2mqtt/service.yml
@@ -1,10 +1,14 @@
   zigbee2mqtt:
     container_name: zigbee2mqtt
-    image: koenkk/zigbee2mqtt
+    build: ./.templates/zigbee2mqtt/.
+    environment:
+      - TZ=Etc/UTC
+    ports:
+      - "8080:8080"
     volumes:
       - ./volumes/zigbee2mqtt/data:/app/data
     devices:
-      - /dev/ttyAMA0:/dev/ttyACM0
-      #- /dev/ttyACM0:/dev/ttyACM0
+      - /dev/ttyAMA0:/dev/ttyACM0 # should work even if no adapter
+     #- /dev/ttyACM0:/dev/ttyACM0 # should work if CC2531 connected
+     #- /dev/ttyUSB0:/dev/ttyACM0 # Electrolama zig-a-zig-ah! (zzh!) maybe other as well
     restart: unless-stopped
-    network_mode: host


### PR DESCRIPTION
Changes Zigbee2MQTT service definition:

1. Moves container out of host mode.
2. Re-adds port 8080:8080 mapping (web UI).
3. Adds TZ environment variable (to make it clear container supports this).
4. More comments on devices list.
5. Builds container from Dockerfile to support sensible IOTstack defaults:
	* Referencing Mosquitto by container name rather than localhost
	* Enables Zigbee2MQTT web UI by default

First-time users should only ever have to work out how their adapter presents itself and define it appropriately in the device list.

Dockerfile-based build will not be picked up unless user recreates the service from its template.

Changes to internal default configuration file will not overwrite existing configuration files. Internal defaults will only become active on first install or if persistent storage area is erased.

Documentation update not included as part of PR 2/2. Assumes most users will view documentation online so master branch is appropriate (but feel free to cherry-pick the change if you wish).

Signed-off-by: Phill Kelley <pmk.57t49@lgosys.com>