### PR TITLE
20210917 Mosquitto - master branch - PR 1 of 3

### DIFF
--- a/.templates/mosquitto/Dockerfile
+++ b/.templates/mosquitto/Dockerfile
@@ -1,6 +1,9 @@
 # Download base image
 FROM eclipse-mosquitto:latest
 
+# see https://github.com/alpinelinux/docker-alpine/issues/98
+RUN sed -i 's/https/http/' /etc/apk/repositories
+
 # Add support tools
 RUN apk update && apk add --no-cache rsync tzdata
 


### PR DESCRIPTION
A problem affecting the build of the Mosquitto container keeps showing
up in Discord questions. Examples:

* [2021-09-17](https://discord.com/channels/638610460567928832/638610461109256194/888096248761045022)
* [2021-09-09](https://discord.com/channels/638610460567928832/638610461109256194/885494986710335498)

The problem is discussed in [alpinelinux/docker-alpine issues/98](https://github.com/alpinelinux/docker-alpine/issues/98).

It is not clear whether:

1. The problem is transient (ie those reporting it are able to get past
the problem on a retry);
2. Only affects Mosquitto or potentially affects other Alpine-based
IOTstack containers using `apk` to add packages (eg Node-RED); or
3. Environmental (eg if there is a proxy system between the Raspberry Pi
and dl-cdn.alpinelinux.org).

This Pull Request is implementing the patch suggested by Issue 98 of
reverting `apk` requests to use HTTP.

Given the march towards HTTPS-everywhere, reverting to HTTP might seem
inadvisable but:

* Issue 98 was opened in July 2020.
* There seems to have been no significant progress towards its
resolution since January 2021.
* The Discord traffic suggests it is an ongoing and present issue for
IOTstack users.