### PR TITLE
20220404 Zigbee2MQTT - old-menu branch - PR 2 of 3

### DIFF
--- a/.templates/zigbee2mqtt/Dockerfile
+++ b/.templates/zigbee2mqtt/Dockerfile
@@ -1,3 +1,7 @@
+# This file is deprecated. It is being retained for backwards
+# compatibility with existing docker-compose.yml files but will
+# be removed, eventually.
+
 # Download base image
 FROM koenkk/zigbee2mqtt
 
@@ -8,5 +12,8 @@ RUN sed -i.bak \
    -e 's/mqtt:\/\/localhost/mqtt:\/\/mosquitto/' \
    -e '$s/$/\n\nfrontend:\n  port: 8080\n# auth_token: PASSWORD\n/' \
    /app/configuration.yaml
+
+RUN echo "*** DEPRECATION NOTICE: Please read IOTstack Zigbee2MQTT documentation:"
+RUN echo "*** https://sensorsiot.github.io/IOTstack/Containers/Zigbee2MQTT/"
 
 # EOF

--- a/.templates/zigbee2mqtt/service.yml
+++ b/.templates/zigbee2mqtt/service.yml
@@ -1,14 +1,18 @@
   zigbee2mqtt:
     container_name: zigbee2mqtt
-    build: ./.templates/zigbee2mqtt/.
+    image: koenkk/zigbee2mqtt:latest
     environment:
       - TZ=Etc/UTC
+      - ZIGBEE2MQTT_CONFIG_MQTT_SERVER=mqtt://mosquitto:1883
+      - ZIGBEE2MQTT_CONFIG_FRONTEND=true
+      - ZIGBEE2MQTT_CONFIG_ADVANCED_LOG_SYMLINK_CURRENT=true
     ports:
       - "8080:8080"
     volumes:
       - ./volumes/zigbee2mqtt/data:/app/data
     devices:
-      - /dev/ttyAMA0:/dev/ttyACM0 # should work even if no adapter
-     #- /dev/ttyACM0:/dev/ttyACM0 # should work if CC2531 connected
-     #- /dev/ttyUSB0:/dev/ttyACM0 # Electrolama zig-a-zig-ah! (zzh!) maybe other as well
+      - /dev/ttyAMA0:/dev/ttyACM0
     restart: unless-stopped
+    depends_on:
+      - mosquitto
+

--- a/docs/Containers/Zigbee2MQTT.md
+++ b/docs/Containers/Zigbee2MQTT.md
@@ -1,34 +1,3 @@
 # Zigbe2MQTT
-* [Web Guide](https://www.zigbee2mqtt.io/information/docker.html)
 
-## First startup
-
-After starting the stack check to see if there is an error due to missing device. This is because the devices are mapped differently on the Pi. If your device is not showing in the container then you can also follow the followings steps.
-
-If you get a startup failure open the docker-compose.yml file and under zigbee2mqtt change this:
-
-```yml
- devices:
-      - /dev/ttyAMA0:/dev/ttyACM0
-      #- /dev/ttyACM0:/dev/ttyACM0
-```
-
-to 
-
-```yml
- devices:
-      #- /dev/ttyAMA0:/dev/ttyACM0
-      - /dev/ttyACM0:/dev/ttyACM0
-```
-
-and run docker-compose up -d again
-
-If the container starts then run `docker logs zigbe2mqtt` so see the log output and if your device is recognised. You may need to reset the device for docker to see it.
-
-To edit the configuration file `sudo nano volumes/zigbee2mqtt/data/configuration.yaml` you many need to restart the container for changes to take affect `docker-compose restart zigbee2mqtt`
-
-Unfortunately I don't own a zigbee device and cannot offer support on the setup you will need to follow the website instructions for further instructions https://www.zigbee2mqtt.io/
-
-## terminal access
-
-to access the terminal run `docker exec -it zigbee2mqtt /bin/sh` or select `/bin/sh
+This is the old-menu branch documentation. Please refer to [this page of the IOTstack Wiki](https://sensorsiot.github.io/IOTstack/Containers/Zigbee2MQTT/).


### PR DESCRIPTION
Deprecates Dockerfile-based build in favour of environment variables
that implement the same behaviour.

Dockerfile retained to avoid introducing a breaking change. A
notification is displayed each time the Dockerfile is run:

```
*** DEPRECATION NOTICE: Please read IOTstack Zigbee2MQTT documentation:
*** https://sensorsiot.github.io/IOTstack/Containers/Zigbee2MQTT/
```

The intention is that user attention will be drawn to the need to update
their service definitions.

The revised service definition:

* includes a `depends_on` clause tying Zigbee2MQTT to Mosquitto (the
default arrangement for IOTstack).
* reduces the `devices` list to just `- /dev/ttyAMA0:/dev/ttyACM0`
in favour of extended "how to" documentation for device discovery.

Addresses issues raised in #402, #423 and #538.

Documentation reduced to a stub pointing to master branch.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>