### PR TITLE
Pin InfluxDB to 1.8 - PR 3 of 3 - experimental branch

### DIFF
--- a/.internal/templates/services/influxdb/config.js
+++ b/.internal/templates/services/influxdb/config.js
@@ -16,7 +16,7 @@ const influxDb = () => {
         }
       ],
       volumes: true,
-      imageTags: ['1.8.4', 'latest'],
+      imageTags: ['1.8', '1.8.4', 'latest'],
       networks: true,
       logging: true
     }


### PR DESCRIPTION
Changes pin from 1.8.4 to 1.8. This will pick up the multiple images tagged with 1.8.5 (following on from multiple images tagged 1.8.4) and any future 1.8.6 etc.

Formatted as per your Discord advice (1.8, 1.8.4, latest).

The problem I see with "latest" is that it doesn't work.