### PR TITLE
20220404 Zigbee2MQTT - master branch - PR 1 of 3

### DIFF
--- a/.templates/zigbee2mqtt/Dockerfile
+++ b/.templates/zigbee2mqtt/Dockerfile
@@ -1,3 +1,7 @@
+# This file is deprecated. It is being retained for backwards
+# compatibility with existing docker-compose.yml files but will
+# be removed, eventually.
+
 # Download base image
 FROM koenkk/zigbee2mqtt
 
@@ -8,5 +12,8 @@ RUN sed -i.bak \
    -e 's/mqtt:\/\/localhost/mqtt:\/\/mosquitto/' \
    -e '$s/$/\n\nfrontend:\n  port: 8080\n# auth_token: PASSWORD\n/' \
    /app/configuration.yaml
+
+RUN echo "*** DEPRECATION NOTICE: Please read IOTstack Zigbee2MQTT documentation:"
+RUN echo "*** https://sensorsiot.github.io/IOTstack/Containers/Zigbee2MQTT/"
 
 # EOF

--- a/.templates/zigbee2mqtt/service.yml
+++ b/.templates/zigbee2mqtt/service.yml
@@ -1,15 +1,18 @@
 zigbee2mqtt:
   container_name: zigbee2mqtt
-  build: ./.templates/zigbee2mqtt/.
+  image: koenkk/zigbee2mqtt:latest
   environment:
     - TZ=Etc/UTC
+    - ZIGBEE2MQTT_CONFIG_MQTT_SERVER=mqtt://mosquitto:1883
+    - ZIGBEE2MQTT_CONFIG_FRONTEND=true
+    - ZIGBEE2MQTT_CONFIG_ADVANCED_LOG_SYMLINK_CURRENT=true
   ports:
     - "8080:8080"
   volumes:
     - ./volumes/zigbee2mqtt/data:/app/data
   devices:
-    - /dev/ttyAMA0:/dev/ttyACM0 # should work even if no adapter
-   #- /dev/ttyACM0:/dev/ttyACM0 # should work if CC2531 connected
-   #- /dev/ttyUSB0:/dev/ttyACM0 # Electrolama zig-a-zig-ah! (zzh!) maybe other as well
+    - /dev/ttyAMA0:/dev/ttyACM0
   restart: unless-stopped
+  depends_on:
+    - mosquitto
 

--- a/docs/Containers/Zigbee2MQTT.md
+++ b/docs/Containers/Zigbee2MQTT.md
@@ -35,7 +35,7 @@
 
 5. <a name="upStack"></a>Bring up your stack:
 
-	```bash
+	```console
 	$ cd ~/IOTstack
 	$ docker-compose up -d
 	```
@@ -73,7 +73,7 @@ For those reasons, it is better to take the time to identify your Zigbee adapter
 1. If your Zigbee adapter is connected to your Raspberry Pi, disconnect it.
 2. Run the following command (the option is the digit "1"):
 
-	```bash
+	```console
 	$ ls -1 /dev/serial/by-id
 	```
 
