### PR TITLE
20210908 Python - master branch - PR 1 of 2

### DIFF
--- a/.templates/python/Dockerfile
+++ b/.templates/python/Dockerfile
@@ -1,9 +1,48 @@
 FROM python:3
 
-WORKDIR /usr/src/app
+# user+group ID defaults for IOTstack
+ENV IOTSTACK_UID=1000
+ENV IOTSTACK_GID=1000
 
-COPY requirements.txt ./
+# the template folder is named
+ENV TEMPLATE="app"
 
-RUN pip install --no-cache-dir -r requirements.txt
+# where IOTstack template files are stored
+ENV PYTHON_DEFAULTS="/iotstack_defaults/${TEMPLATE}"
 
-CMD [ "python", "./app.py" ]
+# ensure the defaults directory exists
+RUN mkdir -p ${PYTHON_DEFAULTS}
+
+# copy template files to defaults directory in image
+COPY ${TEMPLATE} ${PYTHON_DEFAULTS}
+
+# the requirements file (if it exists) is
+ENV REQUIREMENTS="${PYTHON_DEFAULTS}/requirements.txt"
+
+# set up requirements (if the file exists)
+RUN if [ -e ${REQUIREMENTS} ] ; then pip3 install --no-cache-dir -r ${REQUIREMENTS} ; fi
+
+# the python working directory is 
+ENV PYTHON_WORKDIR="/usr/src/${TEMPLATE}"
+
+# ensure the working directory exists
+RUN mkdir -p ${PYTHON_WORKDIR}
+
+# add an entry-point script
+ENV ENTRY_POINT="docker-entrypoint.sh"
+COPY ${ENTRY_POINT} /${ENTRY_POINT}
+RUN chmod 755 /${ENTRY_POINT}
+
+# unset variables that are not needed
+ENV TEMPLATE=
+ENV REQUIREMENTS=
+ENV ENTRY_POINT=
+
+# set the working directory
+WORKDIR ${PYTHON_WORKDIR}
+
+# away we go
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/usr/local/bin/python", "./app.py"]
+
+# EOF

--- a/.templates/python/app/app.py
+++ b/.templates/python/app/app.py
@@ -1,1 +1,8 @@
-print("hello world")
+import time
+
+print("The world is born. Hello World.", flush=True)
+
+while True:
+
+   time.sleep(10)
+   print("The world is re-born. Hello World.", flush=True)

--- a/.templates/python/build.py
+++ b/.templates/python/build.py
@@ -89,14 +89,11 @@ def main():
     if not os.path.exists(serviceService):
       os.makedirs(serviceService, exist_ok=True)
 
-    # Files copy
+    # copy supporting files
     shutil.copy(r'%s/Dockerfile' % serviceTemplate, r'%s/Dockerfile' % serviceService)
+    shutil.copy(r'%s/docker-entrypoint.sh' % serviceTemplate, r'%s/docker-entrypoint.sh' % serviceService)
+    shutil.copytree(r'%s/app' % serviceTemplate, r'%s/app' % serviceService)
 
-    print("sudo mkdir -p " + serviceVolume + "/app ")
-    subprocess.call("user=$(whoami) && sudo mkdir -p " + serviceVolume + "/app && sudo chown -R $user:$user " + serviceVolume, shell=True)
-    print("sudo chown -R $user:$user ./volumes/python")
-    shutil.copy(r'%s/app/requirements.txt' % serviceTemplate, r'%s/app/requirements.txt' % serviceVolume)
-    shutil.copy(r'%s/app/app.py' % serviceTemplate, r'%s/app/app.py' % serviceVolume)
     return True
 
   # #####################################

