### PR TITLE
Allow cli parameters to be given

### DIFF
--- a/.templates/influxdb/terminal.sh
+++ b/.templates/influxdb/terminal.sh
@@ -12,4 +12,4 @@ echo "to exit type: EXIT"
 echo ""
 echo "docker exec -it influxdb influx"
 
-docker exec -it influxdb influx
+docker exec -it influxdb influx $*

--- a/.templates/influxdb/terminal.sh
+++ b/.templates/influxdb/terminal.sh
@@ -12,4 +12,4 @@ echo "to exit type: EXIT"
 echo ""
 echo "docker exec -it influxdb influx"
 
-docker exec -it influxdb influx $*
+docker exec -it influxdb influx "$@"


### PR DESCRIPTION
It's useful to give command line parameters to influxdb like this:

.templates/influxdb/terminal.sh -precision rfc3339

This change just gives parameters on to the influx command.