### PR TITLE
20220327 Blynk Server documentation

### DIFF
--- a/docs/Containers/Blynk_server.md
+++ b/docs/Containers/Blynk_server.md
@@ -72,14 +72,14 @@ When you select Blynk Server in the IOTstack menu, the *template service definit
 
 On a first install of IOTstack, you run the menu, choose your containers, and are told to do this:
 
-```bash
+```console
 $ cd ~/IOTstack
 $ docker-compose up -d
 ```
 
 `docker-compose` reads the *Compose* file. When it arrives at the `blynk_server` fragment, it finds:
 
-```
+```yaml
   blynk_server:
     build:
       context: ./.templates/blynk_server/.
@@ -99,7 +99,7 @@ The `BLYNK_SERVER_VERSION` argument is passed into the build process. This impli
 
 The *Dockerfile* begins with:
 
-```
+```Dockerfile
 FROM ubuntu
 ```
 
@@ -117,7 +117,7 @@ The ***local image*** is instantiated to become your running container.
 
 When you run the `docker images` command after Blynk Server has been built, you *may* see two rows that are relevant:
 
-```bash
+```console
 $ docker images
 REPOSITORY              TAG      IMAGE ID       CREATED         SIZE
 iotstack_blynk_server   latest   3cd6445f8a7e   3 hours ago     652MB
@@ -135,7 +135,7 @@ You *may* see the same pattern in *Portainer*, which reports the ***base image**
 
 You can inspect Blynk Server's log by:
 
-```
+```console
 $ docker logs blynk_server
 ```
 
@@ -153,7 +153,7 @@ The first time you launch the `blynk_server` container, the following structure 
 
 The two `.properties` files can be used to alter Blynk Server's configuration. When you make change to these files, you activate then by restarting the container:
 
-```
+```console
 $ cd ~/IOTstack
 $ docker-compose restart blynk_server
 ```
@@ -162,7 +162,7 @@ $ docker-compose restart blynk_server
 
 Erasing Blynk Server's persistent storage area triggers self-healing and restores known defaults:
 
-```
+```console
 $ cd ~/IOTstack
 $ docker-compose rm --force --stop -v blynk_server
 $ sudo rm -rf ./volumes/blynk_server
@@ -172,7 +172,7 @@ Note:
 
 * You can also remove individual configuration files and then trigger self-healing. For example, if you decide to edit `server.properties` and make a mess, you can restore the original default version like this:
 
-	```
+	```console
 	$ cd ~/IOTstack
 	$ rm volumes/blynk_server/config/server.properties
 	$ docker-compose restart blynk_server
@@ -186,7 +186,7 @@ At the time of writing, version 0.41.16 was the most up-to-date. Suppose that ve
 
 1. Edit your *Compose* file to change the version nuumber:
 
-	```
+	```yaml
 	  blynk_server:
 	    build:
 	      context: ./.templates/blynk_server/.
@@ -202,7 +202,7 @@ At the time of writing, version 0.41.16 was the most up-to-date. Suppose that ve
 
 	- If you only want to reconstruct the **local** image:
 
-		```
+		```console
 		$ cd ~/IOTstack
 		$ docker-compose up --build -d blynk_server
 		$ docker system prune -f
@@ -210,7 +210,7 @@ At the time of writing, version 0.41.16 was the most up-to-date. Suppose that ve
 
 	- If you want to update the Ubuntu **base** image at the same time:
 
-		```
+		```console
 		$ cd ~/IOTstack
 		$ docker-compose build --no-cache --pull blynk_server
 		$ docker-compose up -d blynk_server
@@ -243,7 +243,7 @@ You may encounter browser security warnings which you will have to acknowledge i
 2. Save changes.
 3. Restart the container using either Portainer or the command line:
 
-	```
+	```console
 	$ cd ~/IOTstack
 	$ docker-compose restart blynk_server
 	```

--- a/docs/Containers/Blynk_server.md
+++ b/docs/Containers/Blynk_server.md
@@ -2,7 +2,7 @@
 
 This document discusses an IOTstack-specific version of Blynk-Server. It is built on top of an [Ubuntu](https://hub.docker.com/_/ubuntu) base image using a *Dockerfile*.
 
-## References
+## <a name="references"></a>References
 
 - [Ubuntu base image](https://hub.docker.com/_/ubuntu) at DockerHub
 - [Peter Knight Blynk-Server fork](https://github.com/Peterkn2001/blynk-server) at GitHub (includes documentation)
@@ -18,7 +18,7 @@ Acknowledgement:
 
 - Original writeup from @877dev
 
-## Significant directories and files
+## <a name="significantFiles"></a>Significant directories and files
 
 ```
 ~/IOTstack
@@ -56,19 +56,19 @@ Everything in ❽:
 * will be replaced if it is not present when the container starts; but
 * will never be overwritten if altered by you.
 
-## How Blynk Server gets built for IOTstack
+## <a name="howBlynkServerIOTstackGetsBuilt"></a>How Blynk Server gets built for IOTstack
 
