### PR TITLE
20220327 Home Assistant documentation

### DIFF
--- a/docs/Containers/Home-Assistant.md
+++ b/docs/Containers/Home-Assistant.md
@@ -27,11 +27,16 @@ Each version:
 
 Home Assistant Container runs as a **single** Docker container, and doesn't support all the features that Supervised Home Assistant does (such as add-ons). Supervised Home Assistant runs as a **collection** of Docker containers under its own orchestration.
 
-Technically, both versions of Home Assistant can be installed on your Raspberry Pi but you can't **run** both at the same time. Each version runs in "host mode" and binds to port 8123 so, in practice, the first version to start will claim the port and the second will then be blocked.
+The **only** method supported by IOTstack is Home Assistant Container.
 
-IOTstack used to offer a menu entry leading to a convenience script that could install Supervised Home Assistant but that stopped working when Home Assistant changed their approach. Now, the only method supported by IOTstack is Home Assistant Container.
+> To understand why, see [about Supervised Home Assistant](#hassioBackground).
 
-### <a name="installHAContainer"></a>Installing Home Assistant Container
+If Home Assistant Container will not do what you want then, basically, you will need two Raspberry Pis:
+
+* One running Raspberry Pi OS ("Raspbian") hosting IOTstack; and
+* Another dedicated to running [Home Assistant Operating System](https://www.home-assistant.io/installation/raspberrypi).
+
+## <a name="installHAContainer"></a>Installing Home Assistant Container
 
 Home Assistant (Container) can be found in the `Build Stack` menu. Selecting it in this menu results in a service definition being added to:
 
@@ -55,121 +60,6 @@ The normal IOTstack commands apply to Home Assistant Container such as:
 $ cd ~/IOTstack
 $ docker-compose up -d
 ```
-
-### <a name="installHASupervised"></a>Installing Supervised Home Assistant
-
-The direction being taken by the Home Assistant folks is to supply a ready-to-run image for your Raspberry Pi. That effectively dedicates your Raspberry Pi to Home Assistant and precludes the possibility of running alongside IOTstack and containers like Mosquitto, InfluxDB, Node-RED, Grafana, PiHole and WireGuard.
-
-Alternatively you can try to manually install Supervised Home Assistant using their [installation instructions for advanced users](https://github.com/home-assistant/supervised-installer) and when it works, install IOTstack. In theory this should work, but isn't tested or supported.
-
-The recommended approach is to start from a clean slate and use [PiBuilder](https://github.com/Paraphraser/PiBuilder).
-
-When you visit the PiBuilder link you may well have a reaction like "all far too complicated" but you should try to get past that. PiBuilder has two main use-cases:
-
-1. Getting a Raspberry Pi built for IOTstack (and, optionally, Supervised Home Assistant) with the least fuss.
-2. Letting you record all your own customisations so that you can rebuild your Pis quickly with all your customisations already in place (the "magic smoke" scenario).
-
-It's the second use-case that produces most of the apparent complexity you see when you read the [PiBuilder README](https://github.com/Paraphraser/PiBuilder/blob/master/README.md) for the first time.
-
-The first time you use PiBuilder, the process boils down to:
-
-1. Clone the PiBuilder repo onto your support host (Mac, Windows, etc).
-2. Customise two files within the PiBuilder scope:
-
-	- `wpa_supplicant.conf`
-	- `options.sh` where, among other things, you will enable:
-
-		- `HOME_ASSISTANT_SUPERVISED_INSTALL=true`
-
-3. Choose a Raspbian image and transfer it to your installation media (SD/SSD). The imaging tools typically finish by ejecting the installation media.
-4. Re-mount the installation media on your support host and either:
-
-	- Run the supplied `setup_boot_volume.sh` script (if your support host is macOS or Unix); or
-	- Just drag the *contents* of the PiBuilder "boot" folder into the top level of the "/boot" partition on your installation media (if your support host is Windows).
-
-5. Move the installation media to your Raspberry Pi and apply power.
-6. Run the scripts in order:
-
-	Step | Command run on support host       | Command run on Raspberry Pi
-	:---:|-----------------------------------|-------------
-	1    | `ssh -4 pi@raspberrypi.local`     |
-	2    |                                   | `/boot/scripts/01_setup.sh «name»`
-	3    | `ssh-keygen -R raspberrypi.local` |
-	4    | `ssh -4 pi@«name».local`          |
-	5    |                                   | `/boot/scripts/02_setup.sh`
-	6    | `ssh pi@«name».local`             |
-	7    |                                   | `/boot/scripts/03_setup.sh`
-	8    | `ssh pi@«name».local`             |
-	9    |                                   | `/boot/scripts/04_setup.sh`
-	10   | `ssh pi@«name».local`             |
-	11   |                                   | `/boot/scripts/05_setup.sh`
-
-	where «name» is the name you give to your Raspberry Pi (eg "iot-hub").
-
-After step 9, Supervised Home Assistant will be running. The `04_setup.sh` script also deals with the [random MACs](#aboutRandomMACs) problem. After step 11, you'll be able to either:
-
-1. Restore a backup; or
-2. Run the IOTstack menu and choose your containers.
-
-## <a name="aboutRandomMACs"></a>Why random MACs are such a hassle
-
-> This material was originally posted as part of [Issue 312](https://github.com/SensorsIot/IOTstack/issues/312). It was moved here following a suggestion by [lole-elol](https://github.com/lole-elol).
-
-When you connect to a Raspberry Pi via SSH (Secure Shell), that's a layer 7 protocol that is riding on top of TCP/IP. TCP (Transmission Control Protocol) is a layer 4 connection-oriented protocol which rides on IP (Internet Protocol) which is a layer 3 protocol. So far, so good.
-
-But you also need to know what happens at layers 2 and 1. When your SSH client (eg Mac or PC or another Unix box) opens its SSH connection, at layer 3 the IP stack applies the subnet mask against the IP addresses of both the source device (your Mac, PC, etc) and destination device (Raspberry Pi) to split them into "network portion" (on the left) and "host portion" on the right. It then compares the two network portions and, if they are the same, it says "local network".
-
-> To complete the picture, if they do not compare the same, then IP substitutes the so-called "default gateway" address (ie your router) and repeats the mask-and-compare process which, unless something is seriously mis-configured, will result in those comparing the same and being "local network". This is why data-comms gurus sometimes say, "all networking is local".
-
-What happens next depends on the data communications media but we'll assume Ethernet and WiFi seeing as they are pretty much interchangeable for our purposes.
-
-The source machine (Mac, PC, etc) issues an ARP (address resolution protocol). It is a broadcast frame (we talk about "frames" rather than "packets" at Layer 2) asking the question, "who has this destination IP address?" The Raspberry Pi responds with a unicast packet saying, "that's me" and part of that includes the MAC (media access control) address of the Raspberry Pi. The source machine only does this **once** (and this is a key point). It assumes the relationship between IP address and MAC address will not change and it adds the relationship to its "ARP cache". You can see the cache on any Unix computer with:
-
-```bash
-$ arp -a
-```
-
-The Raspberry Pi makes the same assumption: it has learned both the IP and MAC address of the source machine (Mac, PC, etc) from the ARP request and has added that to its own ARP cache.
-
-In addition, every layer two switch (got one of those in your home?) has been snooping on this traffic and has learned, for each of its ports, which MAC address(es) are on those ports.
-
-Not "MAC **and** IP". A switch works at Layer 2. All it sees are frames. It only caches MAC addresses!
-
-When the switch saw the "who has?" ARP broadcast, it replicated that out of all of its ports but when the "that's me" came back from the Raspberry Pi as a unicast response, it only went out on the switch port where the source machine (Mac, PC, etc) was attached.
-
-After that, it's all caching. The Mac or PC has a packet to send to the Pi. It finds the hit in its ARP cache, wraps the packet in a frame and sends it out its Ethernet or WiFi interface. Any switches receive the frame, consult their own tables, and send the frame out the port on the next hop to the destination device. It doesn't matter whether you have one switch or several in a cascade, they have all learned the "next hop" to each destination MAC address they have seen. 
-
-Ditto when the Pi sends back any reply packets. ARP. Switch. Mac/PC. All cached.
-
-The same basic principles apply, irrespective of whether the "switching function" is wired (Ethernet) or WiFi, so it doesn't really matter if your home arrangement is as straightforward as Mac or PC and Pi, both WiFi, via a local WiFi "hub" which is either standalone or part of your router. If something is capable of learning where a MAC is, it does.
-
-Still so far so good.
-
-Now comes the problem. You have established an SSH session connected to the Pi over its WiFi interface. You install Network Manager. As part of its setup, Network Manager discards the **fixed** MAC address which is burned into the Pi's WiFi interface and substitutes a randomly generated MAC address. It doesn't ask for permission to do that. It doesn't warn you it's about to do it. It just does it.
-
-When the WiFi interface comes up, it almost certainly "speaks" straight away via DHCP to ask for an IP address. The DHCP server looks in its own table of MAC-to-IP associations (fixed or dynamic, doesn't matter) and says "never seen **that** MAC before - here's a brand new IP address lease".
-
-The DHCP request is broadcast so all the switches will have learned the new MAC but they'll also still have the old MAC (until it times out). The Mac/PC will receive the DHCP broadcast but, unless it's the DHCP server, will discard it. Either way, it has no means of knowing that this new random MAC belongs to the Pi so it can't do anything sensible with the information.
-
-Meanwhile, SSH is trying to keep the session alive. It still thinks "old IP address" and its ARP cache still thinks old IP belongs to old MAC. Switches know where the frames are meant to go but even if a frame does get somewhere near the Pi, the Pi's NIC (network interface card) ignores it because it's now the wrong destination MAC. The upshot is that SSH looks like the session has frozen and it will eventually time-out with a broken pipe.
-
-To summarise: Network Manager has changed the MAC without so much as a by-your-leave and, unless you have assigned static IP addresses **in the Raspberry Pi** it's quite likely that the Pi will have a different IP address as well. But even a static IP can't save you from the machinations of Network Manager!
-
-The Pi is as happy as the proverbial Larry. It goes on, blissfully unaware that it has just confused the heck out of everything else. You can speed-up some of the activities that need to happen before everything gets going again. You can do things like clear the old entry from the ARP cache on the Mac/PC. You can try to force a multicast DNS daemon restart so that the "raspberrypi.local" address gets updated more quickly but mDNS is a distributed database so it can be hit and miss (and can sometimes lead to complaints about two devices trying to use the same name). Usually, the most effective thing you can do is pull power from the Pi, reboot your Mac/PC (easiest way to clear its ARP cache) and then apply power to the Pi so that it announces its mDNS address at the right time for the newly-booted Mac/PC to hear it and update its mDNS records. 
-
-That's why the installation advice says words to the effect of:
-
-> whatever else you do, **don't** try to install Network Manager while you're connected over WiFi. If SSH is how you're going to do it, you're in for a world of pain if you don't run an Ethernet cable for at least that part of the process.
-
-And it does get worse, of course. Installing Network Manager turns on random WiFi MAC. You can turn it off and go back to the fixed MAC. But then, when you install Docker, it happens again. It may also be that other packages come along in future and say, "hey, look, Network Manager is installed - let's take advantage of that" and it happens again when you least expect it.
-
-Devices changing their MACs at random is becoming reasonably common. If you have a mobile device running a reasonably current OS, it is probably changing its MAC all the time. The idea is to make it hard for Fred's Corner Store to track you and conclude, "Hey, Alex is back in the shop again."
-
-Random MACs are not a problem for a **client** device like a phone, tablet or laptop. But they are definitely a serious problem for a **server** device.
-
-> In TCP/IP any device can be a client or a server for any protocol. The distinction here is about *typical* use. A mobile device is not usually set up to *offer* services like MQTT or Node-RED. It typically *initiates* connections with servers like Docker containers running on a Raspberry Pi.
-
-It is not just configuration-time SSH sessions that break. If you decide to leave Raspberry Pi random Wifi MAC active **and** you have other clients (eq IoT devices) communicating with the Pi over WiFi, you will wrong-foot those clients each time the Raspberry Pi reboots. Data communications services from those clients will be impacted until those client devices time-out and catch up.
 
 ## <a name="usingBluetooth"></a>Using bluetooth from the container
 
@@ -319,3 +209,22 @@ your RPi hostname is raspberrypi)
     outside your LAN(e.g. using a mobile phone):
     `https://homeassistant.<yourdomain>.duckdns.org/` Now the certificate
     should work without any warnings.
+
+## <a name="hassioBackground"></a>about Supervised Home Assistant
+
+IOTstack used to offer a menu entry leading to a convenience script that could install Supervised Home Assistant. That script stopped working when Home Assistant changed their approach. The script's author [made it clear](https://github.com/Kanga-Who/home-assistant/blob/master/Supervised%20on%20Raspberry%20Pi%20with%20Debian.md) that script's future was bleak so the affordance was [removed from IOTstack](https://github.com/SensorsIot/IOTstack/pull/493).
+
+For a time, you could manually install Supervised Home Assistant using their [installation instructions for advanced users](https://github.com/home-assistant/supervised-installer). Once you got HA working, you could install IOTstack, and the two would (mostly) happily coexist.
+
+The direction being taken by the Home Assistant folks is to supply a [ready-to-run image for your Raspberry Pi](https://www.home-assistant.io/installation/raspberrypi). They still support the installation instructions for advanced users but the [requirements](https://github.com/home-assistant/architecture/blob/master/adr/0014-home-assistant-supervised.md#supported-operating-system-system-dependencies-and-versions) are very specific. In particular:
+
+> Debian Linux Debian 11 aka Bullseye (no derivatives)
+
+Raspberry Pi OS is a Debian *derivative* and it is becoming increasingly clear that the "no derivatives" part of that requirement must be taken literally and seriously. Recent examples of significant incompatibilities include:
+
+* [introducing a dependency on `grub` (GRand Unified Bootloader)](https://github.com/home-assistant/supervised-installer/pull/201). The Raspberry Pi does not use `grub` but the change is actually about forcing Control Groups version 1 when the Raspberry Pi uses version 2.
+* [unilaterally starting `systemd-resolved`](https://github.com/home-assistant/supervised-installer/pull/202). This is a DNS resolver which claims port 53. That means you can't your own DNS service like PiHole, AdGuardHome or BIND9 as an IOTstack container. 
+
+Because of the self-updating nature of Supervised Home Assistant, your Raspberry Pi might be happily running Supervised Home Assistant plus IOTstack one day, and suddenly start misbehaving the next day, simply because Supervised Home Assistant assumed it was in total control of your Raspberry Pi.
+
+If you want Supervised Home Assistant to work, reliably, it really needs to be its own dedicated appliance. If you want IOTstack to work, reliably, it really needs to be kept well away from Supervised Home Assistant. If you want both Supervised Home Assistant and IOTstack, you really need two Raspberry Pis.

--- a/docs/Containers/Home-Assistant.md
+++ b/docs/Containers/Home-Assistant.md
@@ -2,7 +2,7 @@
 
 Home Assistant is a home automation platform. It is able to track and control all devices at your home and offer a platform for automating control.
 
-## References
+## <a name="references"></a>References
 
 - [Home Assistant home page](https://www.home-assistant.io/)
 
@@ -13,7 +13,7 @@ Home Assistant is a home automation platform. It is able to track and control al
 - [DockerHub](https://hub.docker.com/r/homeassistant/home-assistant/)
 
 
-## Home Assistant: two versions
+## <a name="twoVersions"></a>Home Assistant: two versions
 
 There are two versions of Home Assistant:
 
@@ -31,7 +31,7 @@ Technically, both versions of Home Assistant can be installed on your Raspberry 
 
 IOTstack used to offer a menu entry leading to a convenience script that could install Supervised Home Assistant but that stopped working when Home Assistant changed their approach. Now, the only method supported by IOTstack is Home Assistant Container.
 
-### Installing Home Assistant Container
+### <a name="installHAContainer"></a>Installing Home Assistant Container
 
 Home Assistant (Container) can be found in the `Build Stack` menu. Selecting it in this menu results in a service definition being added to:
 
@@ -56,7 +56,7 @@ $ cd ~/IOTstack
 $ docker-compose up -d
 ```
 
-### Installing Supervised Home Assistant
+### <a name="installHASupervised"></a>Installing Supervised Home Assistant
 
 The direction being taken by the Home Assistant folks is to supply a ready-to-run image for your Raspberry Pi. That effectively dedicates your Raspberry Pi to Home Assistant and precludes the possibility of running alongside IOTstack and containers like Mosquitto, InfluxDB, Node-RED, Grafana, PiHole and WireGuard.
 
@@ -106,12 +106,12 @@ The first time you use PiBuilder, the process boils down to:
 
 	where «name» is the name you give to your Raspberry Pi (eg "iot-hub").
 
-After step 9, Supervised Home Assistant will be running. The `04_setup.sh` script also deals with the [random MACs](#why-random-macs-are-such-a-hassle) problem. After step 11, you'll be able to either:
+After step 9, Supervised Home Assistant will be running. The `04_setup.sh` script also deals with the [random MACs](#aboutRandomMACs) problem. After step 11, you'll be able to either:
 
 1. Restore a backup; or
 2. Run the IOTstack menu and choose your containers.
 
-## Why random MACs are such a hassle
+## <a name="aboutRandomMACs"></a>Why random MACs are such a hassle
 
 > This material was originally posted as part of [Issue 312](https://github.com/SensorsIot/IOTstack/issues/312). It was moved here following a suggestion by [lole-elol](https://github.com/lole-elol).
 
@@ -171,7 +171,8 @@ Random MACs are not a problem for a **client** device like a phone, tablet or la
 
 It is not just configuration-time SSH sessions that break. If you decide to leave Raspberry Pi random Wifi MAC active **and** you have other clients (eq IoT devices) communicating with the Pi over WiFi, you will wrong-foot those clients each time the Raspberry Pi reboots. Data communications services from those clients will be impacted until those client devices time-out and catch up.
 
-## Using bluetooth from the container
+## <a name="usingBluetooth"></a>Using bluetooth from the container
+
 In order to be able to use BT & BLE devices from HA integrations, make sure that bluetooth is enabled and powered on at the start of the (Rpi) host by editing `/etc/bluetooth/main.conf`:
 
 ```conf
@@ -190,7 +191,7 @@ UP
 ```
 ref: https://scribles.net/auto-power-on-bluetooth-adapter-on-boot-up/
 
-## HTTPS with a valid SSL certificate
+## <a name="httpsWithSSLcert"></a>HTTPS with a valid SSL certificate
 
 Some HA integrations (e.g google assistant) require your HA API to be
 accessible via https with a valid certificate. You can configure HA to do this:
@@ -209,70 +210,83 @@ your RPi hostname is raspberrypi)
 2. Make sure you have duckdns working.
 3. On your internet router, forward public port 443 to the RPi port 443
 4. Add swag to ~/IOTstack/docker-compose.yml beneath the `services:`-line:
-```
-  swag:
-    image: ghcr.io/linuxserver/swag
-    cap_add:
-      - NET_ADMIN
-    environment:
-      - PUID=1000
-      - PGID=1000
-      - TZ=Etc/UTC
-      - URL=<yourdomain>.duckdns.org
-      - SUBDOMAINS=wildcard
-      - VALIDATION=duckdns
-      - DUCKDNSTOKEN=<token>
-      - CERTPROVIDER=zerossl
-      - EMAIL=<e-mail> # required when using zerossl
-    volumes:
-      - ./volumes/swag/config:/config
-    ports:
-      - 443:443
-    restart: unless-stopped
-```
-    Replace the bracketed values. Do NOT use any "-characters to enclose the values.
+
+	```yaml
+	  swag:
+	    image: ghcr.io/linuxserver/swag
+	    cap_add:
+	      - NET_ADMIN
+	    environment:
+	      - PUID=1000
+	      - PGID=1000
+	      - TZ=Etc/UTC
+	      - URL=<yourdomain>.duckdns.org
+	      - SUBDOMAINS=wildcard
+	      - VALIDATION=duckdns
+	      - DUCKDNSTOKEN=<token>
+	      - CERTPROVIDER=zerossl
+	      - EMAIL=<e-mail> # required when using zerossl
+	    volumes:
+	      - ./volumes/swag/config:/config
+	    ports:
+	      - 443:443
+	    restart: unless-stopped
+	```
+
+	Replace the bracketed values. Do NOT use any "-characters to enclose the values.
 
 5. Start the swag container, this creates the file to be edited in the next step:
-   ```
-   cd ~/IOTstack && docker-compose up -d
-   ```
 
-    Check it starts up OK: `docker-compose logs -f swag`. It will take a minute or two before it finally logs "Server ready".
+	```bash
+	$ cd ~/IOTstack
+	$ docker-compose up -d
+	```
+
+	Check it starts up OK: `docker-compose logs -f swag`. It will take a minute or two before it finally logs "Server ready".
 
 6. Enable reverse proxy for `raspberrypi.local`. `homassistant.*` is already by default. and fix homeassistant container name ("upstream_app"):
-      ```
-      sed -e 's/server_name/server_name *.local/' \
-          volumes/swag/config/nginx/proxy-confs/homeassistant.subdomain.conf.sample \
-          > volumes/swag/config/nginx/proxy-confs/homeassistant.subdomain.conf
-      ```
+
+	```bash
+	$ cd ~/IOTstack
+	$ sed -e 's/server_name/server_name *.local/' \
+	  volumes/swag/config/nginx/proxy-confs/homeassistant.subdomain.conf.sample \
+	  > volumes/swag/config/nginx/proxy-confs/homeassistant.subdomain.conf
+	```
 
 7. Forward to correct IP when target is a container running in "network_mode:
    host" (like Home Assistant does):
-   ```
-   cat << 'EOF' | sudo tee volumes/swag/config/custom-cont-init.d/add-host.docker.internal.sh
-   #!/bin/sh
-   DOCKER_GW=$(ip route | awk 'NR==1 {print $3}')
 
-   sed -i -e "s/upstream_app .*/upstream_app ${DOCKER_GW};/" \
-       /config/nginx/proxy-confs/homeassistant.subdomain.conf
-   EOF
-   sudo chmod u+x volumes/swag/config/custom-cont-init.d/add-host.docker.internal.sh
-   ```
+	```bash
+	cd ~/IOTstack
+	cat << 'EOF' | sudo tee volumes/swag/config/custom-cont-init.d/add-host.docker.internal.sh
+	#!/bin/sh
+	DOCKER_GW=$(ip route | awk 'NR==1 {print $3}')
+	
+	sed -i -e "s/upstream_app .*/upstream_app ${DOCKER_GW};/" \
+	   /config/nginx/proxy-confs/homeassistant.subdomain.conf
+	EOF
+	sudo chmod u+x volumes/swag/config/custom-cont-init.d/add-host.docker.internal.sh
+	```
+
    (This needs to be copy-pasted/entered as-is, ignore any "> "-prefixes printed
    by bash)
 
 8. (optional) Add reverse proxy password protection if you don't want to rely
    on the HA login for security, doesn't affect API-access:
-    ```
-    sed -i -e 's/#auth_basic/auth_basic/' \
-        volumes/swag/config/nginx/proxy-confs/homeassistant.subdomain.conf
-    docker-compose exec swag htpasswd -c /config/nginx/.htpasswd anyusername
-    ```
+
+	```bash
+	$ cd ~/IOTstack
+	$ sed -i -e 's/#auth_basic/auth_basic/' \
+		volumes/swag/config/nginx/proxy-confs/homeassistant.subdomain.conf
+	$ docker-compose exec swag htpasswd -c /config/nginx/.htpasswd anyusername
+	```
+
 9. Add `use_x_forwarded_for` and `trusted_proxies` to your homeassistant [http
    config](https://www.home-assistant.io/integrations/http). The configuration
    file is at `volumes/home_assistant/configuration.yaml` For a default install
    the resulting http-section should be:
-   ```
+
+   ```yaml
    http:
       use_x_forwarded_for: true
       trusted_proxies:
@@ -280,6 +294,7 @@ your RPi hostname is raspberrypi)
         - 172.16.0.0/12
         - 10.77.0.0/16
    ```
+
 10. Refresh the stack: `cd ~/IOTstack && docker-compose stop && docker-compose
     up -d` (again may take 1-3 minutes for swag to start if it recreates
     certificates)
@@ -292,10 +307,12 @@ your RPi hostname is raspberrypi)
     are just testing)
 
     Or from the command line in the RPi:
-    ```
-    curl --resolve homeassistant.<yourdomain>.duckdns.org:443:127.0.0.1 \
+
+    ```bash
+    $ curl --resolve homeassistant.<yourdomain>.duckdns.org:443:127.0.0.1 \
         https://homeassistant.<yourdomain>.duckdns.org/
     ```
+
     (output should end in `if (!window.latestJS) { }</script></body></html>`)
 
 13. And finally test your router forwards correctly by accessing it from

--- a/docs/Containers/Home-Assistant.md
+++ b/docs/Containers/Home-Assistant.md
@@ -65,7 +65,7 @@ $ docker-compose up -d
 
 In order to be able to use BT & BLE devices from HA integrations, make sure that Bluetooth is enabled:
 
-``` { .console linenums="1" }
+```console
 $ hciconfig
 hci0:	Type: Primary  Bus: UART
 	BD Address: DC:89:FB:A6:32:4B  ACL MTU: 1021:8  SCO MTU: 64:1
@@ -74,7 +74,7 @@ hci0:	Type: Primary  Bus: UART
 	TX bytes:11583 acl:0 sco:0 commands:159 errors:0
 ```
 
-The "UP" in line 4 indicates that Bluetooth is enabled. If Bluetooth is not enabled, check:
+The "UP" in the third line of output indicates that Bluetooth is enabled. If Bluetooth is not enabled, check:
 
 ```console
 $ grep "^AutoEnable" /etc/bluetooth/main.conf

--- a/docs/Containers/Home-Assistant.md
+++ b/docs/Containers/Home-Assistant.md
@@ -63,23 +63,40 @@ $ docker-compose up -d
 
 ## <a name="usingBluetooth"></a>Using bluetooth from the container
 
-In order to be able to use BT & BLE devices from HA integrations, make sure that bluetooth is enabled and powered on at the start of the (Rpi) host by editing `/etc/bluetooth/main.conf`:
+In order to be able to use BT & BLE devices from HA integrations, make sure that Bluetooth is enabled:
 
-```conf
-....
-[Policy]
+``` { .console linenums="1" }
+$ hciconfig
+hci0:	Type: Primary  Bus: UART
+	BD Address: DC:89:FB:A6:32:4B  ACL MTU: 1021:8  SCO MTU: 64:1
+	UP RUNNING 
+	RX bytes:2003 acl:0 sco:0 events:159 errors:0
+	TX bytes:11583 acl:0 sco:0 commands:159 errors:0
+```
+
+The "UP" in line 4 indicates that Bluetooth is enabled. If Bluetooth is not enabled, check:
+
+```console
+$ grep "^AutoEnable" /etc/bluetooth/main.conf
 AutoEnable=true
 ```
 
-After a reboot, check that BT is up:
+If `AutoEnable` is either missing or not set to `true`, then:
 
-```sh
-(root) # hciconfig
-...
-UP
-...
-```
-ref: https://scribles.net/auto-power-on-bluetooth-adapter-on-boot-up/
+1. Use `sudo` to and your favouring text editor to open:
+
+	```
+	/etc/bluetooth/main.conf
+	```
+
+2. Find `AutoEnable` and make it `true`.
+
+	> If `AutoEnable` is missing, it needs to be added to the `[Policy]` section.
+	
+3. Reboot your Raspberry Pi.
+4. Check that the Bluetooth interface is enabled.
+
+See also: [Scribles: Auto Power On Bluetooth Adapter on Boot-up](https://scribles.net/auto-power-on-bluetooth-adapter-on-boot-up/).
 
 ## <a name="httpsWithSSLcert"></a>HTTPS with a valid SSL certificate
 

--- a/docs/Containers/Home-Assistant.md
+++ b/docs/Containers/Home-Assistant.md
@@ -56,7 +56,7 @@ The active image is *generic* in the sense that it should work on any platform. 
 
 The normal IOTstack commands apply to Home Assistant Container such as:
 
-```bash
+```console
 $ cd ~/IOTstack
 $ docker-compose up -d
 ```
@@ -127,7 +127,7 @@ your RPi hostname is raspberrypi)
 
 5. Start the swag container, this creates the file to be edited in the next step:
 
-	```bash
+	```console
 	$ cd ~/IOTstack
 	$ docker-compose up -d
 	```
@@ -136,7 +136,7 @@ your RPi hostname is raspberrypi)
 
 6. Enable reverse proxy for `raspberrypi.local`. `homassistant.*` is already by default. and fix homeassistant container name ("upstream_app"):
 
-	```bash
+	```console
 	$ cd ~/IOTstack
 	$ sed -e 's/server_name/server_name *.local/' \
 	  volumes/swag/config/nginx/proxy-confs/homeassistant.subdomain.conf.sample \
@@ -146,7 +146,7 @@ your RPi hostname is raspberrypi)
 7. Forward to correct IP when target is a container running in "network_mode:
    host" (like Home Assistant does):
 
-	```bash
+	```console
 	cd ~/IOTstack
 	cat << 'EOF' | sudo tee volumes/swag/config/custom-cont-init.d/add-host.docker.internal.sh
 	#!/bin/sh
@@ -164,7 +164,7 @@ your RPi hostname is raspberrypi)
 8. (optional) Add reverse proxy password protection if you don't want to rely
    on the HA login for security, doesn't affect API-access:
 
-	```bash
+	```console
 	$ cd ~/IOTstack
 	$ sed -i -e 's/#auth_basic/auth_basic/' \
 		volumes/swag/config/nginx/proxy-confs/homeassistant.subdomain.conf
@@ -198,7 +198,7 @@ your RPi hostname is raspberrypi)
 
     Or from the command line in the RPi:
 
-    ```bash
+    ```console
     $ curl --resolve homeassistant.<yourdomain>.duckdns.org:443:127.0.0.1 \
         https://homeassistant.<yourdomain>.duckdns.org/
     ```


### PR DESCRIPTION
Repairs broken internal hyperlinks by restoring internal anchors.

Restored anchors converted to null-anchor form.

Fixes some spacing and alignment errors (apparent in MacDown authoring
tool).

Prefers multi-line command syntax over `&&` form which can be confusing
to new users (quasi standard followed in other IOTstack documentation).

Prefers `$ ` prompt form for commands users should execute. This is
another quasi-standard.

Explicitly sets `cd ~/IOTstack` where its omission might produce
unexpected results.

Adds code-fence rendering hints where appropriate.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>