### PR TITLE
20211002 MariaDB health check - master branch - PR 1 of 3

### DIFF
--- a/.templates/mariadb/Dockerfile
+++ b/.templates/mariadb/Dockerfile
@@ -10,4 +10,16 @@ RUN sed -i.bak \
   -e "s/^read_buffer_size/# read_buffer_size/" \
   /defaults/my.cnf
 
+# copy the health-check script into place
+ENV HEALTHCHECK_SCRIPT "iotstack_healthcheck.sh"
+COPY ${HEALTHCHECK_SCRIPT} /usr/local/bin/${HEALTHCHECK_SCRIPT}
+
+# define the health check
+HEALTHCHECK \
+   --start-period=30s \
+   --interval=30s \
+   --timeout=10s \
+   --retries=3 \
+   CMD ${HEALTHCHECK_SCRIPT} || exit 1
+
 # EOF

--- a/.templates/mariadb/iotstack_healthcheck.sh
+++ b/.templates/mariadb/iotstack_healthcheck.sh
@@ -8,7 +8,13 @@ HEALTHCHECK_PORT="${MYSQL_TCP_PORT:-3306}"
 EXPECTED="mysqld is alive"
 
 # run the check
-RESPONSE=$(mysqladmin -p${MYSQL_ROOT_PASSWORD} ping -h localhost)
+if [ -z "$MYSQL_ROOT_PASSWORD" ] ; then
+   RESPONSE=$(mysqladmin ping -h localhost)
+else
+   # note - there is NO space between "-p" and the password. This is
+   # intentional. It is part of the mysql and mysqladmin API.
+   RESPONSE=$(mysqladmin -p${MYSQL_ROOT_PASSWORD} ping -h localhost)
+fi
 
 # did the mysqladmin command succeed?
 if [ $? -eq 0 ] ; then

--- a/.templates/mariadb/iotstack_healthcheck.sh
+++ b/.templates/mariadb/iotstack_healthcheck.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+
+# set a default for the port
+# (refer https://mariadb.com/kb/en/mariadb-environment-variables/ )
+HEALTHCHECK_PORT="${MYSQL_TCP_PORT:-3306}"
+
+# the expected response is?
+EXPECTED="mysqld is alive"
+
+# run the check
+RESPONSE=$(mysqladmin -p${MYSQL_ROOT_PASSWORD} ping -h localhost)
+
+# did the mysqladmin command succeed?
+if [ $? -eq 0 ] ; then
+
+   # yes! is the response as expected?
+   if [ "$RESPONSE" = "$EXPECTED" ] ; then
+
+      # yes! this could still be a false positive so probe the port
+      if nc -w 1 localhost $HEALTHCHECK_PORT >/dev/null 2>&1; then
+
+         # port responding - that defines healthy
+         exit 0
+
+      fi
+
+   fi
+
+fi
+
+# otherwise the check fails
+exit 1

--- a/docs/Containers/MariaDB.md
+++ b/docs/Containers/MariaDB.md
@@ -1,4 +1,5 @@
 ## Source
