### PR TITLE
20210917 Mosquitto - HTTP not HTTPS during build + health check - experimental branch - PR 3 of 3

### DIFF
--- a/.internal/templates/services/mosquitto/buildFiles/Dockerfile
+++ b/.internal/templates/services/mosquitto/buildFiles/Dockerfile
@@ -13,6 +13,18 @@ ENV IOTSTACK_DEFAULTS_DIR="iotstack_defaults"
 # copy template files to image
 COPY --chown=mosquitto:mosquitto ${IOTSTACK_DEFAULTS_DIR} /${IOTSTACK_DEFAULTS_DIR}
 
+# copy the health-check script into place
+ENV HEALTHCHECK_SCRIPT "iotstack_healthcheck.sh"
+COPY ${HEALTHCHECK_SCRIPT} /usr/local/bin/${HEALTHCHECK_SCRIPT}
+
+# define the health check
+HEALTHCHECK \
+   --start-period=30s \
+   --interval=30s \
+   --timeout=10s \
+   --retries=3 \
+   CMD ${HEALTHCHECK_SCRIPT} || exit 1
+
 # replace the docker entry-point script
 ENV IOTSTACK_ENTRY_POINT="docker-entrypoint.sh"
 COPY ${IOTSTACK_ENTRY_POINT} /${IOTSTACK_ENTRY_POINT}

--- a/.internal/templates/services/mosquitto/buildFiles/Dockerfile
+++ b/.internal/templates/services/mosquitto/buildFiles/Dockerfile
@@ -1,14 +1,17 @@
 # Download base image
 FROM eclipse-mosquitto:latest
 
+# see https://github.com/alpinelinux/docker-alpine/issues/98
+RUN sed -i 's/https/http/' /etc/apk/repositories
+
 # Add support tools
 RUN apk update && apk add --no-cache rsync tzdata
 
 # where IOTstack template files are stored
-ENV MOSQUITTO_IOTSTACK_DEFAULTS="/iotstack_defaults"
+ENV IOTSTACK_DEFAULTS_DIR="iotstack_defaults"
 
 # copy template files to image
-COPY --chown=mosquitto:mosquitto . /${MOSQUITTO_IOTSTACK_DEFAULTS}
+COPY --chown=mosquitto:mosquitto ${IOTSTACK_DEFAULTS_DIR} /${IOTSTACK_DEFAULTS_DIR}
 
 # replace the docker entry-point script
 ENV IOTSTACK_ENTRY_POINT="docker-entrypoint.sh"

--- a/.internal/templates/services/mosquitto/buildFiles/docker-entrypoint.sh
+++ b/.internal/templates/services/mosquitto/buildFiles/docker-entrypoint.sh
@@ -4,8 +4,11 @@ set -e
 # Set permissions
 user="$(id -u)"
 if [ "$user" = '0' -a -d "/mosquitto" ]; then
-  rsync -arp --ignore-existing /${MOSQUITTO_IOTSTACK_DEFAULTS}/ "/mosquitto"
-  chown -R mosquitto:mosquitto /mosquitto
+
+   rsync -arp --ignore-existing /${IOTSTACK_DEFAULTS_DIR}/ "/mosquitto"
+
+   chown -R mosquitto:mosquitto /mosquitto
+   
 fi
 
 exec "$@"

--- a/.internal/templates/services/mosquitto/buildFiles/iotstack_defaults/config/filter.acl
+++ b/.internal/templates/services/mosquitto/buildFiles/iotstack_defaults/config/filter.acl
@@ -1,0 +1,6 @@
+user admin
+topic read #
+topic write #
+
+pattern read #
+pattern write #

--- a/.internal/templates/services/mosquitto/buildFiles/iotstack_defaults/config/mosquitto.conf
+++ b/.internal/templates/services/mosquitto/buildFiles/iotstack_defaults/config/mosquitto.conf
@@ -1,0 +1,33 @@
+# required by https://mosquitto.org/documentation/migrating-to-2-0/
+#
+listener 1883
+
+# persistence enabled for remembering retain flag across restarts
+#
+persistence true
+persistence_location /mosquitto/data
+
+# logging options:
+#   enable one of the following (stdout = less wear on SD cards but
+#   logs do not persist across restarts)
+#log_dest file /mosquitto/log/mosquitto.log
+log_dest stdout
+log_timestamp_format %Y-%m-%dT%H:%M:%S
+
+# password handling:
+#   password_file commented-out allow_anonymous true =
+#     open access
+#   password_file commented-out allow_anonymous false =
+#     no access
+#   password_file activated     allow_anonymous true =
+#     passwords omitted is permitted but
+#     passwords provided must match pwfile
+#   password_file activated     allow_anonymous false =
+#     no access without passwords
+#     passwords provided must match pwfile
+#
+#password_file /mosquitto/pwfile/pwfile
+allow_anonymous true
+
+# Uncomment to enable filters
+#acl_file /mosquitto/config/filter.acl

