### PR TITLE
20220327 PiHole - old-menu branch - PR 2 of 2

### DIFF
--- a/docs/Containers/Pi-hole.md
+++ b/docs/Containers/Pi-hole.md
@@ -1,8 +1,3 @@
 # Pi-hole
-Pi-hole is a fantastic utility to reduce ads
 
-The interface can be found on `"your_ip":8089/admin`
-
-Default password is `pihole`. This can be changed in the `~/IOTstack/services/pihole/pihole.env` file
-
-To enable your router to use the pihole container edit your DNS settings on your router to point to your Pi's IP address
+This is the old-menu branch documentation. Please refer to [this page of the IOTstack Wiki](https://sensorsiot.github.io/IOTstack/Containers/Pi-hole/).


### PR DESCRIPTION
Reduces PiHole documentation to a stub, pointing to master branch
documentation.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>