### PR TITLE
Remove navigation tabs from docs pages (in favour of topic list)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,8 +2,6 @@ site_name: IOTstack
 site_description: 'Docker stack for getting started on IOT on the Raspberry PI'
 theme:
   name: material
-  features:
-    - navigation.tabs
 plugins:
   - search
 # - awesome-pages


### PR DESCRIPTION
Following on from PRs [335](https://github.com/SensorsIot/IOTstack/pull/335), [336](https://github.com/SensorsIot/IOTstack/pull/336) and [337](https://github.com/SensorsIot/IOTstack/pull/337), it now appears as though the original `mkdocs.yml` contained another error:

```
  features:
    - tabs
```

Part of the advice from [squidfunk/mkdocs-material issue 2639](https://github.com/squidfunk/mkdocs-material/issues/2639) included that `tabs` had been deprecated in favour of `navigation.tabs` so I made that change in PRs 335 & 336:

```
  features:
    - navigation.tabs
```

That appears to have had the effect of **activating** the feature, whereas the evidence suggests that the old `tabs` value did not actually activate the feature. The result is that on wider screens, the topic strip which used to appear at the left of the screen has been converted to a strip of tabs across the top of the screen. That might be appropriate where there are only a few sub-pages but makes navigation more difficult for the IOTstack Wiki.

![facets](https://user-images.githubusercontent.com/34226495/117920923-2aefe180-b333-11eb-8bd5-6c651393ecbf.png)

This problem was [reported on Discord](https://discord.com/channels/638610460567928832/638610461109256194/841735679780323409) by @877dev.

This PR removes both lines from `mkdocs.yml`.
