### PR TITLE
Octoprint - ports - PR 1 of 3 - master branch

### DIFF
--- a/.templates/octoprint/service.yml
+++ b/.templates/octoprint/service.yml
@@ -9,7 +9,6 @@ octoprint:
   # - CAMERA_DEV=/dev/video0
   ports:
     - "9980:80"
-    - "9981:8080"
   devices:
     - /dev/ttyAMA0:/dev/ttyACM0
   # - /dev/video0:/dev/video0


### PR DESCRIPTION
Removes 9981:8080 port mapping (unnecessary).

Extends documentation:

* first run (Wizard)
* restarting the container
* username and password recovery