### PR TITLE
openHAB - consistency fixes - old-menu branch - 2 of 3

### DIFF
--- a/.templates/openhab/service.yml
+++ b/.templates/openhab/service.yml
@@ -12,8 +12,8 @@
     environment:
       - OPENHAB_HTTP_PORT=4050
       - OPENHAB_HTTPS_PORT=4051
-      - EXTRA_JAVA_OPTS: "-Duser.timezone=Europe/Berlin"
-    logging:
-      options:
-        max-size: "5m"
-        max-file: "3"
+      - EXTRA_JAVA_OPTS=-Duser.timezone=Etc/UTC
+#   logging:
+#     options:
+#       max-size: "5m"
+#       max-file: "3"

--- a/.templates/openhab/service.yml
+++ b/.templates/openhab/service.yml
@@ -1,11 +1,8 @@
   openhab:
-    image: "openhab/openhab:2.4.0"
     container_name: openhab
+    image: "openhab/openhab:latest"
     restart: unless-stopped
     network_mode: host
-#    cap_add:
-#      - NET_ADMIN
-#      - NET_RAW
     volumes:
       - "/etc/localtime:/etc/localtime:ro"
       - "/etc/timezone:/etc/timezone:ro"
@@ -13,9 +10,10 @@
       - "./volumes/openhab/conf:/openhab/conf"
       - "./volumes/openhab/userdata:/openhab/userdata"
     environment:
-      OPENHAB_HTTP_PORT: "8080"
-      OPENHAB_HTTPS_PORT: "8443"
-      EXTRA_JAVA_OPTS: "-Duser.timezone=Europe/Berlin"
-#    # The command node is very important. It overrides
-#    # the "gosu openhab tini -s ./start.sh" command from Dockerfile and runs as root!
-#    command: "tini -s ./start.sh server"
+      - OPENHAB_HTTP_PORT=4050
+      - OPENHAB_HTTPS_PORT=4051
+      - EXTRA_JAVA_OPTS: "-Duser.timezone=Europe/Berlin"
+    logging:
+      options:
+        max-size: "5m"
+        max-file: "3"

--- a/docs/Containers/openHAB.md
+++ b/docs/Containers/openHAB.md
@@ -1,6 +1,3 @@
 # Openhab
-## References
-- [Docker](https://hub.docker.com/r/openhab/openhab/)
-- [website](https://www.openhab.org/)
 
-openHAB has been added without Amazon Dashbutton binding. Port binding is `8080` for http and `8443` for https. 
+See [documentation on master branch](https://github.com/SensorsIot/IOTstack/blob/master/docs/Containers/openHAB.md).


### PR DESCRIPTION
Uses a consistent service definition across all three branches.

Removes pin to version 2.4.0. A check today shows "latest" runs on
32-bit Raspbian without problems so there appears to be no reason for
the pin. There is no pin in either master or experimental so this looks
like a legacy holdover.

Fixes mal-formed environment variables (no leading hyphens) so it is
slightly amazing that the resulting docker-compose.yml would work.

Changes to ports 4050 and 4051 to be consistent with master and
experimental branches.

Removes commented out capabilities which seem unnecessary.

Adds logging options from experimental branch.

Replaces documentation with a pointer to master branch.