+
 * [Docker hub](https://hub.docker.com/r/linuxserver/mariadb/)
 * [Webpage](https://mariadb.org/)
 
@@ -62,6 +63,103 @@ To close the terminal session, either:
 
 * type "exit" and press <kbd>return</kbd>; or
 * press <kbd>control</kbd>+<kbd>d</kbd>.
+
+## <a name="healthCheck"> Container health check </a>
+
+### <a name="healthCheckTheory"> theory of operation </a>
+
+A script , or "agent", to assess the health of the MariaDB container has been added to the *local image* via the *Dockerfile*. In other words, the script is specific to IOTstack.
+
+The agent is invoked 30 seconds after the container starts, and every 30 seconds thereafter. The agent:
+
+1. Runs the command:
+
+	```
+	mysqladmin ping -h localhost
+	```
+
+2. If that command succeeds, the agent compares the response returned by the command with the expected response:
+	
+	```
+	mysqld is alive
+	```
+	
+3. If the command returned the expected response, the agent tests the responsiveness of the TCP port the `mysqld` daemon should be listening on (see [customising health-check](#healthCheckCustom)).
+
+4. If all of those steps succeed, the agent concludes that MariaDB is functioning properly and returns "healthy".
+
+### <a name="healthCheckMonitor"> monitoring health-check </a>
+
+Portainer's *Containers* display contains a *Status* column which shows health-check results for all containers that support the feature.
+
+You can also use the `docker ps` command to monitor health-check results. The following command narrows the focus to mariadb:
+
+```bash
+$ docker ps --format "table {{.Names}}\t{{.Status}}"  --filter name=mariadb
+```
+
+Possible reply patterns are:
+
+1. The container is starting and has not yet run the health-check agent:
+
+	```
+	NAMES     STATUS
+	mariadb   Up 5 seconds (health: starting)
+	```
+
+2. The container has been running for at least 30 seconds and the health-check agent has returned a positive result within the last 30 seconds:
+
+	```
+	NAMES     STATUS
+	mariadb   Up 33 seconds (healthy)
+	```
+
+3. The container has been running for more than 90 seconds but has failed the last three successive health-check tests:
+
+	```
+	NAMES     STATUS
+	mariadb   Up About a minute (unhealthy)
+	```
+	
+### <a name="healthCheckCustom"> customising health-check </a>
+
+You can customise the operation of the health-check agent by editing the `mariadb` service definition in your *Compose* file:
+
+1. By default, the `mysqld` daemon listens to **internal** port 3306. If you need change that port, you also need to inform the health-check agent via an environment variable. For example, suppose you changed the **internal** port to 12345:
+
+	```yaml
+	    environment:
+	      - MYSQL_TCP_PORT=12345
+	```
+	
+	Notes:
+	
+	* The `MYSQL_TCP_PORT` variable is [defined by MariaDB](https://mariadb.com/kb/en/mariadb-environment-variables/), not IOTstack, so changing this variable affects more than just the health-check agent.
+	* If you are running "old menu", this change should be made in the file:
+
+		```
+		~/IOTstack/services/mariadb/mariadb.env
+		```
+	
+2. The `mysqladmin ping` command relies on the root password supplied via the `MYSQL_ROOT_PASSWORD` environment variable in the *Compose* file. The command will not succeed if the root password is not correct, and the agent will return "unhealthy". 
+
+3. If the health-check agent misbehaves in your environment, or if you simply don't want it to be active, you can disable all health-checking for the container by adding the following lines to its service definition:
+
+	```yaml
+	    healthcheck:
+	      disable: true
+	```
+
+	Note:
+	
+	* The mere presence of a `healthcheck:` clause in the `mariadb` service definition overrides the supplied agent. In other words, the following can't be used to re-enable the supplied agent:	
+
+		```yaml
+		    healthcheck:
+		      disable: false
+		```
+		
+		You must remove the entire `healthcheck:` clause.
 
 ## Keeping MariaDB up-to-date
 

--- a/docs/Containers/MariaDB.md
+++ b/docs/Containers/MariaDB.md
@@ -39,10 +39,10 @@ You only get the opportunity to change the `MQSL_` prefixed environment variable
 		$ docker-compose rm --force --stop -v mariadb
 		$ sudo rm -rf ./volumes/mariadb
 		```
-		
+
 	* Edit `docker-compose.yml` and change the variables.
 	* Bring up the container:
-	
+
 		```
 		$ docker-compose up -d mariadb 
 		```
@@ -79,11 +79,11 @@ The agent is invoked 30 seconds after the container starts, and every 30 seconds
 	```
 
 2. If that command succeeds, the agent compares the response returned by the command with the expected response:
-	
+
 	```
 	mysqld is alive
 	```
-	
+
 3. If the command returned the expected response, the agent tests the responsiveness of the TCP port the `mysqld` daemon should be listening on (see [customising health-check](#healthCheckCustom)).
 
 4. If all of those steps succeed, the agent concludes that MariaDB is functioning properly and returns "healthy".
@@ -120,7 +120,7 @@ Possible reply patterns are:
 	NAMES     STATUS
 	mariadb   Up About a minute (unhealthy)
 	```
-	
+
 ### <a name="healthCheckCustom"> customising health-check </a>
 
 You can customise the operation of the health-check agent by editing the `mariadb` service definition in your *Compose* file:
@@ -131,16 +131,16 @@ You can customise the operation of the health-check agent by editing the `mariad
 	    environment:
 	      - MYSQL_TCP_PORT=12345
 	```
-	
+
 	Notes:
-	
+
 	* The `MYSQL_TCP_PORT` variable is [defined by MariaDB](https://mariadb.com/kb/en/mariadb-environment-variables/), not IOTstack, so changing this variable affects more than just the health-check agent.
 	* If you are running "old menu", this change should be made in the file:
 
 		```
 		~/IOTstack/services/mariadb/mariadb.env
 		```
-	
+
 2. The `mysqladmin ping` command relies on the root password supplied via the `MYSQL_ROOT_PASSWORD` environment variable in the *Compose* file. The command will not succeed if the root password is not correct, and the agent will return "unhealthy". 
 
 3. If the health-check agent misbehaves in your environment, or if you simply don't want it to be active, you can disable all health-checking for the container by adding the following lines to its service definition:
@@ -151,14 +151,14 @@ You can customise the operation of the health-check agent by editing the `mariad
 	```
 
 	Note:
-	
-	* The mere presence of a `healthcheck:` clause in the `mariadb` service definition overrides the supplied agent. In other words, the following can't be used to re-enable the supplied agent:	
+
+	* The mere presence of a `healthcheck:` clause in the `mariadb` service definition overrides the supplied agent. In other words, the following can't be used to re-enable the supplied agent:
 
 		```yaml
 		    healthcheck:
 		      disable: false
 		```
-		
+
 		You must remove the entire `healthcheck:` clause.
 
 ## Keeping MariaDB up-to-date

--- a/docs/Containers/NextCloud.md
+++ b/docs/Containers/NextCloud.md
@@ -262,6 +262,12 @@ You can silence the warning by editing the Nextcloud service definition in `dock
 
 Nextcloud traffic is not encrypted. Do **not** expose it to the web by opening a port on your home router. Instead, use a VPN like Wireguard to provide secure access to your home network, and let your remote clients access Nextcloud over the VPN tunnel.
 
+## <a name="healthCheck"> Container health check </a>
+
+A script , or "agent", to assess the health of the MariaDB container has been added to the *local image* via the *Dockerfile*. In other words, the script is specific to IOTstack.
+
+Because it is an instance of MariaDB, Nextcloud_DB inherits the health-check agent. See the [IOTstack MariaDB](https://sensorsiot.github.io/IOTstack/Containers/MariaDB/) documentation for more information.
+
 ## <a name="updatingNextcloud"> Keeping Nextcloud up-to-date </a>
 
 To update the `nextcloud` container:


### PR DESCRIPTION
Follows on from suggestion in [Issue 415](https://github.com/SensorsIot/IOTstack/issues/415)
to add health-check to more containers. See also
[PR 406](https://github.com/SensorsIot/IOTstack/pull/406/commits/dbb6217ddb7b54e6d6a247a7c2b29ca364482ab5).

Changes:

* Adds `iotstack_healthcheck.sh` script to template.
* Adds commands to Dockerfile to copy that script into the local image
and activate health-checking on launch.
* Describes health-check functionality in the MariaDB documentation.
* References MariaDB health-check documentation in NextCloud
documentation.