--- a/.templates/python/docker-entrypoint.sh
+++ b/.templates/python/docker-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+# does the working directory exist (something is badly wrong if it does not)
+if [ -d "$PYTHON_WORKDIR" ] ; then
+
+   # are self-healing defaults available?
+   if [ -d "$PYTHON_DEFAULTS" ] ; then
+
+      # yes! replace anything that has gone missing
+      cp -an "$PYTHON_DEFAULTS"/* "$PYTHON_WORKDIR"
+
+   fi
+
+   # set appropriate ownership throughout
+   chown -R "$IOTSTACK_UID:$IOTSTACK_GID" "$PYTHON_WORKDIR"
+
+fi
+
+# start python
+exec "$@"

--- a/.templates/python/service.yml
+++ b/.templates/python/service.yml
@@ -2,6 +2,13 @@ python:
   container_name: python
   build: ./services/python/.
   restart: unless-stopped
-  network_mode: host
+  environment:
+    - TZ=Etc/UTC
+    - IOTSTACK_UID=1000
+    - IOTSTACK_GID=1000
+  # ports:
+  #   - "external:internal"
   volumes:
     - ./volumes/python/app:/usr/src/app
+  networks:
+    - iotstack_nw

--- a/docs/Containers/Python.md
+++ b/docs/Containers/Python.md
@@ -1,51 +1,323 @@
 # Python
-* [Docker hub](https://hub.docker.com/_/python)
 
-## Running python code in docker
+## <a name="references"> references </a>
 
-In order to run code in docker the container needs to be build from a Dockerfile. There are 2 key files in the service directory
+* [Python.org](https://www.python.org)
+* [Dockerhub image library](https://hub.docker.com/_/python)
+* [GitHub docker-library/python](https://github.com/docker-library/python)
 
-### services/python/requirements.txt
+## <a name="menuPython"> selecting Python in the IOTstack menu </a>
 
-Normally on your system you would install modules with pip and they would be available system wide. The container that comes off Docker hub is blank and we will have to install them and bake them into the container. Before your first run add the modules that you require to the requirements.txt, each on a new line
+When you select Python in the menu:
+
+1. The following folder and file structure is created:
+
+	```
+	$ tree ~/IOTstack/services/python
+	/home/pi/IOTstack/services/python
+	├── app
+	│   └── app.py
+	├── docker-entrypoint.sh
+	└── Dockerfile
+	```
+	
+	Note:
+	
+	* Under "old menu" (old-menu branch), the `service.yml` is also copied into the `python` directory but is then not used.
+
+2. This service definition is added to your `docker-compose.yml`:
+
+	```yaml
+	python:
+	  container_name: python
+	  build: ./services/python/.
+	  restart: unless-stopped
+	  environment:
+	  - TZ=Etc/UTC
+	  - IOTSTACK_UID=1000
+	  - IOTSTACK_GID=1000
+	# ports:
+	#   - "external:internal"
+	  volumes:
+	  - ./volumes/python/app:/usr/src/app
+	  networks:
+	  - iotstack_nw
+	```
+	
+	Notes:
+	
+	* This service definition is for "new menu" (master branch). The only difference with "old menu" (old-menu branch) is the omission of the last two lines.
+	* See also [customising your Python service definition](#customisingPython).
+
+
+## <a name="firstLaunchPython"> Python - first launch </a>
+
+After running the menu, you are told to run the commands:
 
 ```
-flask
-bs4
-```
-**IMPORTANT**: Every time you alter the requirements file you will need to rebuild the container and bake in the new modules
-
-To build the container run `docker-compose build python`. 
-
-### services/python/service.yml
-
-This is the template that gets concatenated into docker-compose.yml and there are a few things to note here
-
-```yml
-  python:
-    container_name: python
-    build: ./services/python/.
-    restart: unless-stopped
-    network_mode: host
-    volumes:
-      - ./volumes/python/app:/usr/src/app
+$ cd ~/IOTstack
+$ docker-compose up -d
 ```
 
-The container runs in host network mode. This is because i have no idea which ports you want to use. The implication of this is you will not be able to connect by name to the other container and therefore if you want to connect to the mqtt service or influx you will need to use `localhost` or `127.0.0.1` because the python container "thinks" from network perspective that it is the Pi
+This is what happens:
 
-The container is set to restart unless stopped. Therefore if you write an application it will effectively execute in an endless loop. If you only want a run once method then you will need to comment out the "restart" section in the docker-compose.yml file and the service.yml
+1. *docker-compose* reads your `docker-compose.yml`.
+2. When it finds the service definition for Python, it encounters:
 
-## Where to put your code
+	```
+	build: ./services/python/.
+	```
 
-You will need to copy your code to `IOTstack/volumes/python/app`. The container is set to execute `app.py` as the main file.
+	The leading period means "the directory containing `docker-compose.yml` while the trailing period means "Dockerfile", so the path expands to:
 
-### writing to the console
+	```
+	~/IOTstack/services/python/Dockerfile
+	```
 
-If you execute a print statement the text will appear in the console of the container. The output can be accessed by running `docker logs python`
+3. The `Dockerfile` is processed. It downloads the **base** image for Python from Dockerhub and then makes changes including:
 
-### writing to disk
-Inside the container the working directory is `/usr/src/app` as mapped in the volume command. It would be advised to read or write any data from this directory.
+	* copying the contents of the following directory into the image as a set of defaults:
 
-## Image clutter
+		```
+		/home/pi/IOTstack/services/python/app
+		```
 
-Doing multiple builds of the python image will create many unused images. These can be cleaned up inside portainer or by running `./scripts/prune-images.sh`
+	* copying the following file into the image:
+
+		```
+		/home/pi/IOTstack/services/python/docker-entrypoint.sh
+		```
+
+		The `docker-entrypoint.sh` script runs each time the container launches and performs initialisation and "self repair" functions.
+	
+	The output of the Dockerfile run is a new **local** image tagged with the name `iotstack_python`.
+	
+4. The `iotstack_python` image is instantiated to become the running container.
+5. When the container starts, the `docker-entrypoint.sh` script runs and initialises the container's persistent storage area:
+
+	```bash
+	$ tree -pu ~/IOTstack/volumes
+	/home/pi/IOTstack/volumes
+	└── [drwxr-xr-x root    ]  python
+	    └── [drwxr-xr-x pi      ]  app
+	        └── [-rwxr-xr-x pi      ]  app.py
+	```
+	
+	Note:
+	
+	* the top-level `python` folder is owned by "root" but the `app` directory and its contents are owned by "pi".
+	
+5. The initial `app.py` Python script is a "hello world" placeholder. It runs as an infinite loop emitting messages every 10 seconds until terminated. You can see what it is doing by running:
+
+	```bash
+	$ docker logs -f python
+	The world is born. Hello World.
+	The world is re-born. Hello World.
+	The world is re-born. Hello World.
+	…
+	```
+	
+	Pressing <kbd>control</kbd>+<kbd>c</kbd> terminates the log display but does not terminate the running container.
+	
+## <a name="stopPython"> stopping the Python service </a>
+
+To stop the container from running, either:
+
+* take down your whole stack:
+
+	```bash
+	$ cd ~/IOTstack
+	$ docker-compose down
+	```
+	
+* terminate the python container
+
+	```bash
+	$ cd ~/IOTstack
+	$ docker-compose rm --force --stop -v python
+	```
+		
+## <a name="startPython"> starting the Python service </a>
+
+To bring up the container again after you have stopped it, either:
+
+* bring up your whole stack:
+
+	```bash
+	$ cd ~/IOTstack
+	$ docker-compose up -d
+	```
+	
+* bring up the python container
+
+	```bash
+	$ cd ~/IOTstack
+	$ docker-compose up -d python
+	```
+
+## <a name="reLaunchPython"> Python - second-and-subsequent launch </a>
+
+Each time you launch the Python container *after* the first launch:
+
+1. The existing local image (`iotstack_python`) is instantiated to become the running container.
+2. The `docker-entrypoint.sh` script runs and performs "self-repair" by replacing any files that have gone missing from the persistent storage area. Self-repair does **not** overwrite existing files! 
+3. The `app.py` Python script is run.
+
+## <a name="yourPythonScript"> developing your own Python script </a>
+
+1. Edit (or replace) the file:
+
+	```
+	~/IOTstack/volumes/python/app/app.py
+	```
+	
+2. Tell the python container to notice the change by:
+
+	```bash
+	$ cd ~/IOTstack
+	$ docker-compose restart python
+	```
+	
+## <a name="debugging"> when things go wrong - check the log </a>
+
+If the container misbehaves, the log is your friend:
+
+```
+$ docker logs python
+```
+
+## <a name="cleanSlate"> getting a clean slate </a>
+
+If you make a mess of things and need to start from a clean slate:
+
+```bash
+$ cd ~/IOTstack
+$ docker-compose rm --force --stop -v python
+$ sudo rm -rf ./volumes/python
+$ docker-compose up -d python
+```
+
+The container will re-initialise the persistent storage area from its defaults.
+
+## <a name="bakingPython"> making your own Python script the default </a>
+
+Suppose you have been developing a Python script and you want to "freeze dry" everything into an image so that it becomes the default when you ask for a clean slate.
+
+1. If you have identified a need for a `requirements.txt`, create that by running the following command:
+
+	```bash
+	$ docker exec python bash -c 'pip3 freeze >requirements.txt'
+	```
+	
+	That creates a file at the following path (it will be owned by root):
+	
+	```
+	~/IOTstack/volumes/python/app/requirements.txt
+	```
+
+2. Run the following commands:
+
+	```bash
+	$ cd ~/IOTstack
+	$ cp -r ./volumes/python/app/* ./services/python/app
+	```
+
+	The `cp` command copies:
+	
+	* your Python script;
+	* the optional `requirements.txt`; and
+	* any other files you may have put into the Python working directory.
+
+	Key point:
+	
+	* **everything** copied into the `./services/python/app` directory will become part of the new image.
+
+3. Terminate the Python container and erase its persistent storage area:
+
+	```bash
+	$ cd ~/IOTstack
+	$ docker-compose rm --force --stop -v python
+	$ sudo rm -rf ./volumes/python
+	```
+	
+	Note:
+	
+	* If erasing the persistent storage area feels too risky, just move it out of the way:
+
+		```
+		$ cd ~/IOTstack/volumes
+		$ sudo mv python python.off
+		```
+	
+4. Rebuild the local image:
+
+	```bash
+	$ cd ~IOTstack
+	$ docker-compose up --build -d python
+	```
+	
+	The `--build` directive will trigger a new Dockerfile run which, in turn, will process the (optional) `requirements.txt` and then bundle your Python application and any other supporting folders and files into a new local image, and then instantiate that to be the new running container.
+	
+	On its first launch, the new container will re-populate the persistent storage area but, this time it will be your Python script and any other supporting files, rather than the original "hello world" script.
+	
+5. Clean up by removing the old local image:
+
+	```bash
+	$ docker system prune -f
+	```
+
+## <a name="customisingPython"> customising your Python service definition </a>
+
+The service definition shown in [selecting Python in the menu](#menuPython) contains a number of customisation points:
+
+1. `restart: unless-stopped` assumes your Python script will run in an infinite loop. If your script is intended to run once and terminate, you should remove this directive.
+2. `TZ=Etc/UTC` should be set to your local time-zone. Never use quote marks on the right hand side of a `TZ=` variable.
+3. If you are running as a different user ID, you may want to change both `IOTSTACK_UID` and `IOTSTACK_GID` to appropriate values.
+
+	Notes:
+
+	* Don't use user and group *names* because these variables are applied *inside* the container where those names are (probably) undefined.
+	* The only thing these variables affect is the ownership of:
+
+		```
+		~/IOTstack/volumes/python/app
+		```
+
+		and its contents. If you want everything to be owned by root, set both of these variables to zero (eg `IOTSTACK_UID=0`).
+
+4. If your Python script listens to data-communications traffic, you can set up the port mappings by uncommenting the `ports:` directive.
+
+After making a change to the service definition, you can apply it via:
+
+```bash
+$ cd ~/IOTstack
+$ docker-compose up -d python
+```
+
+## <a name="persistentStorage"> writing to disk </a>
+
+Inside the container the working directory is `/usr/src/app` (ie as mapped in the `volumes:` directive of the service definition). Any data your Python script writes into this directory (or a sub-directory) will persist across container launches.
+
+If your script writes into any other directory inside the container, the data will be lost when the container re-launches.
+
+## <a name="routineMaintenance"> routine maintenance </a>
+
+To make sure you are running from the most-recent **base** image of Python from Dockerhub:
+
+```
+$ cd ~/IOTstack
+$ docker-compose build --no-cache --pull python
+$ docker-compose up -d python
+$ docker system prune -f
+$ docker system prune -f
+```
+
+In words:
+
+1. Be in the right directory.
+2. Force docker-compose to download the most-recent version of the Python **base** image from Dockerhub, and then run the Dockerfile to build a new **local** image.
+3. Instantiate the newly-built **local** image.
+4. Remove the old **local** image.
+5. Remove the old **base** image
+
+The old base image can't be removed until the old local image has been removed, which is why the `prune` command needs to be run twice. 

--- a/docs/Containers/Python.md
+++ b/docs/Containers/Python.md
@@ -20,9 +20,9 @@ When you select Python in the menu:
 	├── docker-entrypoint.sh
 	└── Dockerfile
 	```
-	
+
 	Note:
-	
+
 	* Under "old menu" (old-menu branch), the `service.yml` is also copied into the `python` directory but is then not used.
 
 2. This service definition is added to your `docker-compose.yml`:
@@ -43,9 +43,9 @@ When you select Python in the menu:
 	  networks:
 	  - iotstack_nw
 	```
-	
+
 	Note:
-	
+
 	* This service definition is for "new menu" (master branch). The only difference with "old menu" (old-menu branch) is the omission of the last two lines.
 
 ### <a name="customisingPython"> customising your Python service definition </a>
@@ -115,9 +115,9 @@ This is what happens:
 		```
 
 		The `docker-entrypoint.sh` script runs each time the container launches and performs initialisation and "self repair" functions.
-	
+
 	The output of the Dockerfile run is a new **local** image tagged with the name `iotstack_python`.
-	
+
 4. The `iotstack_python` image is instantiated to become the running container.
 5. When the container starts, the `docker-entrypoint.sh` script runs and initialises the container's persistent storage area:
 
@@ -128,11 +128,11 @@ This is what happens:
 	    └── [drwxr-xr-x pi      ]  app
 	        └── [-rwxr-xr-x pi      ]  app.py
 	```
-	
+
 	Note:
-	
+
 	* the top-level `python` folder is owned by "root" but the `app` directory and its contents are owned by "pi".
-	
+
 5. The initial `app.py` Python script is a "hello world" placeholder. It runs as an infinite loop emitting messages every 10 seconds until terminated. You can see what it is doing by running:
 
 	```bash
@@ -142,9 +142,9 @@ This is what happens:
 	The world is re-born. Hello World.
 	…
 	```
-	
+
 	Pressing <kbd>control</kbd>+<kbd>c</kbd> terminates the log display but does not terminate the running container.
-	
+
 ## <a name="stopPython"> stopping the Python service </a>
 
 To stop the container from running, either:
@@ -155,14 +155,14 @@ To stop the container from running, either:
 	$ cd ~/IOTstack
 	$ docker-compose down
 	```
-	
+
 * terminate the python container
 
 	```bash
 	$ cd ~/IOTstack
 	$ docker-compose rm --force --stop -v python
 	```
-		
+
 ## <a name="startPython"> starting the Python service </a>
 
 To bring up the container again after you have stopped it, either:
@@ -173,7 +173,7 @@ To bring up the container again after you have stopped it, either:
 	$ cd ~/IOTstack
 	$ docker-compose up -d
 	```
-	
+
 * bring up the python container
 
 	```bash
@@ -293,7 +293,7 @@ To make *Flask* and *beautifulsoup4* a permanent part of your container:
 	```
 	$ cd ~/IOTstack/services/python/app
 	```
-	
+
 2. Use your favourite text editor to create the file `requirements.txt` in that directory. Each package you want to add should be on a line by itself:
 
 	```
@@ -311,7 +311,7 @@ To make *Flask* and *beautifulsoup4* a permanent part of your container:
 	```
 
 	Note:
-	
+
 	* You will see a warning about running pip as root - ignore it.
 
 4. Confirm that the packages have been added:
@@ -331,19 +331,19 @@ Note:
 	```
 	~/IOTstack/volumes/python/app/requirements.txt
 	```
-	
+
 	This copy is the result of the "self-repair" code that runs each time the container starts noticing that `requirements.txt` is missing and making a copy from the defaults stored inside the image.
-	
+
 	If you make more changes to the master version of `requirements.txt` in the *services* directory and rebuild the local image, the copy in the *volumes* directory will **not** be kept in-sync. That's because the "self-repair" code **never** overwrites existing files.
-	
+
 	If you want to bring the copy of `requirements.txt` in the *volumes* directory up-to-date:
-	
+
 	```
 	$ cd ~/IOTstack
 	$ rm ./volumes/python/app/requirements.txt
 	$ docker-compose restart python
 	```
-	
+
 	The `requirements.txt` file will be recreated and it will be a copy of the version in the *services* directory as of the last image rebuild.
 
 ### <a name="scriptBaking"> making your own Python script the default </a>
@@ -355,13 +355,13 @@ Suppose the Python script you have been developing reaches a major milestone and
 	```bash
 	$ docker exec python bash -c 'pip3 freeze >requirements.txt'
 	```
-	
+
 	That generates a `requirements.txt` representing the state of play inside the running container. Because it is running *inside* the container, the `requirements.txt` created by that command appears *outside* the container at:
-	
+
 	```
 	~/IOTstack/volumes/python/app/requirements.txt
 	```
-	
+
 2. Make your work the default:
 
 	```bash
@@ -370,13 +370,13 @@ Suppose the Python script you have been developing reaches a major milestone and
 	```
 
 	The `cp` command copies:
-	
+
 	* your Python script;
 	* the optional `requirements.txt` (from step 1); and
 	* any other files you may have put into the Python working directory.
 
 	Key point:
-	
+
 	* **everything** copied into `./services/python/app` will become part of the new local image.
 
 3. Terminate the Python container and erase its persistent storage area:
@@ -386,16 +386,16 @@ Suppose the Python script you have been developing reaches a major milestone and
 	$ docker-compose rm --force --stop -v python
 	$ sudo rm -rf ./volumes/python
 	```
-	
+
 	Note:
-	
+
 	* If erasing the persistent storage area feels too risky, just move it out of the way:
 
 		```
 		$ cd ~/IOTstack/volumes
 		$ sudo mv python python.off
 		```
-	
+
 4. Rebuild the local image:
 
 	```bash
@@ -403,9 +403,9 @@ Suppose the Python script you have been developing reaches a major milestone and
 	$ docker-compose build --force-rm python
 	$ docker-compose up -d --force-recreate python
 	```
-		
+
 	On its first launch, the new container will re-populate the persistent storage area but, this time, it will be your Python script and any other supporting files, rather than the original "hello world" script.
-	
+
 5. Clean up by removing the old local image:
 
 	```bash
@@ -433,7 +433,7 @@ Proceed like this:
 	```
 	$ docker rmi iotstack_python
 	```
-	
+
 3. Rename the `python` services directory to the name of your project:
 
 	```
@@ -459,11 +459,11 @@ Proceed like this:
 	  networks:                                   networks:
 	    - iotstack_nw                               - iotstack_nw
 	```
-	
+
 	Note:
-	
+
 	* if you make a copy of the `python` service definition and then perform the required "wishbone" edits on the copy, the `python` definition will still be active so `docker-compose` may try to bring up both services. You will eliminate the risk of confusing yourself if you follow these instructions "as written" by **not** leaving the `python` service definition in place.
-		
+
 5. Start the renamed service:
 
 	```


### PR DESCRIPTION
Revamps Python structure:

* Dockerfile:

	- handles arbitrarily-complex template which defaults to a "hello
world" script and no requirements.txt. The user can later add their own
script, supporting files and requirements.txt as the need arises.
	- Only processes requirements.txt if it is present in the template.
	- adds docker-entrypoint.sh with self-repair capabilities.
	- launches Python script via docker-entrypoint.sh.

* Removes all instances of requirements.txt (was always a null file but,
between old-menu and master branch, seemed to have cloned itself AND
not put one copy where it needed to be).
* Adjusts build.py to copy all template files to services directory.
* Adjusts service definition to:

	- take container out of host mode, in favour of providing
commented-out placeholders for potential port mappings. There is nothing
stopping the user from putting the container back into host mode but the
documented excuse of "no idea which ports a user script might expose" is
a recipe for colliding with the ports being used by other containers
	- add environment variables for timezone, plus UID/GID support for
self-repair code (defaults to UID=GID=1000)
	- add `iotstack_nw` definition for new menu

* Default "hello world" app now runs as an infinite loop (ie the typical
"service" pattern where `restart: unless-stopped` makes sense), rather
than as a one-shot where constant restarting by docker is not really
what you want.

Documentation rewritten.