### PR TITLE
20211011 Home Assistant - old-menu branch - PR 2 of 3

### DIFF
--- a/.templates/home_assistant/service.yml
+++ b/.templates/home_assistant/service.yml
@@ -1,0 +1,10 @@
+  home_assistant:
+    container_name: home_assistant
+    image: ghcr.io/home-assistant/home-assistant:stable
+    #image: ghcr.io/home-assistant/raspberrypi3-homeassistant:stable
+    #image: ghcr.io/home-assistant/raspberrypi4-homeassistant:stable
+    restart: unless-stopped
+    network_mode: host
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      - ./volumes/home_assistant:/config

--- a/menu.sh
+++ b/menu.sh
@@ -62,6 +62,7 @@ declare -A cont_array=(
 	[heimdall]="Heimdall Application Dashboard"
 	[dashmachine]="DashMachine"
 	[homer]="Homer"
+	[home_assistant]="Home Assistant Container"
 	# add yours here
 )
 
@@ -107,6 +108,7 @@ declare -a armhf_keys=(
 	"heimdall"
 	"dashmachine"
 	"homer"
+	"home_assistant"
 	# add yours here
 )
 sys_arch=$(uname -m)


### PR DESCRIPTION
Adds service definition for `home_assistant` (previously missing).

Changes menu to provide `home_assistant` as an option.

No documentation added (assumes master branch documentation is definitive).