### PR TITLE
20210809 MariaDB + Nextcloud - old-menu branch - PR 2 of 3

### DIFF
--- a/.templates/mariadb/Dockerfile
+++ b/.templates/mariadb/Dockerfile
@@ -1,0 +1,13 @@
+# Download base image
+FROM ghcr.io/linuxserver/mariadb
+
+# apply stability patches recommended in
+#   
+#   https://discord.com/channels/638610460567928832/638610461109256194/825049573520965703
+#   https://stackoverflow.com/questions/61809270/how-to-discover-why-mariadb-crashes
+RUN sed -i.bak \
+  -e "s/^thread_cache_size/# thread_cache_size/" \
+  -e "s/^read_buffer_size/# read_buffer_size/" \
+  /defaults/my.cnf
+
+# EOF

--- a/.templates/mariadb/service.yml
+++ b/.templates/mariadb/service.yml
@@ -1,10 +1,11 @@
   mariadb:
-    image: linuxserver/mariadb
+    build: ./.templates/mariadb/.
     container_name: mariadb
     env_file:
       - ./services/mariadb/mariadb.env
     volumes:
       - ./volumes/mariadb/config:/config
+      - ./volumes/mariadb/db_backup:/backup
     ports:
       - "3306:3306"
     restart: unless-stopped

--- a/.templates/nextcloud/service.yml
+++ b/.templates/nextcloud/service.yml
@@ -16,7 +16,7 @@
 
   nextcloud_db:
     container_name: nextcloud_db
-    image: ghcr.io/linuxserver/mariadb
+    build: ./.templates/mariadb/.
     restart: unless-stopped
     environment:
       - TZ=Etc/UTC
@@ -26,5 +26,8 @@
       - MYSQL_PASSWORD=user_password
       - MYSQL_DATABASE=nextcloud
       - MYSQL_USER=nextcloud
+    ports:
+      - "9322:3306"
     volumes:
       - ./volumes/nextcloud/db:/config
+      - ./volumes/nextcloud/db_backup:/backup


### PR DESCRIPTION
1. Adds Dockerfile to MariaDB template to add stability patches recommended in:

	* [StackOverflow](https://stackoverflow.com/questions/61809270/how-to-discover-why-mariadb-crashes)
	* [Discord](https://discord.com/channels/638610460567928832/638610461109256194/825049573520965703)

	Note:

	* I have been running these patches for three months and they definitely improve stability (zero crashes in nextcloud_db). The Discord link above contains a similar stability report for MariaDB.

2. Alters service definitions for both MariaDB and Nextcloud to:

	* build using the Dockerfile
	* add a volume mapping to support backup/restore of MariaDB database.

		Note:

		* it was a conscious decision to place the db_backup folder in `./volumes/CONTAINER` rather than mimic the arrangement for influxdb. It simplifies the backup/restore design.

3. Adds port mapping 9322:3306 to nextcloud_db service definition. This is needed so "restore" routines can tell when the MariaDB service is open for business.

	Note:

	* MariaDB already exposes 3306:3306.