### PR TITLE
20210826 TICK - master branch - PR 1 of 3

### DIFF
--- a/.templates/chronograf/service.yml
+++ b/.templates/chronograf/service.yml
@@ -1,0 +1,21 @@
+chronograf:
+  container_name: chronograf
+  image: chronograf:latest
+  restart: unless-stopped
+  environment:
+    - TZ=Etc/UTC
+  # see https://docs.influxdata.com/chronograf/v1.9/administration/config-options/
+    - INFLUXDB_URL=http://influxdb:8086
+  # - INFLUXDB_USERNAME=
+  # - INFLUXDB_PASSWORD=
+  # - INFLUXDB_ORG=
+  # - KAPACITOR_URL=http://kapacitor:9092
+  ports:
+    - "8888:8888"
+  volumes:
+    - ./volumes/chronograf:/var/lib/chronograf
+  depends_on:
+    - influxdb
+  # - kapacitor
+  networks:
+    - iotstack_nw

--- a/.templates/kapacitor/service.yml
+++ b/.templates/kapacitor/service.yml
@@ -1,0 +1,21 @@
+kapacitor:
+  container_name: kapacitor
+  image: kapacitor:1.5
+  restart: unless-stopped
+  environment:
+    - TZ=Etc/UTC
+  # see https://docs.influxdata.com/kapacitor/v1.6/administration/configuration/#kapacitor-environment-variables
+    - KAPACITOR_INFLUXDB_0_URLS_0=http://influxdb:8086
+  # - KAPACITOR_INFLUXDB_USERNAME=
+  # - KAPACITOR_INFLUXDB_PASSWORD=
+  # - KAPACITOR_HOSTNAME=kapacitor
+  # - KAPACITOR_LOGGING_LEVEL=INFO
+  # - KAPACITOR_REPORTING_ENABLED=false
+  ports:
+    - "9092:9092"
+  volumes:
+    - ./volumes/kapacitor:/var/lib/kapacitor
+  depends_on:
+    - influxdb
+  networks:
+    - iotstack_nw

--- a/docs/Containers/Chronograf.md
+++ b/docs/Containers/Chronograf.md
@@ -1,0 +1,71 @@
+# Chronograf
+ 
+## <a name="references"> References </a>
+
+- [*influxdata Chronograf* documentation](https://docs.influxdata.com/chronograf/)
+- [*GitHub*: influxdata/influxdata-docker/chronograf](https://github.com/influxdata/influxdata-docker/tree/master/chronograf)
+- [*DockerHub*: influxdata Chronograf](https://hub.docker.com/_/chronograf)
+
+## <a name="kapacitorIntegration"> Kapacitor integration </a>
+
+If you selected Kapacitor in the menu and want Chronograf to be able to interact with it, you need to edit `docker-compose.yml` to un-comment the lines which are commented-out in the following:
+
+```yaml
+chronograf:
+  …
+  environment:
+  …
+  # - KAPACITOR_URL=http://kapacitor:9092
+  depends_on:
+  …
+  # - kapacitor
+```
+
+If the Chronograf container is already running when you make this change, run:
+
+```bash
+$ cd ~IOTstack
+$ docker-compose up -d chronograf
+```
+
+## <a name="upgradingChronograf"> Upgrading Chronograf </a>
+
+You can update the container via:
+
+```bash
+$ cd ~/IOTstack
+$ docker-compose pull
+$ docker-compose up -d
+$ docker system prune
+```
+
+In words:
+
+* `docker-compose pull` downloads any newer images;
+* `docker-compose up -d` causes any newly-downloaded images to be instantiated as containers (replacing the old containers); and
+* the `prune` gets rid of the outdated images.
+
+### <a name="versionPinning"> Chronograf version pinning </a>
+
+If you need to pin to a particular version:
+
+1. Use your favourite text editor to open `docker-compose.yml`.
+2. Find the line:
+
+	```
+	image: chronograf:latest
+	```
+
+3. Replace `latest` with the version you wish to pin to. For example, to pin to version 1.9.0:
+
+	```
+	image: chronograf:1.9.0
+	```
+
+4. Save the file and tell `docker-compose` to bring up the container:
+
+	```bash
+	$ cd ~/IOTstack
+	$ docker-compose up -d chronograf
+	$ docker system prune
+	```

--- a/docs/Containers/Kapacitor.md
+++ b/docs/Containers/Kapacitor.md
@@ -1,0 +1,53 @@
+# Kapacitor
+ 
+## <a name="references"> References </a>
+
+- [*influxdata Kapacitor* documentation](https://docs.influxdata.com/kapacitor/)
+- [*GitHub*: influxdata/influxdata-docker/kapacitor](https://github.com/influxdata/influxdata-docker/tree/master/kapacitor)
+- [*DockerHub*: influxdata Kapacitor](https://hub.docker.com/_/kapacitor)
+
+## <a name="upgradingKapacitor"> Upgrading Kapacitor </a>
+
+You can update the container via:
+
+```bash
+$ cd ~/IOTstack
+$ docker-compose pull
+$ docker-compose up -d
+$ docker system prune
+```
+
+In words:
+
+* `docker-compose pull` downloads any newer images;
+* `docker-compose up -d` causes any newly-downloaded images to be instantiated as containers (replacing the old containers); and
+* the `prune` gets rid of the outdated images.
+
+### <a name="versionPinning"> Kapacitor version pinning </a>
+
+If you need to pin to a particular version:
+
+1. Use your favourite text editor to open `docker-compose.yml`.
+2. Find the line:
+
+	```
+   image: kapacitor:1.5
+	```
+
+3. Replace `1.5` with the version you wish to pin to. For example, to pin to version 1.5.9:
+
+	```
+   image: kapacitor:1.5.9
+	```
+	
+	Note:
+	
+	* Be cautious about using the `latest` tag. At the time of writing, there was no `linux/arm/v7` architecture support. 
+
+4. Save the file and tell `docker-compose` to bring up the container:
+
+	```bash
+	$ cd ~/IOTstack
+	$ docker-compose up -d kapacitor
+	$ docker system prune
+	```


### PR DESCRIPTION
1. Adds Chronograf and Kapacitor service definitions to complement Telegraf and InfluxDB, and complete the TICK stack. Assumes Chronograf may be added without Kapacitor (uncommenting relevant lines in Chronograf service definition is required to enable full integration).
2. Adds minimal documentation for both containers.