### PR TITLE
20220206 prometheus - master branch - PR 1 of 2

### DIFF
--- a/.templates/prometheus-cadvisor/service.yml
+++ b/.templates/prometheus-cadvisor/service.yml
@@ -1,5 +1,5 @@
 prometheus-cadvisor:
-  container_name: cadvisor
+  container_name: prometheus-cadvisor
   image: zcube/cadvisor:latest
   restart: unless-stopped
   ports:

--- a/.templates/prometheus-nodeexporter/service.yml
+++ b/.templates/prometheus-nodeexporter/service.yml
@@ -1,5 +1,5 @@
 prometheus-nodeexporter:
-  container_name: nodeexporter
+  container_name: prometheus-nodeexporter
   image: prom/node-exporter:latest
   restart: unless-stopped
   expose:

--- a/.templates/prometheus/service.yml
+++ b/.templates/prometheus/service.yml
@@ -18,6 +18,6 @@ prometheus:
     #    - --web.console.libraries=/usr/share/prometheus/console_libraries
     #    - --web.console.templates=/usr/share/prometheus/consoles
   depends_on:
-    - cadvisor
-    - nodeexporter
+    - prometheus-cadvisor
+    - prometheus-nodeexporter
 

--- a/docs/Containers/Prometheus.md
+++ b/docs/Containers/Prometheus.md
@@ -40,9 +40,9 @@ If you do not select all three containers, Prometheus will not start.
 
 When you select *Prometheus* in the IOTstack menu, the service definition includes the three containers:
 
-* *Prometheus*
-* *CAdvisor*
-* *Node Exporter*
+*	*prometheus*
+*	*prometheus-cadvisor;* and
+* 	*prometheus-nodeexporter*.
 
 ## <a name="significantFiles"> Significant directories and files </a>
 
@@ -142,7 +142,7 @@ The remaining instructions in the *Dockerfile* customise the *base image* to pro
 
 The *local image* is instantiated to become your running container.
 
-When you run the `docker images` command after *Prometheus* has been built, you will see two rows for *Prometheus*:
+When you run the `docker images` command after *Prometheus* has been built, you *may* see two rows for *Prometheus*:
 
 ```bash
 $ docker images
@@ -154,7 +154,9 @@ prom/prometheus      latest      3f9575991a6c   3 days ago       169MB
 * `prom/prometheus` is the *base image*; and
 * `iotstack_prometheus`  is the *local image*.
 
-You will see the same pattern in Portainer, which reports the *base image* as "unused". You should not remove the *base* image, even though it appears to be unused.
+You *may* see the same pattern in Portainer, which reports the *base image* as "unused". You should not remove the *base* image, even though it appears to be unused.
+
+> Whether you see one or two rows depends on the version of `docker-compose` you are using and how your version of `docker-compose` builds local images.
 
 ### <a name="dependencies"> Dependencies: *CAdvisor* and *Node Exporter* </a>
 
@@ -315,6 +317,8 @@ Breaking it down into parts:
 Your existing *Prometheus* container continues to run while the rebuild proceeds. Once the freshly-built *local image* is ready, the `up` tells `docker-compose` to do a new-for-old swap. There is barely any downtime for your service.
 
 The `prune` is the simplest way of cleaning up. The first call removes the old *local image*. The second call cleans up the old *base image*.
+
+> Whether an old *base image* exists depends on the version of `docker-compose` you are using and how your version of `docker-compose` builds local images.
 
 ### <a name="versionPinning"> *Prometheus* version pinning </a>
 


### PR DESCRIPTION
Uses `prometheus-` prefix consistently for subordinate containers (service name, container name, dependency name) to address concern raised in comment to [Issue 472](https://github.com/SensorsIot/IOTstack/issues/472#issuecomment-1030104238).

Documentation updated.

Fixes #472

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>