### PR TITLE
Fix Install Docker

### DIFF
--- a/scripts/install_docker.sh
+++ b/scripts/install_docker.sh
@@ -19,7 +19,7 @@ if [ "$1" == "install" ]; then
     echo "Docker already installed" >&2
   else
     echo "Install Docker" >&2
-    curl -fsSL https://get.docker.com | sh
+    curl -fsSL https://get.docker.com | sudo sh
     RESTART_REQUIRED="true"
     sudo usermod -aG docker $USER
   fi


### PR DESCRIPTION
Reported in [Issue 222](#222)

Docker can only be installed calling ./menu.sh with sudo.
This commit adds the missing sudo after piping the output of
get.docker.com install script to an unprivileged sh.