### PR TITLE
20210809 MariaDB + Nextcloud - master branch - PR 1 of 3

### DIFF
--- a/.templates/mariadb/Dockerfile
+++ b/.templates/mariadb/Dockerfile
@@ -1,0 +1,13 @@
+# Download base image
+FROM ghcr.io/linuxserver/mariadb
+
+# apply stability patches recommended in
+#   
+#   https://discord.com/channels/638610460567928832/638610461109256194/825049573520965703
+#   https://stackoverflow.com/questions/61809270/how-to-discover-why-mariadb-crashes
+RUN sed -i.bak \
+  -e "s/^thread_cache_size/# thread_cache_size/" \
+  -e "s/^read_buffer_size/# read_buffer_size/" \
+  /defaults/my.cnf
+
+# EOF

--- a/.templates/mariadb/service.yml
+++ b/.templates/mariadb/service.yml
@@ -1,5 +1,5 @@
 mariadb:
-  image: linuxserver/mariadb
+  build: ./.templates/mariadb/.
   container_name: mariadb
   environment:
     - TZ=Etc/UTC
@@ -11,6 +11,7 @@ mariadb:
     - MYSQL_PASSWORD=%randomPassword%
   volumes:
     - ./volumes/mariadb/config:/config
+    - ./volumes/mariadb/db_backup:/backup
   ports:
     - "3306:3306"
   restart: unless-stopped

--- a/.templates/nextcloud/service.yml
+++ b/.templates/nextcloud/service.yml
@@ -19,7 +19,7 @@ nextcloud:
 
 nextcloud_db:
   container_name: nextcloud_db
-  image: ghcr.io/linuxserver/mariadb
+  build: ./.templates/mariadb/.
   restart: unless-stopped
   environment:
     - TZ=Etc/UTC
@@ -29,7 +29,10 @@ nextcloud_db:
     - MYSQL_PASSWORD=%randomMySqlPassword%
     - MYSQL_DATABASE=nextcloud
     - MYSQL_USER=nextcloud
+  ports:
+    - "9322:3306"
   volumes:
     - ./volumes/nextcloud/db:/config
+    - ./volumes/nextcloud/db_backup:/backup
   networks:
     - nextcloud_internal

--- a/docs/Containers/MariaDB.md
+++ b/docs/Containers/MariaDB.md
@@ -4,9 +4,9 @@
 
 ## About
 
-MariaDB is a fork of MySQL. This is an unofficial image provided by linuxserver.io because there is no official image for arm
+MariaDB is a fork of MySQL. This is an unofficial image provided by linuxserver.io because there is no official image for arm.
 
-## Conneting to the DB
+## Connecting to the DB
 
 The port is 3306. It exists inside the docker network so you can connect via `mariadb:3306` for internal connections. For external connections use `<your Pis IP>:3306`
 
