### PR TITLE
Use a stable build of deconz by default

### DIFF
--- a/.templates/deconz/service.yml
+++ b/.templates/deconz/service.yml
@@ -1,5 +1,5 @@
 deconz:
-  image: marthoc/deconz
+  image: marthoc/deconz:stable
   container_name: deconz
   restart: unless-stopped
   ports:


### PR DESCRIPTION
The default tag (:latest) of the deconz docker image uses beta releases
as well. It is probably best to use only stable releases by default and
let users override the tag if they wish to set up beta releases.