### PR TITLE
20220320 wireguard documentation

### DIFF
--- a/docs/Containers/WireGuard.md
+++ b/docs/Containers/WireGuard.md
@@ -540,7 +540,7 @@ $ docker exec wireguard bash -c 'apt update ; apt install -y tcpdump'
 To monitor traffic:
 
 ```bash
-$ docker exec wireguard tcpdump -i eth0 -n udp port «internal»
+$ docker exec -t wireguard tcpdump -i eth0 -n udp port «internal»
 ```
 
 Press <kbd>ctrl</kbd><kbd>c</kbd> to terminate the capture.
@@ -568,6 +568,10 @@ There will be a short delay. The expected answer is either:
 
 * `«public»/udp open|filtered unknown` = router is listening
 * `«public»/udp closed unknown` = router is not listening
+
+Note:
+
+* Some routers always return the same answer irrespective of whether the router is or isn't listening to the port being checked. This stops malicious users from working out which ports might be open. This test will not be useful if your router behaves like that. You will have to rely on `tcpdump` telling you whether your router is forwarding traffic to your Raspberry Pi.
 
 ## The read-only flag
 


### PR DESCRIPTION
Adds `-t` (allocate pseudo tty) flag to `docker exec` call to run
`tcpdump` inside the WireGuard container. This speeds up delivery of
packet-capture output to the terminal.

Adds a note to the test for checking the router's public port to
explain that routers often return misleading information as a
security feature, meaning the test will not be definitive.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>