@@ -14,10 +14,65 @@ The port is 3306. It exists inside the docker network so you can connect via `ma
 
 ## Setup
 
-Before starting the stack edit the `./services/mariadb/mariadb.env` file and set your access details. This is optional however you will only have one shot at the preconfig. If you start the container without setting the passwords then you will have to either delete its volume directory or enter the terminal and change manually
+Before starting the stack, edit the `docker-compose.yml` file and check your environment variables. In particular:
 
-The env file has three commented fields for credentials, either **all three** must be commented or un-commented. You can't have only one or two, its all or nothing.
+```
+  environment:
+    - TZ=Etc/UTC
+    - MYSQL_ROOT_PASSWORD=
+    - MYSQL_DATABASE=default
+    - MYSQL_USER=mariadbuser
+    - MYSQL_PASSWORD=
+```
+
+If you are running old-menu, you will have to set both passwords. Under new-menu, the menu may have allocated random passwords for you but you can change them if you like.
+
+You only get the opportunity to change the `MQSL_` prefixed environment variables before you bring up the container for the first time. If you decide to change these values after initialisation, you will either have to:
+
+1. Erase the persistent storage area and start again. There are three steps:
+
+	* Stop the container and remove the persistent storage area:
+
+		```
+		$ cd ~/IOTstack
+		$ docker-compose rm --force --stop -v mariadb
+		$ sudo rm -rf ./volumes/mariadb
+		```
+		
+	* Edit `docker-compose.yml` and change the variables.
+	* Bring up the container:
+	
+		```
+		$ docker-compose up -d mariadb 
+		```
+
+2. Open a terminal window within the container (see below) and change the values by hand.
+
+	> The how-to is beyond the scope of this documentation. Google is your friend!
 
 ## Terminal
 
-A terminal is provided to access mariadb by the cli. execute `./services/mariadb/terminal.sh`. You will need to run `mysql -uroot -p` to enter mariadbs interface
+You can open a terminal session within the mariadb container via:
+
+```
+$ docker exec -it mariadb bash
+```
+
+To close the terminal session, either:
+
+* type "exit" and press <kbd>return</kbd>; or
+* press <kbd>control</kbd>+<kbd>d</kbd>.
+
+## Keeping MariaDB up-to-date
+
+To update the `mariadb` container:
+
+```
+$ cd ~/IOTstack
+$ docker-compose build --no-cache --pull mariadb
+$ docker-compose up -d mariadb
+$ docker system prune
+$ docker system prune
+```
+
+The first "prune" removes the old *local* image, the second removes the old *base* image.

--- a/docs/Containers/NextCloud.md
+++ b/docs/Containers/NextCloud.md
@@ -23,7 +23,7 @@ nextcloud:
 
 nextcloud_db:
   container_name: nextcloud_db
-  image: ghcr.io/linuxserver/mariadb
+  build: ./.templates/mariadb/.
   restart: unless-stopped
   environment:
     - TZ=Etc/UTC
@@ -33,8 +33,11 @@ nextcloud_db:
     - MYSQL_PASSWORD=«user_password»
     - MYSQL_DATABASE=nextcloud
     - MYSQL_USER=nextcloud
+  ports:
+    - "9322:3306"
   volumes:
     - ./volumes/nextcloud/db:/config
+    - ./volumes/nextcloud/db_backup:/backup
 ```
 
 There are two containers, one for the cloud service itself, and the other for the database. Both containers share the same persistent storage area in the volumes subdirectory so they are treated as a unit. This will not interfere with any other MariaDB containers you might wish to run.
@@ -258,6 +261,29 @@ You can silence the warning by editing the Nextcloud service definition in `dock
 ## <a name="security"> Security considerations</a>
 
 Nextcloud traffic is not encrypted. Do **not** expose it to the web by opening a port on your home router. Instead, use a VPN like Wireguard to provide secure access to your home network, and let your remote clients access Nextcloud over the VPN tunnel.
+
+## <a name="updatingNextcloud"> Keeping Nextcloud up-to-date </a>
+
+To update the `nextcloud` container:
+
+```
+$ cd ~/IOTstack
+$ docker-compose pull nextcloud
+$ docker-compose up -d nextcloud
+$ docker system prune
+```
+
+To update the `nextcloud_db` container:
+
+```
+$ cd ~/IOTstack
+$ docker-compose build --no-cache --pull nextcloud_db
+$ docker-compose up -d nextcloud_db
+$ docker system prune
+$ docker system prune
+```
+
+The first "prune" removes the old *local* image, the second removes the old *base* image.
 
 ## <a name="backups"> Backups </a>
 


### PR DESCRIPTION
1. Adds Dockerfile to MariaDB template to add stability patches recommended in:

	* [StackOverflow](https://stackoverflow.com/questions/61809270/how-to-discover-why-mariadb-crashes)
	* [Discord](https://discord.com/channels/638610460567928832/638610461109256194/825049573520965703)

	Note:

	* I have been running these patches for three months and they definitely improve stability (zero crashes in nextcloud_db). The Discord link above contains a similar stability report for MariaDB.

2. Alters service definitions for both MariaDB and Nextcloud to:

	* build using the Dockerfile
	* add a volume mapping to support backup/restore of MariaDB database.

		Note:

		* it was a conscious decision to place the db_backup folder in `./volumes/CONTAINER` rather than mimic the arrangement for influxdb. It simplifies the backup/restore design.

3. Adds port mapping 9322:3306 to nextcloud_db service definition. This is needed so "restore" routines can tell when the MariaDB service is open for business.

	Note:

	* MariaDB already exposes 3306:3306.

4. Adds explanation to Nextcloud documentation on how to update the containers.

5. Some enhancements to MariaDB documentation:

	* replaces discussion of environment file with variables.
	* explains how to reset the persistent storage area.
	* deprecates `terminal.sh` script in favour of just showing how to do it (and get out again).
	* adds explanation on how to update the container.