--- a/.internal/templates/services/mosquitto/buildFiles/iotstack_healthcheck.sh
+++ b/.internal/templates/services/mosquitto/buildFiles/iotstack_healthcheck.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env sh
+
+# assume the following environment variables, all of which may be null
+#    HEALTHCHECK_PORT
+#    HEALTHCHECK_USER
+#    HEALTHCHECK_PASSWORD
+#    HEALTHCHECK_TOPIC
+
+# set a default for the port
+HEALTHCHECK_PORT="${HEALTHCHECK_PORT:-1883}"
+
+# strip any quotes from username and password
+HEALTHCHECK_USER="$(eval echo $HEALTHCHECK_USER)"
+HEALTHCHECK_PASSWORD="$(eval echo $HEALTHCHECK_PASSWORD)"
+
+# set a default for the topic
+HEALTHCHECK_TOPIC="${HEALTHCHECK_TOPIC:-iotstack/mosquitto/healthcheck}"
+HEALTHCHECK_TOPIC="$(eval echo $HEALTHCHECK_TOPIC)"
+
+# record the current date and time for the test payload
+PUBLISH=$(date)
+
+# publish a retained message containing the timestamp
+mosquitto_pub \
+   -h localhost \
+   -p "$HEALTHCHECK_PORT" \
+   -t "$HEALTHCHECK_TOPIC" \
+   -m "$PUBLISH" \
+   -u "$HEALTHCHECK_USER" \
+   -P "$HEALTHCHECK_PASSWORD" \
+   -r
+
+# did that succeed?
+if [ $? -eq 0 ] ; then
+
+   # yes! now, subscribe to that same topic with a 2-second timeout
+   # plus returning on the first message
+   SUBSCRIBE=$(mosquitto_sub \
+                -h localhost \
+                -p "$HEALTHCHECK_PORT" \
+                -t "$HEALTHCHECK_TOPIC" \
+                -u "$HEALTHCHECK_USER" \
+                -P "$HEALTHCHECK_PASSWORD" \
+                -W 2 \
+                -C 1 \
+              )
+
+   # did the subscribe succeed?
+   if [ $? -eq 0 ] ; then
+
+      # yes! do the publish and subscribe payloads compare equal?
+      if [ "$PUBLISH" = "$SUBSCRIBE" ] ; then
+
+         # yes! return success
+         exit 0
+
+      fi
+
+   fi
+   
+fi
+
+# otherwise, return failure
+exit 1


### PR DESCRIPTION
A problem affecting the build of the Mosquitto container keeps showing
up in Discord questions. Examples:

* [2021-09-17](https://discord.com/channels/638610460567928832/638610461109256194/888096248761045022)
* [2021-09-09](https://discord.com/channels/638610460567928832/638610461109256194/885494986710335498)

The problem is discussed in [alpinelinux/docker-alpine issues/98](https://github.com/alpinelinux/docker-alpine/issues/98).

It is not clear whether:

1. The problem is transient (ie those reporting it are able to get past
the problem on a retry);
2. Only affects Mosquitto or potentially affects other Alpine-based
IOTstack containers using `apk` to add packages (eg Node-RED); or
3. Environmental (eg if there is a proxy system between the Raspberry Pi
and dl-cdn.alpinelinux.org).

This Pull Request is implementing the patch suggested by Issue 98 of
reverting `apk` requests to use HTTP.

Given the march towards HTTPS-everywhere, reverting to HTTP might seem
inadvisable but:

* Issue 98 was opened in July 2020.
* There seems to have been no significant progress towards its
resolution since January 2021.
* The Discord traffic suggests it is an ongoing and present issue for
IOTstack users.

Also harmonises Mosquitto Dockerfile on experimental branch with the
common versions on master and old-menu branches.