### PR TITLE
20211015 Getting started documentation

### DIFF
--- a/docs/Getting-Started.md
+++ b/docs/Getting-Started.md
@@ -126,7 +126,7 @@ If you are still running on gcgarner/IOTstack and need to migrate to SensorsIot/
 Run the following commands:
 
 ```
-$ sudo bash -c '[ $(egrep -c "^allowinterfaces eth*,wlan*" /etc/dhcpcd.conf) -eq 0 ] && echo "allowinterfaces eth*,wlan*" >> /etc/dhcpcd.conf'
+$ sudo bash -c '[ $(egrep -c "^allowinterfaces eth\*,wlan\*" /etc/dhcpcd.conf) -eq 0 ] && echo "allowinterfaces eth*,wlan*" >> /etc/dhcpcd.conf'
 $ sudo reboot
 ```
 


### PR DESCRIPTION
The `grep` command for the first recommended system patch uses
un-escaped wildcards. It will always succeed so multiple calls will
keep appending `allow interfaces` to `/etc/dhcpcd.conf`. That doesn't
actually matter but it is untidy.