### PR TITLE
20211002 MariaDB health check - old-menu branch - PR 2 of 3

### DIFF
--- a/.templates/mariadb/Dockerfile
+++ b/.templates/mariadb/Dockerfile
@@ -10,4 +10,16 @@ RUN sed -i.bak \
   -e "s/^read_buffer_size/# read_buffer_size/" \
   /defaults/my.cnf
 
+# copy the health-check script into place
+ENV HEALTHCHECK_SCRIPT "iotstack_healthcheck.sh"
+COPY ${HEALTHCHECK_SCRIPT} /usr/local/bin/${HEALTHCHECK_SCRIPT}
+
+# define the health check
+HEALTHCHECK \
+   --start-period=30s \
+   --interval=30s \
+   --timeout=10s \
+   --retries=3 \
+   CMD ${HEALTHCHECK_SCRIPT} || exit 1
+
 # EOF

--- a/.templates/mariadb/iotstack_healthcheck.sh
+++ b/.templates/mariadb/iotstack_healthcheck.sh
@@ -8,7 +8,13 @@ HEALTHCHECK_PORT="${MYSQL_TCP_PORT:-3306}"
 EXPECTED="mysqld is alive"
 
 # run the check
-RESPONSE=$(mysqladmin -p${MYSQL_ROOT_PASSWORD} ping -h localhost)
+if [ -z "$MYSQL_ROOT_PASSWORD" ] ; then
+   RESPONSE=$(mysqladmin ping -h localhost)
+else
+   # note - there is NO space between "-p" and the password. This is
+   # intentional. It is part of the mysql and mysqladmin API.
+   RESPONSE=$(mysqladmin -p${MYSQL_ROOT_PASSWORD} ping -h localhost)
+fi
 
 # did the mysqladmin command succeed?
 if [ $? -eq 0 ] ; then

--- a/.templates/mariadb/iotstack_healthcheck.sh
+++ b/.templates/mariadb/iotstack_healthcheck.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+
+# set a default for the port
+# (refer https://mariadb.com/kb/en/mariadb-environment-variables/ )
+HEALTHCHECK_PORT="${MYSQL_TCP_PORT:-3306}"
+
+# the expected response is?
+EXPECTED="mysqld is alive"
+
+# run the check
+RESPONSE=$(mysqladmin -p${MYSQL_ROOT_PASSWORD} ping -h localhost)
+
+# did the mysqladmin command succeed?
+if [ $? -eq 0 ] ; then
+
+   # yes! is the response as expected?
+   if [ "$RESPONSE" = "$EXPECTED" ] ; then
+
+      # yes! this could still be a false positive so probe the port
+      if nc -w 1 localhost $HEALTHCHECK_PORT >/dev/null 2>&1; then
+
+         # port responding - that defines healthy
+         exit 0
+
+      fi
+
+   fi
+
+fi
+
+# otherwise the check fails
+exit 1

--- a/docs/Containers/MariaDB.md
+++ b/docs/Containers/MariaDB.md
@@ -1,23 +1,3 @@
-## Source
-* [Docker hub](https://hub.docker.com/r/linuxserver/mariadb/)
-* [Webpage](https://mariadb.org/)
+# MariaDB
 
-## About
-
-MariaDB is a fork of MySQL. This is an unofficial image provided by linuxserver.io because there is no official image for arm
-
-## Conneting to the DB
-
-The port is 3306. It exists inside the docker network so you can connect via `mariadb:3306` for internal connections. For external connections use `<your Pis IP>:3306`
-
-![image](https://user-images.githubusercontent.com/46672225/69734358-7f030800-1137-11ea-9874-7d2c86b3d239.png)
-
-## Setup
-
-Before starting the stack edit the `./services/mariadb/mariadb.env` file and set your access details. This is optional however you will only have one shot at the preconfig. If you start the container without setting the passwords then you will have to either delete its volume directory or enter the terminal and change manually
-
-The env file has three commented fields for credentials, either **all three** must be commented or un-commented. You can't have only one or two, its all or nothing.
-
-## Terminal
-
-A terminal is provided to access mariadb by the cli. execute `./services/mariadb/terminal.sh`. You will need to run `mysql -uroot -p` to enter mariadbs interface
+Please refer to the [documentation on the master branch](https://sensorsiot.github.io/IOTstack/Containers/MariaDB/).


### PR DESCRIPTION
Follows on from suggestion in [Issue 415](https://github.com/SensorsIot/IOTstack/issues/415)
to add health-check to more containers. See also
[PR 406](https://github.com/SensorsIot/IOTstack/pull/406/commits/dbb6217ddb7b54e6d6a247a7c2b29ca364482ab5).

Changes:

* Adds `iotstack_healthcheck.sh` script to template.
* Adds commands to Dockerfile to copy that script into the local image
and activate health-checking on launch.
* Reduces old-menu MariaDB documentation to a stub pointing to new-menu
documentation (this is already the situation for old-menu NextCloud
documentation).