### PR TITLE
Node-RED revised documentation - PR 2 of 2 - old-menu branch

### DIFF
--- a/.templates/nodered/service.yml
+++ b/.templates/nodered/service.yml
@@ -8,6 +8,7 @@
       - "1880:1880"
     volumes:
       - ./volumes/nodered/data:/data
+      - ./volumes/nodered/ssh:/root/.ssh
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
     devices:

--- a/scripts/nodered_list_installed_nodes.sh
+++ b/scripts/nodered_list_installed_nodes.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+INTERNAL="/usr/src/node-red/node_modules"
+EXTERNAL="$HOME/IOTstack/volumes/nodered/data/node_modules"
+
+echo -e "\nNodes installed by Dockerfile INSIDE the container at $INTERNAL"
+
+CANDIDATES=$(docker exec nodered bash -c "ls -1d $INTERNAL/node-red-*")
+
+for C in $CANDIDATES; do
+
+   NODE=$(basename "$C")
+
+   # is a node of the same name also present externally
+   if [ -d "$EXTERNAL/$NODE" ] ; then
+
+      # yes! the internal node is blocked by the external node
+      echo " BLOCKED: $NODE"
+
+   else
+
+      # no! so that means it's active
+      echo "  ACTIVE: $NODE"
+
+   fi
+
+done
+
+echo -e "\nNodes installed by Manage Palette OUTSIDE the container at $EXTERNAL"
+
+CANDIDATES=$(ls -1d "$EXTERNAL/node-red-"*)
+
+for C in $CANDIDATES; do
+
+   NODE=$(basename "$C")
+
+   echo " $NODE"
+
+done
+
+echo ""


### PR DESCRIPTION
Node-RED revised documentation - PR 2 of 2 - old-menu branch

Adds new volume mapping to nodered service definition to explicitly support ssh for user root inside the container. This does nothing unless and until a user follows the SSH setup instructions in the updated Node-RED container instructions (master branch). This change won't break any existing installations that use the older method.

Adds helper script for finding duplicated nodes to scripts directory.
