### PR TITLE
docs: Add more warnings about the breaking network change

### DIFF
--- a/docs/Basic_setup/index.md
+++ b/docs/Basic_setup/index.md
@@ -559,6 +559,12 @@ This is how **most** containers behave. There are exceptions so it's always a go
 
 ## stack maintenance
 
+!!! danger "Breaking update"
+    Recent changes will require [manual steps](
+    https://github.com/SensorsIot/IOTstack/blob/master/README.md#significant-change-to-networking)
+    or you may get an error like:  
+    `ERROR: Service "influxdb" uses an undefined network "iotstack_nw"`
+
 ### update Raspberry Pi OS
 
 You should keep your Raspberry Pi up-to-date. Despite the word "container" suggesting that *containers* are fully self-contained, they sometimes depend on operating system components ("WireGuard" is an example).

--- a/docs/Updates/index.md
+++ b/docs/Updates/index.md
@@ -2,6 +2,12 @@
 
 Periodically updates are made to project which include new or modified container template, changes to backups or additional features. As these are released your local copy of this project will become out of date. This section deals with how to bring your project to the latest published state.
 
+!!! danger "Breaking update"
+    Recent changes will require [manual steps](
+    https://github.com/SensorsIot/IOTstack/blob/master/README.md#significant-change-to-networking)
+    or you may get an error like:  
+    `ERROR: Service "influxdb" uses an undefined network "iotstack_nw"`
+
 ## Quick instructions
 
 1. backup your current settings: `cp docker-compose.yml docker-compose.yml.bak`


### PR DESCRIPTION
The recent network change breaks the stack for existing users, requiring
manual fixes.

Add links to doc pages where Discord users have reportedly looked for
solutions, without finding the right place.

Closes #490

![image](https://user-images.githubusercontent.com/95980324/158698558-d60aa534-d80f-42ed-853c-5d36213ebb51.png)
![image](https://user-images.githubusercontent.com/95980324/158699174-1c5c8b86-205d-4004-a2fa-4882ff63a72b.png)
![IOTstack-network-update-problem2](https://user-images.githubusercontent.com/95980324/163127094-6e574955-cde7-4d5b-b26c-f9276d19664e.png)

