### PR TITLE
20211116 Menu - master branch - quote variables in expression

### DIFF
--- a/menu.sh
+++ b/menu.sh
@@ -125,11 +125,11 @@ function check_git_updates()
 	REMOTE=$(git rev-parse "$UPSTREAM")
 	BASE=$(git merge-base @ "$UPSTREAM")
 
-	if [ $LOCAL = $REMOTE ]; then
+	if [ "$LOCAL" = "$REMOTE" ]; then
 			echo "Up-to-date"
-	elif [ $LOCAL = $BASE ]; then
+	elif [ "$LOCAL" = "$BASE" ]; then
 			echo "Need to pull"
-	elif [ $REMOTE = $BASE ]; then
+	elif [ "$REMOTE" = "$BASE" ]; then
 			echo "Need to push"
 	else
 			echo "Diverged"


### PR DESCRIPTION
Function `check_git_updates()` does not quote variables used in expressions. This leads to the errors:

```
./menu.sh: line 128: [: f6d9bbd2f702bf4dcb05e285423ba9a8a3f5390c: unary operator expected
./menu.sh: line 130: [: f6d9bbd2f702bf4dcb05e285423ba9a8a3f5390c: unary operator expected
```

Quotes added to expressions.