### PR TITLE
Pin InfluxDB to 1.8 - PR 1 of 3 - master branch

### DIFF
--- a/.templates/influxdb/service.yml
+++ b/.templates/influxdb/service.yml
@@ -1,6 +1,6 @@
 influxdb:
   container_name: influxdb
-  image: "influxdb:1.8.4"
+  image: "influxdb:1.8"
   restart: unless-stopped
   ports:
     - "8086:8086"


### PR DESCRIPTION
Changes pin from 1.8.4 to 1.8. This will pick up the multiple images tagged with 1.8.5 (following on from multiple images tagged 1.8.4) and any future 1.8.6 etc.
