### PR TITLE
use GITHUB_TOKEN for better security

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:
-          PERSONAL_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Limits *action* access to just the repository that the action is run by.

As recommended by:
https://docs.github.com/en/actions/security-guides/automatic-token-authentication

Tested to work in my fork on github.