### PR TITLE
Fix docker version parsing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -219,6 +219,8 @@ function do_docker_checks() {
 		DOCKER_VERSION_MAJOR=$(echo "$DOCKER_VERSION"| cut -d'.' -f 1)
 		DOCKER_VERSION_MINOR=$(echo "$DOCKER_VERSION"| cut -d'.' -f 2)
 		DOCKER_VERSION_BUILD=$(echo "$DOCKER_VERSION"| cut -d'.' -f 3)
+		DOCKER_VERSION_BUILD=$(echo "$DOCKER_VERSION_BUILD"| cut -f1 -d"-")
+		DOCKER_VERSION_BUILD=$(echo "$DOCKER_VERSION_BUILD"| cut -f1 -d"+")
 
 		if [ "$(minimum_version_check $REQ_DOCKER_VERSION $DOCKER_VERSION_MAJOR $DOCKER_VERSION_MINOR $DOCKER_VERSION_BUILD )" == "true" ]; then
 			[ -f .docker_outofdate ] && rm .docker_outofdate

--- a/menu.sh
+++ b/menu.sh
@@ -279,6 +279,7 @@ function do_docker_checks() {
 
 		DOCKER_VERSION_BUILD=$(echo "$DOCKER_VERSION"| cut -d'.' -f 3)
 		DOCKER_VERSION_BUILD=$(echo "$DOCKER_VERSION_BUILD"| cut -f1 -d"-")
+		DOCKER_VERSION_BUILD=$(echo "$DOCKER_VERSION_BUILD"| cut -f1 -d"+")
 
 		if [ "$(minimum_version_check $REQ_DOCKER_VERSION $DOCKER_VERSION_MAJOR $DOCKER_VERSION_MINOR $DOCKER_VERSION_BUILD )" == "true" ]; then
 			[ -f .docker_outofdate ] && rm .docker_outofdate

--- a/scripts/deps/version_check.py
+++ b/scripts/deps/version_check.py
@@ -1,4 +1,14 @@
+import re
+
 def checkVersion(requiredVersion, currentVersion):
+  """
+  >>> checkVersion('18.2.0', '20.10.11')
+  (True, '', [])
+  >>> checkVersion('18.2.0', '16.3.1')
+  (False, 'Version Check Fail', [False, False, True])
+  >>> checkVersion('18.2.0', '20.10.5+dfsg1')
+  (True, '', [])
+  """
   requiredSplit = requiredVersion.split('.')
 
   if len(requiredSplit) < 2:
@@ -19,7 +29,7 @@ def checkVersion(requiredVersion, currentVersion):
   try:
     currentMajor = int(currentSplit[0])
     currentMinor = int(currentSplit[1])
-    currentBuild = currentSplit[2].split("-")[0]
+    currentBuild = re.split(r'[+-]', currentSplit[2])[0]
     currentBuild = int(currentBuild)
   except:
     return False, 'Invalid Current Version', currentVersion


### PR DESCRIPTION
A docker version like 20.10.5+dfsg1 wasn't recognized. Now strips all '+' and '-' postfixes.

Fixes #447
Fixes #496