### PR TITLE
Improved mkdocs.yml - old-menu branch - PR 2 of 2

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,9 @@ site_description: 'Docker stack for getting started on IOT on the Raspberry PI'
 theme:
   name: material
   features:
-    - tabs
-  plugins:
-    - search
-    - awsome-pages
+    - navigation.tabs
+plugins:
+  - search
+  - awesome-pages
+markdown_extensions:
+  - pymdownx.superfences


### PR DESCRIPTION
The existing mkdocs.yml needs improvement. Currently, it contains:

1. Syntax errors:

	* `plugins:` should be at the same level as `theme:`

2. A deprecated directive:

	* the `tabs` feature should be expressed as `navigation.tabs`

3. A missing extension required for proper formatting of the IOTstack Wiki:

	```
	markdown_extensions:
	  - pymdownx.superfences
	```

See [squidfunk/mkdocs-material issues 2639](https://github.com/squidfunk/mkdocs-material/issues/2639).