### PR TITLE
Improved mkdocs.yml - deactivate awesome-pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,6 @@ theme:
     - navigation.tabs
 plugins:
   - search
-  - awesome-pages
+# - awesome-pages
 markdown_extensions:
   - pymdownx.superfences


### PR DESCRIPTION
`awesome-pages` was in the wrong place in `mkdocs.yml` but was not
producing errors. Moving it to the correct place in PRs 335 and 336
revealed that `mkdocs-awesome-pages-plugin` had not been installed so
documentation failed to build.

This patch comments-out `awesome-pages` on the basis that is seems to
make no real difference to the displayed pages.