### PR TITLE
20211220 mosquitto-selfRepair-logging - old-menu branch - PR 2 of 3

### DIFF
--- a/.templates/mosquitto/docker-entrypoint.sh
+++ b/.templates/mosquitto/docker-entrypoint.sh
@@ -5,9 +5,13 @@ set -e
 user="$(id -u)"
 if [ "$user" = '0' -a -d "/mosquitto" ]; then
 
-   rsync -arp --ignore-existing /${IOTSTACK_DEFAULTS_DIR}/ "/mosquitto"
+   echo "[IOTstack] begin self-repair"
 
-   chown -R mosquitto:mosquitto /mosquitto
+   rsync -arpv --ignore-existing /${IOTSTACK_DEFAULTS_DIR}/ "/mosquitto"
+
+   chown -Rc mosquitto:mosquitto /mosquitto
+
+   echo "[IOTstack] end self-repair"
    
 fi
 


### PR DESCRIPTION
Following a suggestion from @ukkopahis, this pull request proposes logging self-repair activities.

Guard messages make it clear when self-repair begins and ends:

```
[IOTstack] begin self-repair
…
[IOTstack] end self-repair
```

Between the guard messages:

* `-v` option added to `rsync`
* `-c` option added to `chown`

These cause the respective processes to log any changes they make to persistent storage.

Example. Assume `config/filter.acl` has been deleted and ownership of the `pwfile` folder and its contents has been changed to "pi:pi". Self-repair needs to restore `filter.acl` and restore the ownership to "1883:1883":

```
[IOTstack] begin self-repair
sending incremental file list
./
config/
config/filter.acl
pwfile/

sent 326 bytes  received 50 bytes  752.00 bytes/sec
total size is 1,077  speedup is 2.86
changed ownership of '/mosquitto/pwfile/pwfile' to 1883:1883
[IOTstack] end self-repair
```

Signed-off-by: Phill Kelley <pmk.57t49@lgosys.com>