### PR TITLE
20220206 prometheus - old-menu branch - PR 2 of 2

### DIFF
--- a/.templates/prometheus/service.yml
+++ b/.templates/prometheus/service.yml
@@ -18,11 +18,11 @@
       #    - --web.console.libraries=/usr/share/prometheus/console_libraries
       #    - --web.console.templates=/usr/share/prometheus/consoles
     depends_on:
-      - cadvisor
-      - nodeexporter
+      - prometheus-cadvisor
+      - prometheus-nodeexporter
 
-  cadvisor:
-    container_name: cadvisor
+  prometheus-cadvisor:
+    container_name: prometheus-cadvisor
     image: zcube/cadvisor:latest
     restart: unless-stopped
     ports:
@@ -33,8 +33,8 @@
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
 
-  nodeexporter:
-    container_name: nodeexporter
+  prometheus-nodeexporter:
+    container_name: prometheus-nodeexporter
     image: prom/node-exporter:latest
     restart: unless-stopped
     expose:


### PR DESCRIPTION
Uses `prometheus-` prefix consistently for subordinate containers (service name, container name, dependency name) to address concern raised in comment to [Issue 472](https://github.com/SensorsIot/IOTstack/issues/472#issuecomment-1030104238).

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>