### PR TITLE
Node-RED withdraw default privileged flag - PR 2 of 2

### DIFF
--- a/.templates/nodered/service.yml
+++ b/.templates/nodered/service.yml
@@ -3,7 +3,6 @@
     build: ./services/nodered/.
     restart: unless-stopped
     user: "0"
-    privileged: true
     env_file: ./services/nodered/nodered.env
     ports:
       - "1880:1880"


### PR DESCRIPTION
Removes default `privileged: true` from `service.yml` in Node-RED
old-menu branch template.

The [Docker documentation](https://docs.docker.com/engine/reference/commandline/run/#full-container-capabilities---privileged)
describes this flag as:

> The --privileged flag gives all capabilities to the container, and it
also lifts all the limitations enforced by the device cgroup controller.
In other words, the container can then do almost everything that the
host can do. This flag exists to allow special use-cases, like running
Docker within Docker.

See also [privileged vs root in Docker](https://www.cloudsavvyit.com/5211/privileged-vs-root-in-docker-whats-the-difference/)
which warns:

> It’s a special flag you can set at runtime specifically to allow a
Docker container to break free from its namespaces and access the
entire system directly. Generally, this is a very bad idea, as this
allows malicious code from the container to do nasty things like
overwrite the host’s .ssh/authorized_keys or delete disk partitions.

I have been running Node-RED **without** this flag for the past year
and have not encountered a single situation that gave me cause to
think Node-RED needed all the privileges of root.

In my view, the IOTstack repository should adopt the principle of least
privilege and "fail safe" by not exposing users to the possibility that
a maliciously-crafted extension will compromise the security of their
IOTstack host.

If there are indeed situations that warrant the use of this flag,
those users can enable the flag, on their systems, case by case.