@@ -108,7 +108,7 @@ For those reasons, it is better to take the time to identify your Zigbee adapter
 	1. Your adapter was not flashed correctly. Start over at [prepare your Zigbee adapter](#prepareAdapter).
 	2. Your adapter does not mount as a serial device. Try repeating steps 2 through 4 with the command:
 
-		```bash
+		```console
 		$ ls -1 /dev
 		```
 		
@@ -124,7 +124,7 @@ For those reasons, it is better to take the time to identify your Zigbee adapter
 
 6. Check your work like this (the option is the lower-case letter "l"):
 
-	```bash
+	```console
 	$ ls -l /dev/serial/by-id/usb-Texas_Instruments_TI_CC2531_USB_CDC___0X00125A00183F06C5-if00
 	lrwxrwxrwx 1 root root 13 Mar 31 19:49 dev/serial/by-id/usb-Texas_Instruments_TI_CC2531_USB_CDC___0X00125A00183F06C5-if00 -> ../../ttyACM0
 	```
@@ -165,7 +165,7 @@ Note:
 
 Whenever you change the value of an environment variable, you also need to tell `docker-compose` to apply the change:
 
-```bash
+```console
 $ cd ~/IOTstack
 $ docker-compose up -d zigbee2mqtt
 ```
@@ -228,7 +228,7 @@ If you decide to edit the configuration file:
 1. You will need to use `sudo` to edit the file.
 2. After you have finished making changes, you need to inform the running container by:
 
-	```bash
+	```console
 	$ cd ~/IOTstack
 	$ docker-compose restart zigbee2mqtt
 	```
@@ -243,7 +243,7 @@ Note:
 
 ### <a name="checkStatus"></a>Checking status
 
-```bash
+```console
 $ docker ps | grep -e mosquitto -e zigbee2mqtt
 NAMES         CREATED          STATUS
 zigbee2mqtt   33 seconds ago   Up 30 seconds
@@ -272,7 +272,7 @@ Fortunately, Zigbee2MQTT offers a shortcut. If the [`… LOG_SYMLINK_CURRENT`](#
 
 You can use commands like `cat` and `tail` to examine the *current* log. Example:
 
-```bash
+```console
 $ cat ~/IOTstack/volumes/zigbee2mqtt/data/log/current/log.txt
 ```
 
@@ -280,7 +280,7 @@ $ cat ~/IOTstack/volumes/zigbee2mqtt/data/log/current/log.txt
 
 To perform this check, you will need to have the Mosquitto clients installed:
 
-```bash
+```console
 $ sudo apt install -y mosquitto-clients
 ```
 
@@ -293,7 +293,7 @@ The Mosquitto clients package includes two command-line tools:
 
 Assuming the Mosquitto clients are installed, you can run the following command:
 
-```bash
+```console
 $ mosquitto_sub -v -h "localhost" -t "zigbee2mqtt/#" -F "%I %t %p"
 ```
 
@@ -334,7 +334,7 @@ Notes:
 
 	Do not change the *internal* port number on the right hand side of the mapping. To apply changes to the port mapping:
 
-	```bash
+	```console
 	$ cd ~/IOTstack
 	$ docker-compose up -d zigbee2mqtt
 	```
@@ -343,7 +343,7 @@ Notes:
 
 To open a shell inside the Zigbee2MQTT container, run:
 
-```bash
+```console
 $ docker exec -it zigbee2mqtt ash
 ```
 
@@ -355,7 +355,7 @@ To close the shell and leave the container, either type "exit" and press <kbd>re
 
 When you become aware of a new version of Zigbee2MQTT on [DockerHub](https://hub.docker.com/r/koenkk/zigbee2mqtt/tags), do the following:
 
-```bash
+```console
 $ cd ~IOTstack
 $ docker-compose pull zigbee2mqtt
 $ docker-compose up -d zigbee2mqtt
@@ -388,7 +388,7 @@ If you were using the Zigbee2MQTT container in IOTstack before April 2022, you s
 
 The updated service definition is included here for ease of reference:
 
-```yaml
+``` { .yaml linenums="1" }
 zigbee2mqtt:
   container_name: zigbee2mqtt
   image: koenkk/zigbee2mqtt:latest


### PR DESCRIPTION
Deprecates Dockerfile-based build in favour of environment variables
that implement the same behaviour.

Dockerfile retained to avoid introducing a breaking change. A
notification is displayed each time the Dockerfile is run:

```
*** DEPRECATION NOTICE: Please read IOTstack Zigbee2MQTT documentation:
*** https://sensorsiot.github.io/IOTstack/Containers/Zigbee2MQTT/
```

The intention is that user attention will be drawn to the need to update
their service definitions.

The revised service definition:

* includes a `depends_on` clause tying Zigbee2MQTT to Mosquitto (the
default arrangement for IOTstack).
* reduces the `devices` list to just `- /dev/ttyAMA0:/dev/ttyACM0`
in favour of extended "how to" documentation for device discovery.

Addresses issues raised in #402, #423 and #538.

Documentation rewritten and updated.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>