### PR TITLE
Changes to "getting started" documentation - master branch

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -113,7 +113,9 @@ If you are still running on gcgarner/IOTstack and need to migrate to SensorsIot/
 
 * [Migrating IOTstack from gcgarner to SensorsIot](./gcgarner-migration.md).
 
-## <a name="recommendedPatches"> recommended system patch </a>
+## <a name="recommendedPatches"> recommended system patches </a>
+
+### <a name="patch1DHCP"> patch 1 – restrict DHCP </a>
 
 Run the following commands:
 
@@ -123,6 +125,17 @@ $ sudo reboot
 ```
 
 See [Issue 219](https://github.com/SensorsIot/IOTstack/issues/219) and [Issue 253](https://github.com/SensorsIot/IOTstack/issues/253) for more information.
+
+### <a name="patch2DHCP"> patch 2 – update libseccomp2</a>
+
+If you don't have this patch in place, Docker images that are based on Alpine will fail if an image's maintainer updates to [Alpine 3.13](https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.13.0#time64_requirement).
+
+```
+$ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 04EE7237B7D453EC 648ACFD622F3D138
+$ echo "deb http://httpredir.debian.org/debian buster-backports main contrib non-free" | sudo tee -a "/etc/apt/sources.list.d/debian-backports.list"
+$ sudo apt update
+$ sudo apt install libseccomp2 -t buster-backports
+```
 
 ## <a name="aboutSudo"> a word about the `sudo` command </a>
 
@@ -236,6 +249,38 @@ The commands in this menu execute shell scripts in the root of the project.
 The old and new menus differ in the options they offer. You should come back and explore them once your stack is built and running.
 
 ## <a name="switchingMenus"> switching menus </a>
+
+At the time of writing, IOTstack supports three menus:
+
+* "Old Menu" on the `old-menu` branch. This was inherited from [gcgarner/IOTstack](https://github.com/gcgarner/IOTstack).
+* "New Menu" on the `master` branch. This is the current menu.
+* "New New Menu" on the `experimental` branch. This is under development.
+
+With a few precautions, you can switch between git branches as much as you like without breaking anything. The basic check you should perform is:
+
+```
+$ cd ~/IOTstack
+$ git status
+```
+
+Check the results to see if any files are marked as "modified". For example:
+
+```
+modified:   .templates/mosquitto/Dockerfile
+```
+
+Key point:
+
+* Files marked "untracked" do not matter. You only need to check for "modified" files because those have the potential to stop you from switching branches cleanly.
+
+The way to avoid potential problems is to move any modified files to one side and restore the unmodified original. For example:
+
+```
+$ mv .templates/mosquitto/Dockerfile .templates/mosquitto/Dockerfile.save
+$ git checkout -- .templates/mosquitto/Dockerfile
+```
+
+When `git status` reports no more "modified" files, it is safe to switch your branch.
 
 ### <a name="menuMasterBranch"> current menu (master branch) </a>
 


### PR DESCRIPTION
1. Adds new system patch to update `libseccomp2` to a version that is
compatible with images based on Alpine 3.13 or later.

	Any 32-bit Raspbian `zigbee2mqtt` users updating on or about June
3 2021 fell into this hole. The image maintainer reverted to Alpine
3.12 but other Alpine-based images (eg Mosquitto, Node-RED) are at
risk if their maintainers update to 3.13 or later.

	References:

	- [Alpine 3.13 release notes](https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.13.0#time64_requirement)
	- [Discord discussion](https://discord.com/channels/638610460567928832/638610461109256194/849960528394059806)
	- [Patching options](https://blog.samcater.com/fix-workaround-rpi4-docker-libseccomp2-docker-20/)

2. Adds words about checking for and resolving "modified" files that
may prevent users from switching between IOTstack branches.

	Reference:

	- [Discord suggestion](https://discord.com/channels/638610460567928832/638610461109256194/853572152616157226)