### PR TITLE
20211011 Home Assistant - experimental branch - PR 3 of 3

### DIFF
--- a/.internal/templates/services/home_assistant/template.yml
+++ b/.internal/templates/services/home_assistant/template.yml
@@ -1,12 +1,10 @@
 home_assistant:
   container_name: home_assistant
-  image: homeassistant/home-assistant:stable
+  image: ghcr.io/home-assistant/home-assistant:stable
+  #image: ghcr.io/home-assistant/raspberrypi3-homeassistant:stable
+  #image: ghcr.io/home-assistant/raspberrypi4-homeassistant:stable
   restart: unless-stopped
+  network_mode: host
   volumes:
     - /etc/localtime:/etc/localtime:ro
     - ./volumes/home_assistant:/config
-  network_mode: host
-  logging:
-    options:
-      max-size: "5m"
-      max-file: "3"


### PR DESCRIPTION
Changes `home_assistant` service definition to:

* Reference ghcr.io containers, and provide options to select tailored
images for Raspberry Pi 3 and 4.
* Places container into Host Mode so it can receive multicast traffic.

Documentation not changed (assumes master branch documentation is
definitive).