### PR TITLE
20220117 prometheus - master branch

### DIFF
--- a/.templates/prometheus-cadvisor/service.yml
+++ b/.templates/prometheus-cadvisor/service.yml
@@ -1,0 +1,12 @@
+prometheus-cadvisor:
+  container_name: cadvisor
+  image: zcube/cadvisor:latest
+  restart: unless-stopped
+  ports:
+    - "8082:8080"
+  volumes:
+    - /:/rootfs:ro
+    - /var/run:/var/run:rw
+    - /sys:/sys:ro
+    - /var/lib/docker/:/var/lib/docker:ro
+

--- a/.templates/prometheus-nodeexporter/service.yml
+++ b/.templates/prometheus-nodeexporter/service.yml
@@ -1,0 +1,7 @@
+prometheus-nodeexporter:
+  container_name: nodeexporter
+  image: prom/node-exporter:latest
+  restart: unless-stopped
+  expose:
+    - "9100"
+

--- a/.templates/prometheus/service.yml
+++ b/.templates/prometheus/service.yml
@@ -20,28 +20,4 @@ prometheus:
   depends_on:
     - cadvisor
     - nodeexporter
-  networks:
-    - iotstack_nw
 
-cadvisor:
-  container_name: cadvisor
-  image: zcube/cadvisor:latest
-  restart: unless-stopped
-  ports:
-    - "8082:8080"
-  volumes:
-    - /:/rootfs:ro
-    - /var/run:/var/run:rw
-    - /sys:/sys:ro
-    - /var/lib/docker/:/var/lib/docker:ro
-  networks:
-    - iotstack_nw
-
-nodeexporter:
-  container_name: nodeexporter
-  image: prom/node-exporter:latest
-  restart: unless-stopped
-  expose:
-    - "9100"
-  networks:
-    - iotstack_nw

--- a/docs/Containers/Prometheus.md
+++ b/docs/Containers/Prometheus.md
@@ -1,24 +1,5 @@
 # Prometheus
 
-- [References](#references)
-- [Significant directories and files](#significantFiles)
-- [How Prometheus gets built for IOTstack](#howPrometheusIOTstackGetsBuilt)
-	- [Prometheus source code](#githubSourceCode)
-	- [Prometheus images](#dockerHubImages)
-	- [IOTstack menu](#iotstackMenu)
-	- [IOTstack first run](#iotstackFirstRun)
-	- [Dependencies: *CAdvisor* and *Node Exporter*](#dependencies)
-- [Configuring Prometheus](#configuringPrometheus)
-	- [Configuration directory](#configDir)
-		- [Active configuration file](#activeConfig)
-		- [Reference configuration file](#referenceConfig)
-	- [Environment variables](#environmentVars)
-	- [Migration considerations](#migration)
-- [Upgrading Prometheus](#upgradingPrometheus)
-	- [Prometheus version pinning](#versionPinning)
-
-<hr>
-
 ## <a name="references"> References </a>
 
 * [*Prometheus* home](https://prometheus.io)
@@ -36,13 +17,32 @@
 
 ## <a name="overview"> Overview </a>
 
-Three containers are installed when you select *Prometheus* in the IOTstack menu:
+Prometheus is a collection of three containers:
 
 * *Prometheus*
 * *CAdvisor*
 * *Node Exporter*
 
 The [default configuration](#activeConfig) for *Prometheus* supplied with IOTstack scrapes information from all three containers.
+
+## <a name="installProm"> Installing Prometheus </a>
+
+### <a name="installPromNewMenu"> *if you are running New Menu …* </a>
+
+When you select *Prometheus* in the IOTstack menu, you must also select:
+
+*	*prometheus-cadvisor;* and
+* 	*prometheus-nodeexporter*.
+
+If you do not select all three containers, Prometheus will not start.
+
+### <a name="installPromOldMenu"> *if you are running Old Menu …* </a>
+
+When you select *Prometheus* in the IOTstack menu, the service definition includes the three containers:
+
+* *Prometheus*
+* *CAdvisor*
+* *Node Exporter*
 
 ## <a name="significantFiles"> Significant directories and files </a>
 
@@ -276,11 +276,11 @@ Note:
 
 ## <a name="upgradingPrometheus"> Upgrading *Prometheus* </a>
 
-You can update most containers like this:
+You can update `cadvisor` and `nodeexporter` like this:
 
 ```bash
 $ cd ~/IOTstack
-$ docker-compose pull
+$ docker-compose pull cadvisor nodeexporter
 $ docker-compose up -d
 $ docker system prune
 ```
@@ -290,8 +290,6 @@ In words:
 * `docker-compose pull` downloads any newer images;
 * `docker-compose up -d` causes any newly-downloaded images to be instantiated as containers (replacing the old containers); and
 * the `prune` gets rid of the outdated images.
-
-The auxiliary containers `cadvisor` and `nodeexporter` are updated via this method.
 
 This "simple pull" strategy doesn't work when a *Dockerfile* is used to build a *local image* on top of a *base image* downloaded from [*DockerHub*](https://hub.docker.com). The *local image* is what is running so there is no way for the `pull` to sense when a newer version becomes available.
 


### PR DESCRIPTION
[Issue 472](https://github.com/SensorsIot/IOTstack/issues/472) reports a new-menu problem where selecting Prometheus does not install cadvisor and nodeexporter.

The template `service.yml` for Prometheus contains all three service definitions. It is not clear why cadvisor and nodeexporter are being removed prior to their insertion into the compose file.

> NextCloud and NextCloud_DB are both defined in a single `service.yml`. Both services make it into the compose file so a working pattern exists for this basic approach.

Prior to [PR419](https://github.com/SensorsIot/IOTstack/pull/419), the template contained `build.sh`, `service_cadvisor-arm.yml` and `service_node-exporter.yml` as well as `service.yml`. That was not working under new-menu, possibly explained by the following line in `build.sh`:

```
TODO: Prometheus needs to have a build.py file created before this bash script is executed.
```

This Pull Request adopts a brute-force approach by having three separate templates for new-menu:

* prometheus
* prometheus-cadvisor
* prometheus-nodeexporter

The naming structure ensures all three sort together in the menu.

Documentation updated to make it clear that all three need to be selected.

Networks directives removed from all three as part of related PRs and minimise the potential for conflicts.

Signed-off-by: Phill Kelley <pmk.57t49@lgosys.com>