### PR TITLE
Adds web UI password field to Dockerfile - master (1 of 2)

### DIFF
--- a/.templates/zigbee2mqtt/Dockerfile
+++ b/.templates/zigbee2mqtt/Dockerfile
@@ -6,7 +6,7 @@ FROM koenkk/zigbee2mqtt
 # 2. enable the web front end on port 8080
 RUN sed -i.bak \
    -e 's/mqtt:\/\/localhost/mqtt:\/\/mosquitto/' \
-   -e '$s/$/\n\nfrontend:\n  port: 8080\n/' \
+   -e '$s/$/\n\nfrontend:\n  port: 8080\n# auth_token: PASSWORD\n/' \
    /app/configuration.yaml
 
 # EOF

--- a/docs/Containers/Zigbee2MQTT.md
+++ b/docs/Containers/Zigbee2MQTT.md
@@ -203,6 +203,47 @@ $ docker exec -it zigbee2mqtt ash
 
 When you want to leave the container, either type `exit` and press return, or press Control-D.
 
+## Setting a password for the web interface
+
+By default, the web interface is unprotected. If you want to set a password:
+
+1. Use `sudo` to edit the active configuration file at the path:
+
+	```
+	~/IOTstack/volumes/zigbee2mqtt/data/configuration.yaml
+	```
+
+2. Find the following text:
+
+	```
+	frontend:
+	  port: 8080
+	# auth_token: PASSWORD
+	```
+	
+3. Uncomment the `auth_token` line and replace "PASSWORD" with the password of your choice. For example, to set the password to "mypassword":
+
+	```
+	  auth_token: mypassword
+	```
+	
+	Note:
+	
+	* although the name `auth_token` suggests something more complex, it really is no more than a simple *en-clear* password. If this concerns you, consider disabling the web front-end entirely, like this:
+	
+		```
+		#frontend:
+		# port: 8080
+		# auth_token: PASSWORD
+		```
+
+4. Save the file and restart the container:
+
+	```
+	$ cd ~/IOTstack
+	$ docker-compose restart zigbee2mqtt
+	```
+
 ## Container maintenance
 
 Because the Zigbee2MQTT container is built from a Dockerfile, a normal `pull` command will not automatically download any updates released on DockerHub.


### PR DESCRIPTION
Adds a commented-out "auth_token" field to the default configuration
file set up by the Dockerfile. This follows on from discussion at
[PR310](https://github.com/SensorsIot/IOTstack/pull/310#issuecomment-816557323).

The basic idea is that the web UI should work out-of-the-box but it
should also be easy for anyone who wants to add basic security to
the web interface to do that (or disable the web UI entirely).

Documentation updated to reflect these changes.