-### GitHub Updates
+### <a name="dockerHubImages"></a>GitHub Updates 
 
 Periodically, the source code is updated and a new version is released. You can check for the latest version at the [releases page](https://github.com/Peterkn2001/blynk-server/releases/).
  
-### IOTstack menu
+### <a name="iotstackMenu"></a>IOTstack menu
 
 When you select Blynk Server in the IOTstack menu, the *template service definition* is copied into the *Compose* file.
 
 > Under old menu, it is also copied to the *working service definition* and then not really used.
 
-### IOTstack first run
+### <a name="iotstackFirstRun"></a>OTstack first run 
 
 On a first install of IOTstack, you run the menu, choose your containers, and are told to do this:
 
@@ -131,7 +131,7 @@ You *may* see the same pattern in *Portainer*, which reports the ***base image**
 
 > Whether you see one or two rows depends on the version of `docker-compose` you are using and how your version of `docker-compose` builds local images.
 
-## Logging
+## <a name="logging"></a>Logging
 
 You can inspect Blynk Server's log by:
 
@@ -139,7 +139,7 @@ You can inspect Blynk Server's log by:
 $ docker logs blynk_server
 ```
 
-## Changing Blynk Server's configuration
+## <a name="editConfiguration"></a>Changing Blynk Server's configuration
 
 The first time you launch the `blynk_server` container, the following structure will be created in the persistent storage area:
 
@@ -158,7 +158,7 @@ $ cd ~/IOTstack
 $ docker-compose restart blynk_server
 ```
 
-## Getting a clean slate
+## <a name="cleanSlate"></a>Getting a clean slate
 
 Erasing Blynk Server's persistent storage area triggers self-healing and restores known defaults:
 
@@ -178,7 +178,7 @@ Note:
 	$ docker-compose restart blynk_server
 	```
 
-## Upgrading Blynk Server
+## <a name="upgradingBlynkServer"></a>Upgrading Blynk Server
 
 To find out when a new version has been released, you need to visit the [Blynk-Server releases](https://github.com/Peterkn2001/blynk-server/releases/) page at GitHub.
 
@@ -220,11 +220,11 @@ At the time of writing, version 0.41.16 was the most up-to-date. Suppose that ve
 
 		The second `prune` will only be needed if there is an old *base image* and that, in turn, depends on the version of `docker-compose` you are using and how your version of `docker-compose` builds local images.
 
-## Using Blynk Server
+## <a name="usingBlynkServer"></a>Using Blynk Server
 
 See the [References](#references) for documentation links.
 
-### Connecting to the administrative UI
+### <a name="blynkAdmin"></a>Connecting to the administrative UI
 
 To connect to the administrative interface, navigate to:
 
@@ -237,7 +237,7 @@ You may encounter browser security warnings which you will have to acknowledge i
 - username = `admin@blynk.cc`
 - password = `admin`
 
-### Change username and password
+### <a name="changePassword"></a>Change username and password
 
 1. Click on Users > "email address" and edit email, name and password. 
 2. Save changes.
@@ -248,19 +248,19 @@ You may encounter browser security warnings which you will have to acknowledge i
 	$ docker-compose restart blynk_server
 	```
 
-### Setup gmail
+### <a name="gmailSetup"></a>Setup gmail
 
 Optional step, useful for getting the auth token emailed to you.
 (To be added once confirmed working....)
 
-### iOS/Android app setup
+### <a name="mobileSetup"></a>iOS/Android app setup
 
 1. When setting up the application on your mobile be sure to select "custom" setup [see](https://github.com/Peterkn2001/blynk-server#app-and-sketch-changes).
 2. Press "New Project"
 3. Give it a name, choose device "Raspberry Pi 3 B" so you have plenty of [virtual pins](http://help.blynk.cc/en/articles/512061-what-is-virtual-pins) available, and lastly select WiFi.
 4. Create project and the [auth token](https://docs.blynk.cc/#getting-started-getting-started-with-the-blynk-app-4-auth-token) will be emailed to you (if emails configured). You can also find the token in app under the phone app settings, or in the admin web interface by clicking Users>"email address" and scroll down to token.
 
-### Quick usage guide for app
+### <a name="quickAppGuide"></a>Quick usage guide for app
 
 1. Press on the empty page, the widgets will appear from the right.
 2. Select your widget, let's say a button.
@@ -273,7 +273,7 @@ Optional step, useful for getting the auth token emailed to you.
 
 Enter Node-Red.....
 
-### Node-RED
+### <a name="enterNodeRed"></a>Node-RED
 
 1. Install `node-red-contrib-blynk-ws` from Manage Palette.
 2. Drag a "write event" node into your flow, and connect to a debug node

--- a/docs/Containers/Blynk_server.md
+++ b/docs/Containers/Blynk_server.md
@@ -68,7 +68,7 @@ When you select Blynk Server in the IOTstack menu, the *template service definit
 
 > Under old menu, it is also copied to the *working service definition* and then not really used.
 
-### <a name="iotstackFirstRun"></a>OTstack first run 
+### <a name="iotstackFirstRun"></a>IOTstack first run 
 
 On a first install of IOTstack, you run the menu, choose your containers, and are told to do this:
 


### PR DESCRIPTION
Repairs broken internal hyperlinks by restoring internal anchors.

Restored anchors converted to null-anchor form.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>