### PR TITLE
20211215 nextcloud_db - exposed port - master branch - PR 1 of 3

### DIFF
--- a/.templates/nextcloud/service.yml
+++ b/.templates/nextcloud/service.yml
@@ -29,8 +29,6 @@ nextcloud_db:
     - MYSQL_PASSWORD=%randomMySqlPassword%
     - MYSQL_DATABASE=nextcloud
     - MYSQL_USER=nextcloud
-  ports:
-    - "9322:3306"
   volumes:
     - ./volumes/nextcloud/db:/config
     - ./volumes/nextcloud/db_backup:/backup

--- a/docs/Containers/NextCloud.md
+++ b/docs/Containers/NextCloud.md
@@ -33,8 +33,6 @@ nextcloud_db:
     - MYSQL_PASSWORD=«user_password»
     - MYSQL_DATABASE=nextcloud
     - MYSQL_USER=nextcloud
-  ports:
-    - "9322:3306"
   volumes:
     - ./volumes/nextcloud/db:/config
     - ./volumes/nextcloud/db_backup:/backup


### PR DESCRIPTION
Pull Requests [PR387](https://github.com/SensorsIot/IOTstack/pull/387), [PR388](https://github.com/SensorsIot/IOTstack/pull/388), [PR389](https://github.com/SensorsIot/IOTstack/pull/389) added a port mapping of `9322:3306` to facilitate backup and restores - so the routines could determine when the MariaDB service was ready for business.

The need for this was superseded by PRs [416](https://github.com/SensorsIot/IOTstack/pull/416), [417](https://github.com/SensorsIot/IOTstack/pull/417) and [418](https://github.com/SensorsIot/IOTstack/pull/418). It is sufficient for backup and restore routines to run the health check and rely on the return status.

This PR removes the `9322:3306` as no longer needed. It will also avoid the need to protect the port with an iptables rule in situations where the host is exposed to the network.

Documentation also updated.

Signed-off-by: Phill Kelley <pmk.57t49@lgosys.com>