### PR TITLE
20210826 TICK - experimental branch - PR 3 of 3

### DIFF
--- a/.internal/templates/services/chronograf/template.yml
+++ b/.internal/templates/services/chronograf/template.yml
@@ -1,0 +1,21 @@
+chronograf:
+  container_name: chronograf
+  image: chronograf:latest
+  restart: unless-stopped
+  environment:
+    - TZ=Etc/UTC
+  # see https://docs.influxdata.com/chronograf/v1.9/administration/config-options/
+    - INFLUXDB_URL=http://influxdb:8086
+  # - INFLUXDB_USERNAME=
+  # - INFLUXDB_PASSWORD=
+  # - INFLUXDB_ORG=
+  # - KAPACITOR_URL=http://kapacitor:9092
+  ports:
+    - "8888:8888"
+  volumes:
+    - ./volumes/chronograf:/var/lib/chronograf
+  depends_on:
+    - influxdb
+  # - kapacitor
+  networks:
+    - iotstack_nw

--- a/.internal/templates/services/kapacitor/template.yml
+++ b/.internal/templates/services/kapacitor/template.yml
@@ -1,0 +1,21 @@
+kapacitor:
+  container_name: kapacitor
+  image: kapacitor:1.5
+  restart: unless-stopped
+  environment:
+    - TZ=Etc/UTC
+  # see https://docs.influxdata.com/kapacitor/v1.6/administration/configuration/#kapacitor-environment-variables
+    - KAPACITOR_INFLUXDB_0_URLS_0=http://influxdb:8086
+  # - KAPACITOR_INFLUXDB_USERNAME=
+  # - KAPACITOR_INFLUXDB_PASSWORD=
+  # - KAPACITOR_HOSTNAME=kapacitor
+  # - KAPACITOR_LOGGING_LEVEL=INFO
+  # - KAPACITOR_REPORTING_ENABLED=false
+  ports:
+    - "9092:9092"
+  volumes:
+    - ./volumes/kapacitor:/var/lib/kapacitor
+  depends_on:
+    - influxdb
+  networks:
+    - iotstack_nw


### PR DESCRIPTION
Adds Chronograf and Kapacitor service definitions to complement Telegraf and InfluxDB, and complete the TICK stack. Assumes Chronograf may be added without Kapacitor (uncommenting relevant lines in Chronograf service definition is required to enable full integration).

I made no attempt to create matching `build.js` and/or `config.js` scripts.