### PR TITLE
20211015 Telegraf - defaults - old-menu branch - PR 2 of 3

### DIFF
--- a/.templates/telegraf/Dockerfile
+++ b/.templates/telegraf/Dockerfile
@@ -7,9 +7,12 @@ RUN apt update && apt install -y rsync
 # where IOTstack template files are stored
 ENV IOTSTACK_DEFAULTS_DIR="iotstack_defaults"
 
-# make a copy of the default config file
+# make a copy of the default config file and point to influxdb container
 RUN mkdir -p /${IOTSTACK_DEFAULTS_DIR} && \
-    cp /etc/telegraf/telegraf.conf /${IOTSTACK_DEFAULTS_DIR}/
+    cp /etc/telegraf/telegraf.conf /${IOTSTACK_DEFAULTS_DIR}/ && \
+    sed -i.bak \
+        '/^\[\[outputs.influxdb\]\]/a\ \ urls = ["http://influxdb:8086"]' \
+        /${IOTSTACK_DEFAULTS_DIR}/telegraf.conf
 
 # replace the docker entry-point script with a self-repairing version
 ENV IOTSTACK_ENTRY_POINT="entrypoint.sh"

--- a/.templates/telegraf/Dockerfile
+++ b/.templates/telegraf/Dockerfile
@@ -7,12 +7,23 @@ RUN apt update && apt install -y rsync
 # where IOTstack template files are stored
 ENV IOTSTACK_DEFAULTS_DIR="iotstack_defaults"
 
-# make a copy of the default config file and point to influxdb container
-RUN mkdir -p /${IOTSTACK_DEFAULTS_DIR} && \
-    cp /etc/telegraf/telegraf.conf /${IOTSTACK_DEFAULTS_DIR}/ && \
-    sed -i.bak \
-        '/^\[\[outputs.influxdb\]\]/a\ \ urls = ["http://influxdb:8086"]' \
-        /${IOTSTACK_DEFAULTS_DIR}/telegraf.conf
+# copy template files to image
+COPY ${IOTSTACK_DEFAULTS_DIR} /${IOTSTACK_DEFAULTS_DIR}
+
+# 1. copy the default configuration file that ships with the image as
+#    a baseline reference for the user, and make it read-only.
+# 2. strip comment lines and blank lines from the baseline reference to
+#    use as the starting point for the IOTstack default configuration.
+# 3. edit the IOTstack default configuration to insert an appropriate
+#    URL for influxdb running in another container in the same stack.
+ENV BASELINE_CONFIG=/${IOTSTACK_DEFAULTS_DIR}/telegraf-reference.conf
+ENV IOTSTACK_CONFIG=/${IOTSTACK_DEFAULTS_DIR}/telegraf.conf
+RUN cp /etc/telegraf/telegraf.conf ${BASELINE_CONFIG} && \
+    chmod 444 ${BASELINE_CONFIG} && \
+    grep -v -e "^[ ]*#" -e "^[ ]*$" ${BASELINE_CONFIG} >${IOTSTACK_CONFIG} && \
+    sed -i '/^\[\[outputs.influxdb\]\]/a\ \ urls = ["http://influxdb:8086"]' ${IOTSTACK_CONFIG}
+ENV BASELINE_CONFIG=
+ENV IOTSTACK_CONFIG=
 
 # replace the docker entry-point script with a self-repairing version
 ENV IOTSTACK_ENTRY_POINT="entrypoint.sh"

--- a/.templates/telegraf/iotstack_defaults/additions/inputs.docker.conf
+++ b/.templates/telegraf/iotstack_defaults/additions/inputs.docker.conf
@@ -1,0 +1,15 @@
+# Read metrics about docker containers
+# Credit: @tablatronix
+[[inputs.docker]]
+  endpoint = "unix:///var/run/docker.sock"
+  gather_services = false
+  container_names = []
+  source_tag = false
+  container_name_include = []
+  container_name_exclude = []
+  timeout = "5s"
+  perdevice = false
+  total = true
+  docker_label_include = []
+  docker_label_exclude = []
+  tag_env = ["HEAP_SIZE"]

--- a/.templates/telegraf/iotstack_defaults/additions/inputs.mqtt_consumer.conf
+++ b/.templates/telegraf/iotstack_defaults/additions/inputs.mqtt_consumer.conf
@@ -1,0 +1,10 @@
+# Read metrics from MQTT topic(s)
+# Credit: https://github.com/gcgarner/IOTstack/blob/master/.templates/telegraf/telegraf.conf
+[[inputs.mqtt_consumer]]
+  servers = ["tcp://mosquitto:1883"]
+  topics = [
+    "telegraf/host01/cpu",
+    "telegraf/+/mem",
+    "sensors/#",
+  ]
+  data_format = "json"

--- a/.templates/telegraf/service.yml
+++ b/.templates/telegraf/service.yml
@@ -10,6 +10,7 @@
       - "8125:8125/udp"
     volumes:
       - ./volumes/telegraf/:/etc/telegraf
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     depends_on:
       - influxdb
       - mosquitto


### PR DESCRIPTION
Changes `telegraf` Dockerfile so that the configuration for sending
metrics to InfluxDB uses the "internal network" URL:

```
http://influxdb:8086
```

On a clean install, Telegraf should communicate with InfluxDB
"out of the box".

Acknowledgement: this problem was discovered by
[Discord user "tablatronix"](https://discord.com/channels/638610460567928832/638610461109256194/898349626179076096)