### PR TITLE
20220323 mosquitto - old-menu branch - PR 2 of 2

### DIFF
--- a/.templates/mosquitto/Dockerfile
+++ b/.templates/mosquitto/Dockerfile
@@ -1,5 +1,12 @@
+# supported build argument
+ARG MOSQUITTO_BASE=eclipse-mosquitto:latest
+
 # Download base image
-FROM eclipse-mosquitto:latest
+FROM $MOSQUITTO_BASE
+
+# re-reference supported argument and copy to environment var
+ARG MOSQUITTO_BASE
+ENV MOSQUITTO_BASE=${MOSQUITTO_BASE}
 
 # see https://github.com/alpinelinux/docker-alpine/issues/98
 RUN sed -i 's/https/http/' /etc/apk/repositories
@@ -33,5 +40,14 @@ ENV IOTSTACK_ENTRY_POINT=
 
 # IOTstack also declares these paths
 VOLUME ["/mosquitto/config", "/mosquitto/pwfile"]
+
+# set container metadata
+LABEL com.github.SensorsIot.IOTstack.Dockerfile.build-args="${MOSQUITTO_BASE}"
+LABEL com.github.SensorsIot.IOTstack.Dockerfile.based-on="https://github.com/eclipse/mosquitto"
+
+# don't need these variables in the running container
+ENV MOSQUITTO_BASE=
+ENV HEALTHCHECK_SCRIPT=
+ENV IOTSTACK_ENTRY_POINT=
 
 # EOF

--- a/.templates/mosquitto/service.yml
+++ b/.templates/mosquitto/service.yml
@@ -1,6 +1,9 @@
   mosquitto:
     container_name: mosquitto
-    build: ./.templates/mosquitto/.
+    build:
+      context: ./.templates/mosquitto/.
+      args:
+      - MOSQUITTO_BASE=eclipse-mosquitto:latest
     restart: unless-stopped
     environment:
       - TZ=Etc/UTC


### PR DESCRIPTION
Changed Dockerfile and default service definition to support
`MOSQUITTO_BASE` argument which defaults to `eclipse-mosquitto:latest`.
This means users will not have to edit `.templates/mosquitto/Dockerfile`
in order to pin to a specific version.

Also added image metadata fields (`build-args` and `based-on`) and
unset environment variables not needed outside Dockerfile scope.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>