### PR TITLE
20220327 MariaDB documentation

### DIFF
--- a/docs/Containers/MariaDB.md
+++ b/docs/Containers/MariaDB.md
@@ -1,4 +1,5 @@
 # MariaDB
+
 ## Source
 
 * [Docker hub](https://hub.docker.com/r/linuxserver/mariadb/)
@@ -67,9 +68,9 @@ To close the terminal session, either:
 * type "exit" and press <kbd>return</kbd>; or
 * press <kbd>control</kbd>+<kbd>d</kbd>.
 
-## Container health check
+## <a name="healthCheck"></a>Container health check
 
-### theory of operation
+### <a name="healthCheckTheory"></a>theory of operation
 
 A script , or "agent", to assess the health of the MariaDB container has been added to the *local image* via the *Dockerfile*. In other words, the script is specific to IOTstack.
 
@@ -87,11 +88,11 @@ The agent is invoked 30 seconds after the container starts, and every 30 seconds
 	mysqld is alive
 	```
 
-3. If the command returned the expected response, the agent tests the responsiveness of the TCP port the `mysqld` daemon should be listening on (see [customising health-check](#customising-health-check)).
+3. If the command returned the expected response, the agent tests the responsiveness of the TCP port the `mysqld` daemon should be listening on (see [customising health-check](#healthCheckCustom)).
 
 4. If all of those steps succeed, the agent concludes that MariaDB is functioning properly and returns "healthy".
 
-### monitoring health-check
+### <a name="healthCheckMonitor"></a>monitoring health-check
 
 Portainer's *Containers* display contains a *Status* column which shows health-check results for all containers that support the feature.
 
@@ -124,7 +125,7 @@ Possible reply patterns are:
 	mariadb   Up About a minute (unhealthy)
 	```
 
-### customising health-check
+### <a name="healthCheckCustom"></a>customising health-check
 
 You can customise the operation of the health-check agent by editing the `mariadb` service definition in your *Compose* file:
 

--- a/docs/Containers/MariaDB.md
+++ b/docs/Containers/MariaDB.md
@@ -19,7 +19,7 @@ The port is 3306. It exists inside the docker network so you can connect via `ma
 
 Before starting the stack, edit the `docker-compose.yml` file and check your environment variables. In particular:
 
-```
+```yaml
   environment:
     - TZ=Etc/UTC
     - MYSQL_ROOT_PASSWORD=
@@ -36,7 +36,7 @@ You only get the opportunity to change the `MQSL_` prefixed environment variable
 
 	* Stop the container and remove the persistent storage area:
 
-		```
+		```console
 		$ cd ~/IOTstack
 		$ docker-compose rm --force --stop -v mariadb
 		$ sudo rm -rf ./volumes/mariadb
@@ -45,7 +45,7 @@ You only get the opportunity to change the `MQSL_` prefixed environment variable
 	* Edit `docker-compose.yml` and change the variables.
 	* Bring up the container:
 
-		```
+		```console
 		$ docker-compose up -d mariadb 
 		```
 
@@ -57,7 +57,7 @@ You only get the opportunity to change the `MQSL_` prefixed environment variable
 
 You can open a terminal session within the mariadb container via:
 
-```
+```console
 $ docker exec -it mariadb bash
 ```
 
@@ -98,7 +98,7 @@ Portainer's *Containers* display contains a *Status* column which shows health-c
 
 You can also use the `docker ps` command to monitor health-check results. The following command narrows the focus to mariadb:
 
-```bash
+```console
 $ docker ps --format "table {{.Names}}\t{{.Status}}"  --filter name=mariadb
 ```
 
@@ -169,7 +169,7 @@ You can customise the operation of the health-check agent by editing the `mariad
 
 To update the `mariadb` container:
 
-```
+```console
 $ cd ~/IOTstack
 $ docker-compose build --no-cache --pull mariadb
 $ docker-compose up -d mariadb

--- a/docs/Containers/MariaDB.md
+++ b/docs/Containers/MariaDB.md
@@ -19,7 +19,7 @@ The port is 3306. It exists inside the docker network so you can connect via `ma
 
 Before starting the stack, edit the `docker-compose.yml` file and check your environment variables. In particular:
 
-```yaml
+```
   environment:
     - TZ=Etc/UTC
     - MYSQL_ROOT_PASSWORD=
@@ -36,7 +36,7 @@ You only get the opportunity to change the `MQSL_` prefixed environment variable
 
 	* Stop the container and remove the persistent storage area:
 
-		```console
+		```
 		$ cd ~/IOTstack
 		$ docker-compose rm --force --stop -v mariadb
 		$ sudo rm -rf ./volumes/mariadb
@@ -45,7 +45,7 @@ You only get the opportunity to change the `MQSL_` prefixed environment variable
 	* Edit `docker-compose.yml` and change the variables.
 	* Bring up the container:
 
-		```console
+		```
 		$ docker-compose up -d mariadb 
 		```
 
@@ -57,7 +57,7 @@ You only get the opportunity to change the `MQSL_` prefixed environment variable
 
 You can open a terminal session within the mariadb container via:
 
-```console
+```
 $ docker exec -it mariadb bash
 ```
 
@@ -98,7 +98,7 @@ Portainer's *Containers* display contains a *Status* column which shows health-c
 
 You can also use the `docker ps` command to monitor health-check results. The following command narrows the focus to mariadb:
 
-```console
+```bash
 $ docker ps --format "table {{.Names}}\t{{.Status}}"  --filter name=mariadb
 ```
 
@@ -169,7 +169,7 @@ You can customise the operation of the health-check agent by editing the `mariad
 
 To update the `mariadb` container:
 
-```console
+```
 $ cd ~/IOTstack
 $ docker-compose build --no-cache --pull mariadb
 $ docker-compose up -d mariadb

--- a/docs/Containers/MariaDB.md
+++ b/docs/Containers/MariaDB.md
@@ -19,7 +19,7 @@ The port is 3306. It exists inside the docker network so you can connect via `ma
 
 Before starting the stack, edit the `docker-compose.yml` file and check your environment variables. In particular:
 
-```
+```yaml
   environment:
     - TZ=Etc/UTC
     - MYSQL_ROOT_PASSWORD=


### PR DESCRIPTION
Repairs broken internal hyperlinks by restoring internal anchors.

Restored anchors converted to null-anchor form.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>