### PR TITLE
20211116 volume-mounts - experimental branch - PR 3 of 3

### DIFF
--- a/.internal/templates/services/deconz/template.yml
+++ b/.internal/templates/services/deconz/template.yml
@@ -7,7 +7,7 @@ deconz:
     - "443:443"
     - "5901:5900"
   volumes:
-    - ./volumes/deconz/:/opt/deCONZ
+    - ./volumes/deconz:/opt/deCONZ
   devices: # This list is replaced during the build process. Modify the list in "config.js" to change it.
     - "{$deconzSelectedDevice}"
   environment:

--- a/.internal/templates/services/diyhue/template.yml
+++ b/.internal/templates/services/diyhue/template.yml
@@ -10,7 +10,7 @@ diyhue:
     - IP=%LAN_IP_Address%
     - MAC=%LAN_MAC_Address%
   volumes:
-      - ./volumes/diyhue/:/opt/hue-emulator/export/
+      - ./volumes/diyhue:/opt/hue-emulator/export
   restart: unless-stopped
   networks:
     - iotstack_nw

--- a/.internal/templates/services/pihole/template.yml
+++ b/.internal/templates/services/pihole/template.yml
@@ -25,8 +25,8 @@ pihole:
     - INTERFACE=eth0
     # - DNSMASQ_LISTENING=local
   volumes:
-      - ./volumes/pihole/etc-pihole/:/etc/pihole/
-      - ./volumes/pihole/etc-dnsmasq.d/:/etc/dnsmasq.d/
+      - ./volumes/pihole/etc-pihole:/etc/pihole
+      - ./volumes/pihole/etc-dnsmasq.d:/etc/dnsmasq.d
   dns:
     - 127.0.0.1
     - 1.1.1.1

--- a/.internal/templates/services/telegraf/template.yml
+++ b/.internal/templates/services/telegraf/template.yml
@@ -9,7 +9,7 @@ telegraf:
     - "8094:8094/tcp"
     - "8125:8125/udp"
   volumes:
-    - ./volumes/telegraf/:/etc/telegraf
+    - ./volumes/telegraf:/etc/telegraf
     - /var/run/docker.sock:/var/run/docker.sock:ro
   depends_on:
     - influxdb


### PR DESCRIPTION
Under 2.x versions of docker-compose, volumes statements in service definitions that have trailing slashes cause:

```
Error response from daemon: invalid mount config for type "bind": bind source path does not exist:
```

This problem only shows up on first install of a container (ie when the container's persistent storage area has not yet been initialised).

There are 51 volumes statements across all current service definitions:

```
$ find ~/IOTstack/.templates -name "service.yml" -exec grep -H '\- \./volumes' {} \; | wc -l
51
```

Of those, 5 have a trailing "/" on either or both sides:

```
$ find ~/IOTstack/.templates -name "service.yml" -exec grep -H '\- \./volumes' {} \; | grep -e '/:' -e '/$'
/home/pi/IOTstack/.templates/telegraf/service.yml:    - ./volumes/telegraf/:/etc/telegraf
/home/pi/IOTstack/.templates/pihole/service.yml:      - ./volumes/pihole/etc-pihole/:/etc/pihole/
/home/pi/IOTstack/.templates/pihole/service.yml:      - ./volumes/pihole/etc-dnsmasq.d/:/etc/dnsmasq.d/
/home/pi/IOTstack/.templates/diyhue/service.yml:      - ./volumes/diyhue/:/opt/hue-emulator/export/
/home/pi/IOTstack/.templates/deconz/service.yml:    - ./volumes/deconz/:/opt/deCONZ
```

This pull request removes those extraneous trailing slashes. Changes do not affect current docker-compose or container behaviour.