### PR TITLE
blynk_server dockerfile has been updated to latest version 0.41.16

### DIFF
--- a/.templates/blynk_server/Dockerfile
+++ b/.templates/blynk_server/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER 877dev <877dev@gmail.com>
 #RUN apt-get install -y apt-utils
 #RUN apt-get install -y default-jdk curl
 
-ENV BLYNK_SERVER_VERSION 0.41.15
+ENV BLYNK_SERVER_VERSION 0.41.16
 RUN mkdir /blynk
 RUN curl -L https://github.com/blynkkk/blynk-server/releases/download/v${BLYNK_SERVER_VERSION}/server-${BLYNK_SERVER_VERSION}.jar > /blynk/server.jar
 


### PR DESCRIPTION
Changes in 0.41.16 are:

Remove obsolete code
Updated dependencies
Fixed map pool size property