### PR TITLE
Adds iotstack_nw definition to prometheus containers

### DIFF
--- a/.templates/prometheus/service.yml
+++ b/.templates/prometheus/service.yml
@@ -11,3 +11,5 @@ prometheus:
   command:
     - '--config.file=/etc/prometheus/config.yml'
     - '--storage.tsdb.path=/data'
+  networks:
+    - iotstack_nw

--- a/.templates/prometheus/service_cadvisor-arm.yml
+++ b/.templates/prometheus/service_cadvisor-arm.yml
@@ -11,3 +11,5 @@
       - /var/run:/var/run:rw
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
+    networks:
+      - iotstack_nw

--- a/.templates/prometheus/service_node-exporter.yml
+++ b/.templates/prometheus/service_node-exporter.yml
@@ -4,3 +4,5 @@
     restart: unless-stopped
     expose:
       - 9100
+    networks:
+      - iotstack_nw


### PR DESCRIPTION
Reported in [Issue 320](https://github.com/SensorsIot/IOTstack/issues/320).

`iotstack_nw` definition added to master branch template files:

```
.templates/prometheus/service.yml
.templates/prometheus/service_cadvisor-arm.yml
.templates/prometheus/service_node-exporter.yml
```