### PR TITLE
Adds web UI password field to Dockerfile - old-menu (2 of 2)

### DIFF
--- a/.templates/zigbee2mqtt/Dockerfile
+++ b/.templates/zigbee2mqtt/Dockerfile
@@ -6,7 +6,7 @@ FROM koenkk/zigbee2mqtt
 # 2. enable the web front end on port 8080
 RUN sed -i.bak \
    -e 's/mqtt:\/\/localhost/mqtt:\/\/mosquitto/' \
-   -e '$s/$/\n\nfrontend:\n  port: 8080\n/' \
+   -e '$s/$/\n\nfrontend:\n  port: 8080\n# auth_token: PASSWORD\n/' \
    /app/configuration.yaml
 
 # EOF


### PR DESCRIPTION
Adds a commented-out "auth_token" field to the default configuration
file set up by the Dockerfile. This follows on from discussion at
[PR310](https://github.com/SensorsIot/IOTstack/pull/310#issuecomment-816557323).

The basic idea is that the web UI should work out-of-the-box but it
should also be easy for anyone who wants to add basic security to
the web interface to do that (or disable the web UI entirely).

Documentation is on master branch on the assumption that most people
read it online.