### PR TITLE
20211011 Home Assistant - master branch - PR 1 of 3

### DIFF
--- a/.templates/home_assistant/service.yml
+++ b/.templates/home_assistant/service.yml
@@ -1,11 +1,10 @@
 home_assistant:
   container_name: home_assistant
-  image: homeassistant/home-assistant:stable
+  image: ghcr.io/home-assistant/home-assistant:stable
+  #image: ghcr.io/home-assistant/raspberrypi3-homeassistant:stable
+  #image: ghcr.io/home-assistant/raspberrypi4-homeassistant:stable
   restart: unless-stopped
-  ports:
-    - "8123:8123"
+  network_mode: host
   volumes:
     - /etc/localtime:/etc/localtime:ro
     - ./volumes/home_assistant:/config
-  #network_mode: host
-

--- a/docs/Containers/Home-Assistant.md
+++ b/docs/Containers/Home-Assistant.md
@@ -1,36 +1,57 @@
-# Home assistant
+# Home Assistant
 
-## References
-- [Docker](https://hub.docker.com/r/homeassistant/home-assistant/)
-- [Webpage](https://www.home-assistant.io/)
+Home Assistant is a home automation platform running on Python 3. It is able to track and control all devices at your home and offer a platform for automating control.
 
-Hass.io is a home automation platform running on Python 3. It is able to track and control all devices at home and offer a platform for automating control. Port binding is `8123`.
-Hass.io is exposed to your hosts' network in order to discover devices on your LAN. That means that it does not sit inside Docker's network.
+## <a name="references"> References </a>
 
-## To avoid confusion
+- [Home Assistant home page](https://www.home-assistant.io/)
+
+	- [Raspberry Pi installation](https://www.home-assistant.io/installation/raspberrypi/)
+	- [General installation](https://www.home-assistant.io/installation) (may be useful if you are trying to run on other hardware).
+
+- [GitHub repository](https://github.com/home-assistant/core)
+- [DockerHub](https://hub.docker.com/r/homeassistant/home-assistant/)
+
+
+## <a name="twoVersions">Home Assistant: two versions</a>
 
 There are two versions of Home Assistant:
 
-* Hass.io, and
-* Home Assistant Docker.
+* Hass.io (Home Assistant Core), and
+* Home Assistant Container.
 
-Hass.io uses its own orchestration with 3 docker images:
+Each version:
 
-* `hassio_supervisor`,
-* `hassio_dns` and
-* `homeassistant`.
+* provides a web-based management interface on port 8123; and
+* runs in "host mode" in order to discover devices on your LAN, including devices communicating via multicast traffic.
 
-Home Assistant Docker runs inside a single Docker image, and doesn't support all the features that Hass.io does (such as add-ons). IOTstack allows installing either, but we can only offer limited configuration of Hass.io since it is its own platform.
+IOTstack allows you to **install** either, or both, versions.
 
-> [More info on versions](https://www.home-assistant.io/docs/installation/#recommended).
+Note:
 
-## Menu installation
+* Technically, both versions can **run** at the same time but it is not **supported**. Each version runs in "host mode" and binds to port 8123 so, in practice, the first version to start will claim the port and the second version will then be blocked.
 
-Hass.io installation can be found inside the `Native Installs` menu on the main menu. Home Assistant can be found in the `Build Stack` menu.
+### <a name="versionHassio"> Hass.io </a>
 
-You will be asked to select your device type during the installation. Hass.io is no longer dependant on the IOTstack, it has its own service for maintaining its uptime.
+Hass.io uses its own orchestration:
 
-## Installation
+* hassio\_supervisor
+* hassio\_audio
+* hassio\_cli
+* hassio\_dns
+* hassio\_multicast
+* hassio\_observer
+* homeassistant.
+
+IOTstack can only offer limited configuration of Hass.io since it is its own platform.
+
+### <a name="versionHAContainer"> Home Assistant Container </a>
+
+Home Assistant Container runs as a single Docker container, and doesn't support all the features that Hass.io does (such as add-ons).
+
+## <a name="menuInstallation"> Menu installation </a>
+
+### <a name="installHassio"> Installing Hass.io </a>
 
 Hass.io creates a conundrum:
 
@@ -38,37 +59,37 @@ Hass.io creates a conundrum:
 * One of Hass.io's dependencies is [Network Manager](https://wiki.archlinux.org/index.php/NetworkManager). Network Manager makes **serious** changes to your operating system, with side-effects you may not expect such as giving your Raspberry Pi's WiFi interface a random MAC address both during the installation and, then, each time you reboot. You are in for a world of pain if you install Network Manager without first understanding what is going to happen and planning accordingly.
 * If you don't install Hass.io's dependencies before you install Docker, you will either have to uninstall Docker or rebuild your system. This is because both Docker and Network Manager adjust your Raspberry Pi's networking. Docker is happy to install after Network Manager, but the reverse is not true.
 
-### If Docker is already installed, uninstall it
+#### <a name="uninstallDocker"> Step 1: If Docker is already installed, uninstall it </a>
 
-```
+```bash
 $ sudo apt -y purge docker-ce docker-ce-cli containerd.io
 $ sudo apt -y remove docker-compose
 $ sudo pip3 uninstall docker-compose
 ```
 
-Note that this does **not** interfere with your existing `~/IOTstack` folder.
+Note:
 
-### Ensure your system is fully up-to-date
+* Removing Docker does **not** interfere with your existing `~/IOTstack` folder.
 
-```
+#### <a name="aptUpdate"> Step 2: Ensure your system is fully up-to-date </a>
+
+```bash
 $ sudo apt update
 $ sudo apt upgrade -y
 ```
 
-### Install Hass.io dependencies (stage 1)
+#### <a name="hassioDependencies1"> Step 3: Install Hass.io dependencies (stage 1) </a>
 
 ```bash
 $ sudo apt install -y apparmor apparmor-profiles apparmor-utils
 $ sudo apt install -y software-properties-common apt-transport-https ca-certificates dbus
 ```
 
-The first line is required. A post at [community.home-assistant.io](ttps://community.home-assistant.io/t/installing-home-assistant-supervised-on-raspberry-pi-os/201836) implies the second line may also be required but it is not clear whether those packages are strictly necessary.
-
-### Connect to your Raspberry Pi via Ethernet
+#### <a name="useEthernet"> Step 4: Connect to your Raspberry Pi via Ethernet </a>
 
 You can skip this step if you interact with your Raspberry Pi via a screen connected to its HDMI port, along with a keyboard and mouse.
 
-If, however, you are running "headless" (SSH or VNC), connect your Raspberry Pi to Ethernet.
+If, however, you are running "headless" (SSH or VNC), we **strongly recommend** connecting your Raspberry Pi to Ethernet. This is only a temporary requirement. You can return to WiFi-only operation after Hass.io is installed.
 
 When the Ethernet interface initialises, work out its IP address:
 
@@ -84,7 +105,7 @@ eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
         TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
 ```   
 
-In the above, the IP address assigned to the Ethernet interface is 192.168.132.9.
+In the above, the IP address assigned to the Ethernet interface is on the second line of output, to the right of "inet": 192.168.132.9.
 
 Drop out of your existing session (SSH or VNC) and re-connect to your Raspberry Pi using the IP address assigned to its Ethernet interface:
 
@@ -102,13 +123,11 @@ The reason for stipulating the IP address, rather than a name like `raspberrypi.
 
 If you ignore the advice about connecting via Ethernet and install Network Manager while your session is connected via WiFi, your connection will freeze part way through the installation (when Network Manager starts running and unconditionally changes your Raspberry Pi's WiFi MAC address).
 
-> If you want to know more about why the connection freezes, see [why random MACs are such a hassle ](#aboutRandomMACs).
-
 You *may* be able to re-connect after the WiFi interface acquires a new IP address and advertises that via multicast DNS associated with the name of your device (eg `raspberrypi.local`), but you may also find that the only way to regain control is to power-cycle your Raspberry Pi.
 
 The advice about using Ethernet is well-intentioned. You should heed this advice even if means you need to temporarily relocate your Raspberry Pi just so you can attach it via Ethernet for the next few steps. You can go back to WiFi later, once everything is set up. You have been warned!
 
-### Install Hass.io dependencies (stage 2)
+#### <a name="hassioDependencies2"> Step 5: Install Hass.io dependencies (stage 2) </a>
 
 Install Network Manager:
 
@@ -116,99 +135,133 @@ Install Network Manager:
 $ sudo apt install -y network-manager
 ```
 
-### Consider disabling random MAC address allocation
+#### <a name="disableRandomMac1"> Step 6: Consider disabling random MAC address allocation </a>
 
-According to [@steveatk on Discord](https://discordapp.com/channels/638610460567928832/638610461109256194/758825690715652116), you can stop Network Manager from allocating random MAC addresses to your WiFi interface by editing:
+To understand why you should consider disabling random MAC address allocation, see [why random MACs are such a hassle ](#aboutRandomMACs).
 
-```bash
-$ sudo vi /etc/NetworkManager/NetworkManager.conf
-```
-
-and adding:
+You can stop Network Manager from allocating random MAC addresses to your WiFi interface by running the following commands:
 
 ```bash
-[device]
-wifi.scan-rand-mac-address=no
+$ sudo sed -i.bak '$a\\n[device]\nwifi.scan-rand-mac-address=no\n' /etc/NetworkManager/NetworkManager.conf
+$ sudo systemctl restart NetworkManager.service
 ```
 
-This needs to be done **twice**:
+Acknowledgement:
 
-* after Network Manager is installed; and again
-* after Hass.io is installed via the IOTstack menu.
+* This tip came from [@steveatk on Discord](https://discordapp.com/channels/638610460567928832/638610461109256194/758825690715652116).
 
-In both cases, `NetworkManager.conf` is replaced with a version that enables random MAC allocation.
+#### <a name="reinstallDocker"> Step 7: Re-install Docker </a>
 
-### Re-install docker
-
-If you had to uninstall Docker in the earlier step, now is the time to re-install it. You can use the menu or one of the scripts provided with IOTstack but it is probably just as easy to run:
+You can re-install Docker using the IOTstack menu or one of the scripts provided with IOTstack but the following commands guarantee an up-to-date version of `docker-compose` and also include a dependency needed if you want to run with the 64-bit kernel:
 
 ```bash
 $ curl -fsSL https://get.docker.com | sh
 $ sudo usermod -G docker -a $USER
 $ sudo usermod -G bluetooth -a $USER
 $ sudo apt install -y python3-pip python3-dev
+$ [ "$(uname -m)" = "aarch64" ] && sudo apt install libffi-dev
 $ sudo pip3 install -U docker-compose
 $ sudo pip3 install -U ruamel.yaml==0.16.12 blessed
 $ sudo reboot
 ```
 
-Note that this does **not** interfere with your existing `~/IOTstack` folder.
+Note:
 
-### Run the Hass.io installation
+* Installing or re-installing Docker does **not** interfere with your existing `~/IOTstack` folder.
+
+#### <a name="runHassioInstall"> Step 8: Run the Hass.io installation </a>
 
 Start at:
 
-```
+```bash
 $ cd ~/IOTstack
 $ ./menu.sh
 ```
 
-and then navigate to the installation option.
+Hass.io installation can be found inside the `Native Installs` menu on the main menu. You will be asked to select your device type during the installation.
 
-The installation of Hass.io takes up to 20 minutes (depending on your internet connection). Refrain from restarting your machine until it has come online and you are able to create a user account.
+The installation of Hass.io takes up to 20 minutes (depending on your internet connection). You may also need to respond "Y" to a prompt during the installation process. Refrain from restarting your machine until it has come online and you are able to create a user account.
 
-## Removal
+Hass.io installation is provided as a convenience. It is independent of, is not maintained by, and does not appear in the `docker-compose.yml` for IOTstack. Hass.io has its own service for maintaining its uptime.
 
-To remove Hass.io you first need to stop the service that controls it. Run the following in the terminal: 
+#### <a name="disableRandomMac2"> Re-check random MAC address allocation </a>
+
+Installing Hass.io can re-enable random MAC address allocation. You should check this via:
+
+```bash
+$ tail -3 /etc/NetworkManager/NetworkManager.conf
+[device]
+wifi.scan-rand-mac-address=no
+
+```
+
+If you do **NOT** see `wifi.scan-rand-mac-address=no`, repeat [Step 6](#disableRandomMac1).
+
+### <a name="installHAContainer"> Installing Home Assistant Container </a>
+
+Home Assistant can be found in the `Build Stack` menu. Selecting it in this menu results in a service definition being added to:
+
+```
+~/IOTstack/docker-compose.yml
+```
+
+When you choose "Home Assistant", the service definition added to your `docker-compose.yml` includes the following:
+
+```yaml
+image: ghcr.io/home-assistant/home-assistant:stable
+#image: ghcr.io/home-assistant/raspberrypi3-homeassistant:stable
+#image: ghcr.io/home-assistant/raspberrypi4-homeassistant:stable
+```
+
+The active image is *generic* in the sense that it should work on any platform. You may wish to edit your `docker-compose.yml` to deactivate the generic image in favour of an image tailored to your hardware.
+
+The normal IOTstack commands apply to Home Assistant Container such as:
+
+```bash
+$ cd ~/IOTstack
+$ docker-compose up -d
+```
+
+## <a name="deactivateHassio"> Deactivating Hass.io </a>
+
+Because Hass.io is independent of IOTstack, you can't deactivate it with any of the commands you normally use for IOTstack.
+
+To deactivate Hass.io you first need to stop the service that controls it. Run the following commands in the terminal: 
 
 ```bash
 $ sudo systemctl stop hassio-supervisor.service
 $ sudo systemctl disable hassio-supervisor.service
 ```
 
-This should stop the main service however there are two additional container that still need to be address
-
-This will stop the service and disable it from starting on the next boot.
-
-Next you need to stop the `hassio_dns` and `hassio_supervisor`:
+This will stop the main service and prevent it from starting on the next boot. Next you need to stop and remove the dependent services:
 
 ```bash
-$ docker stop hassio_supervisor
-$ docker stop hassio_dns
-$ docker stop homeassistant
+$ docker stop hassio_audio hassio_cli hassio_dns hassio_multicast hassio_observer homeassistant
+$ docker rm hassio_audio hassio_cli hassio_dns hassio_multicast hassio_observer homeassistant 
 ```
 
-If you want to remove the containers:
-
-```bash
-$ docker rm hassio_supervisor
-$ docker rm hassio_dns
-$ docker stop homeassistant
-```
-
-After rebooting you should be able to reinstall.
+Double-check with `docker ps` to see if there are other containers running with a `hassio_` prefix. They can stopped and removed in the same fashion for `hassio_audio` and so-on.
 
 The stored files are located in `/usr/share/hassio` which can be removed if you need to.
 
-Double-check with `docker ps` to see if there are other hassio containers running. They can stopped and removed in the same fashion for the dns and supervisor.
-
 You can use Portainer to view what is running and clean up the unused images.
+
+At this point, Hass.io is stopped and will not start again after a reboot. Your options are:
+
+* Leave things as they are; or
+* Re-install Hass.io by starting over at [Installing Hass.io](#installHassio); or
+* Re-activate Hass.io by:
+
+	```bash
+	$ sudo systemctl enable hassio-supervisor.service
+	$ sudo systemctl start hassio-supervisor.service
+	```
 
 ## <a name="aboutRandomMACs"> Why random MACs are such a hassle </a>
 
 > This material was originally posted as part of [Issue 312](https://github.com/SensorsIot/IOTstack/issues/312). It was moved here following a suggestion by [lole-elol](https://github.com/lole-elol).
 
-When you connect to a Raspberry Pi via SSH, that's a protocol that is riding on top of TCP/IP. SSH (the layer 4 protocol) uses TCP (a connection-oriented protocol) which rides on IP (the layer 3 protocol). So far, so good.
+When you connect to a Raspberry Pi via SSH (Secure Shell), that's a layer 7 protocol that is riding on top of TCP/IP. TCP (Transmission Control Protocol) is a layer 4 connection-oriented protocol which rides on IP (Internet Protocol) which is a layer 3 protocol. So far, so good.
 
 But you also need to know what happens at layers 2 and 1. When your SSH client (eg Mac or PC or another Unix box) opens its SSH connection, at layer 3 the IP stack applies the subnet mask against the IP addresses of both the source device (your Mac, PC, etc) and destination device (Raspberry Pi) to split them into "network portion" (on the left) and "host portion" on the right. It then compares the two network portions and, if they are the same, it says "local network".
 
@@ -218,7 +271,7 @@ What happens next depends on the data communications media but we'll assume Ethe
 
 The source machine (Mac, PC, etc) issues an ARP (address resolution protocol). It is a broadcast frame (we talk about "frames" rather than "packets" at Layer 2) asking the question, "who has this destination IP address?" The Raspberry Pi responds with a unicast packet saying, "that's me" and part of that includes the MAC (media access control) address of the Raspberry Pi. The source machine only does this **once** (and this is a key point). It assumes the relationship between IP address and MAC address will not change and it adds the relationship to its "ARP cache". You can see the cache on any Unix computer with:
 
-```
+```bash
 $ arp -a
 ```
 
@@ -228,7 +281,7 @@ In addition, every layer two switch (got one of those in your home?) has been sn
 
 Not "MAC **and** IP". A switch works at Layer 2. All it sees are frames. It only caches MAC addresses!
 
-When the switch saw the ARP broadcast, it replicated that out of all of its ports but when the "that's me" came back from the Raspberry Pi as a unicast response, it only went out on the switch port where the source machine (Mac, PC, etc) was attached.
+When the switch saw the "who has?" ARP broadcast, it replicated that out of all of its ports but when the "that's me" came back from the Raspberry Pi as a unicast response, it only went out on the switch port where the source machine (Mac, PC, etc) was attached.
 
 After that, it's all caching. The Mac or PC has a packet to send to the Pi. It finds the hit in its ARP cache, wraps the packet in a frame and sends it out its Ethernet or WiFi interface. Any switches receive the frame, consult their own tables, and send the frame out the port on the next hop to the destination device. It doesn't matter whether you have one switch or several in a cascade, they have all learned the "next hop" to each destination MAC address they have seen. 
 
@@ -244,7 +297,7 @@ When the WiFi interface comes up, it almost certainly "speaks" straight away via
 
 The DHCP request is broadcast so all the switches will have learned the new MAC but they'll also still have the old MAC (until it times out). The Mac/PC will receive the DHCP broadcast but, unless it's the DHCP server, will discard it. Either way, it has no means of knowing that this new random MAC belongs to the Pi so it can't do anything sensible with the information.
 
-Meanwhile, SSH is trying to keep the session alive. It still thinks "old IP address" and its ARP cache still thinks old IP belongs to old MAC. Switches know where the frames are meant to go but even if a frame does get somewhere near the Pi, the Pi's NIC (network interface card) ignores it because it's the wrong destination MAC. The upshot is that SSH looks like the session has frozen and it will eventually time-out with a broken pipe.
+Meanwhile, SSH is trying to keep the session alive. It still thinks "old IP address" and its ARP cache still thinks old IP belongs to old MAC. Switches know where the frames are meant to go but even if a frame does get somewhere near the Pi, the Pi's NIC (network interface card) ignores it because it's now the wrong destination MAC. The upshot is that SSH looks like the session has frozen and it will eventually time-out with a broken pipe.
 
 To summarise: Network Manager has changed the MAC without so much as a by-your-leave and, unless you have assigned static IP addresses **in the Raspberry Pi** it's quite likely that the Pi will have a different IP address as well. But even a static IP can't save you from the machinations of Network Manager!
 
@@ -256,7 +309,7 @@ That's why the installation advice says words to the effect of:
 
 And it does get worse, of course. Installing Network Manager turns on random WiFi MAC. You can turn it off and go back to the fixed MAC. But then, when you install Docker, it happens again. It may also be that other packages come along in future and say, "hey, look, Network Manager is installed - let's take advantage of that" and it happens again when you least expect it.
 
-Devices changing their MACs at random is becoming reasonably common. If you have a mobile device running a reasonably current OS, it is probably changing its MAC all the time. The idea is to make it hard for Fred's Corner Store to track you and conclude, "Hey, Jim is back in the shop again."
+Devices changing their MACs at random is becoming reasonably common. If you have a mobile device running a reasonably current OS, it is probably changing its MAC all the time. The idea is to make it hard for Fred's Corner Store to track you and conclude, "Hey, Alex is back in the shop again."
 
 Random MACs are not a problem for a **client** device like a phone, tablet or laptop. But they are definitely a serious problem for a **server** device.
 


### PR DESCRIPTION
Changes `home_assistant` service definition to:

* Reference ghcr.io containers, and provide options to select tailored
images for Raspberry Pi 3 and 4.
* Places container into Host Mode so it can receive multicast traffic.

Documentation re-organised to clearly separate material relevant to
Hass.io (Home Assistant Core) from Home Assistant Container.

Updates Hass.io material in line with what actually happens when that
version is installed.