### PR TITLE
20220327 Portainer-CE documentation

### DIFF
--- a/docs/Containers/Portainer-ce.md
+++ b/docs/Containers/Portainer-ce.md
@@ -25,14 +25,14 @@ From that it should be clear that *Portainer* is deprecated and that *Portainer 
 
 Run the menu:
 
-```
+```console
 $ cd ~/IOTstack
 $ ./menu.sh
 ```
 
 Choose "Build Stack", select "Portainer-ce", press [TAB] then "\<Ok\>" and follow through to the end of the menu process, typically choosing "Do not overwrite" for any existing services. When the menu finishes:
 
-```
+```console
 $ docker-compose up -d
 ```
 
@@ -83,7 +83,7 @@ Keep in mind that clicking on a "Published Port" does not guarantee that your br
 
 If you forget the password you created for *Portainer CE*, you can recover by doing the following:
 
-```
+```console
 $ cd ~/IOTstack
 $ docker-compose stop portainer-ce
 $ sudo rm -r ./volumes/portainer-ce

--- a/docs/Containers/Portainer-ce.md
+++ b/docs/Containers/Portainer-ce.md
@@ -1,11 +1,11 @@
 # Portainer CE
 
-## References
+## <a name="references"></a>References
  
 - [Docker](https://hub.docker.com/r/portainer/portainer-ce/)
 - [Website](https://www.portainer.io/portainer-ce/)
 
-## Definition
+## <a name="definitions"></a>Definition
 
 - "#yourip" means any of the following:
 
@@ -13,7 +13,7 @@
 	- the multicast domain name of your Raspberry Pi (eg `iot-hub.local`)
 	- the domain name of your Raspberry Pi (eg `iot-hub.mydomain.com`) 
 
-## About *Portainer CE*
+## <a name="about"></a>About *Portainer CE*
 
 *Portainer CE* (Community Edition) is an application for managing Docker. It is a successor to *Portainer*. According to [the *Portainer CE* documentation](https://www.portainer.io/2020/08/portainer-ce-2-0-what-to-expect/)
 
@@ -21,7 +21,7 @@
 
 From that it should be clear that *Portainer* is deprecated and that *Portainer CE* is the way forward.
 
-## Installing *Portainer CE*
+## <a name="installation"></a>Installing *Portainer CE*
 
 Run the menu:
 
@@ -40,7 +40,7 @@ Ignore any message like this:
 
 > WARNING: Found orphan containers (portainer) for this project …
 
-## First run of *Portainer CE*
+## <a name="firstRun"></a>First run of *Portainer CE*
 
 In your web browser navigate to `#yourip:9000/`:
 
@@ -51,7 +51,7 @@ From there, you can click on the "Local" group and take a look around. One of th
 
 There are 'Quick actions' to view logs and other stats. This can all be done from terminal commands but *Portainer CE* makes it easier. 
 
-## Setting the Public IP address for your end-point
+## <a name="setPublicIP"></a>Setting the Public IP address for your end-point
 
 If you click on a "Published Port" in the "Containers" list, your browser may return an error saying something like "can't connect to server" associated with an IP address of "0.0.0.0".
 
@@ -79,7 +79,7 @@ Keep in mind that clicking on a "Published Port" does not guarantee that your br
 
 > All things considered, you will get more consistent behaviour if you simply bookmark the URLs you want to use for your IOTstack services.
 
-## If you forget your password
+## <a name="forgotPassword"></a>If you forget your password
 
 If you forget the password you created for *Portainer CE*, you can recover by doing the following:
 
@@ -92,5 +92,5 @@ $ docker-compose start portainer-ce
 
 Then, follow the steps in:
 
-1. [First run of *Portainer CE*](#first-run-of-portainer-ce); and
-2. [Setting the Public IP address for your end-point](#setting-the-public-ip-address-for-your-end-point).
+1. [First run of *Portainer CE*](#firstRun); and
+2. [Setting the Public IP address for your end-point](#setPublicIP).


### PR DESCRIPTION
Repairs broken internal hyperlinks by restoring internal anchors.

Restored anchors converted to null-anchor form.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>