### PR TITLE
20211002 MariaDB health check - experimental branch - PR 3 of 3

### DIFF
--- a/.internal/templates/services/mariadb/buildFiles/Dockerfile
+++ b/.internal/templates/services/mariadb/buildFiles/Dockerfile
@@ -10,4 +10,16 @@ RUN sed -i.bak \
   -e "s/^read_buffer_size/# read_buffer_size/" \
   /defaults/my.cnf
 
+# copy the health-check script into place
+ENV HEALTHCHECK_SCRIPT "iotstack_healthcheck.sh"
+COPY ${HEALTHCHECK_SCRIPT} /usr/local/bin/${HEALTHCHECK_SCRIPT}
+
+# define the health check
+HEALTHCHECK \
+   --start-period=30s \
+   --interval=30s \
+   --timeout=10s \
+   --retries=3 \
+   CMD ${HEALTHCHECK_SCRIPT} || exit 1
+
 # EOF

--- a/.internal/templates/services/mariadb/buildFiles/iotstack_healthcheck.sh
+++ b/.internal/templates/services/mariadb/buildFiles/iotstack_healthcheck.sh
@@ -8,7 +8,13 @@ HEALTHCHECK_PORT="${MYSQL_TCP_PORT:-3306}"
 EXPECTED="mysqld is alive"
 
 # run the check
-RESPONSE=$(mysqladmin -p${MYSQL_ROOT_PASSWORD} ping -h localhost)
+if [ -z "$MYSQL_ROOT_PASSWORD" ] ; then
+   RESPONSE=$(mysqladmin ping -h localhost)
+else
+   # note - there is NO space between "-p" and the password. This is
+   # intentional. It is part of the mysql and mysqladmin API.
+   RESPONSE=$(mysqladmin -p${MYSQL_ROOT_PASSWORD} ping -h localhost)
+fi
 
 # did the mysqladmin command succeed?
 if [ $? -eq 0 ] ; then

--- a/.internal/templates/services/mariadb/buildFiles/iotstack_healthcheck.sh
+++ b/.internal/templates/services/mariadb/buildFiles/iotstack_healthcheck.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+
+# set a default for the port
+# (refer https://mariadb.com/kb/en/mariadb-environment-variables/ )
+HEALTHCHECK_PORT="${MYSQL_TCP_PORT:-3306}"
+
+# the expected response is?
+EXPECTED="mysqld is alive"
+
+# run the check
+RESPONSE=$(mysqladmin -p${MYSQL_ROOT_PASSWORD} ping -h localhost)
+
+# did the mysqladmin command succeed?
+if [ $? -eq 0 ] ; then
+
+   # yes! is the response as expected?
+   if [ "$RESPONSE" = "$EXPECTED" ] ; then
+
+      # yes! this could still be a false positive so probe the port
+      if nc -w 1 localhost $HEALTHCHECK_PORT >/dev/null 2>&1; then
+
+         # port responding - that defines healthy
+         exit 0
+
+      fi
+
+   fi
+
+fi
+
+# otherwise the check fails
+exit 1


### PR DESCRIPTION
Follows on from suggestion in [Issue 415](https://github.com/SensorsIot/IOTstack/issues/415)
to add health-check to more containers. See also
[PR 406](https://github.com/SensorsIot/IOTstack/pull/406/commits/dbb6217ddb7b54e6d6a247a7c2b29ca364482ab5).

Changes:

* Adds `iotstack_healthcheck.sh` script to template.
* Moves Dockerfile into `buildFiles` directory, and adds commands to
copy the health-check script into the local image and activate
health-checking on launch.

Does not change any documentation on experimental branch.