### PR TITLE
20220404 Zigbee2MQTT - experimental branch - PR 3 of 3

### DIFF
--- a/.internal/templates/services/zigbee2mqtt/Dockerfile
+++ b/.internal/templates/services/zigbee2mqtt/Dockerfile
@@ -1,3 +1,7 @@
+# This file is deprecated. It is being retained for backwards
+# compatibility with existing docker-compose.yml files but will
+# be removed, eventually.
+
 # Download base image
 FROM koenkk/zigbee2mqtt
 
@@ -8,5 +12,8 @@ RUN sed -i.bak \
    -e 's/mqtt:\/\/localhost/mqtt:\/\/mosquitto/' \
    -e '$s/$/\n\nfrontend:\n  port: 8080\n# auth_token: PASSWORD\n/' \
    /app/configuration.yaml
+
+RUN echo "*** DEPRECATION NOTICE: Please read IOTstack Zigbee2MQTT documentation:"
+RUN echo "*** https://sensorsiot.github.io/IOTstack/Containers/Zigbee2MQTT/"
 
 # EOF

--- a/.internal/templates/services/zigbee2mqtt/template.yml
+++ b/.internal/templates/services/zigbee2mqtt/template.yml
@@ -1,22 +1,22 @@
 zigbee2mqtt:
   container_name: zigbee2mqtt
-  build: ./.templates/zigbee2mqtt/.
+  image: koenkk/zigbee2mqtt:latest
   environment:
     - TZ=Etc/UTC
+    - ZIGBEE2MQTT_CONFIG_MQTT_SERVER=mqtt://mosquitto:1883
+    - ZIGBEE2MQTT_CONFIG_FRONTEND=true
+    - ZIGBEE2MQTT_CONFIG_ADVANCED_LOG_SYMLINK_CURRENT=true
   ports:
     - "8080:8080"
   volumes:
     - ./volumes/zigbee2mqtt/data:/app/data
   devices:
     - /dev/ttyAMA0:/dev/ttyACM0
-    # - /dev/ttyACM0:/dev/ttyACM0
-    # - /dev/ttyACM0:/dev/ttyACM0 # should work if CC2531 connected
-    # - /dev/ttyUSB0:/dev/ttyACM0 # Electrolama zig-a-zig-ah! (zzh!) maybe other as well
   restart: unless-stopped
-  network_mode: host
-  # networks:
-  #   - hosts_nw
+  depends_on:
+    - mosquitto
   logging:
     options:
       max-size: "5m"
       max-file: "3"
+


### PR DESCRIPTION
Deprecates Dockerfile-based build in favour of environment variables
that implement the same behaviour.

Dockerfile retained to avoid introducing a breaking change. A
notification is displayed each time the Dockerfile is run:

```
*** DEPRECATION NOTICE: Please read IOTstack Zigbee2MQTT documentation:
*** https://sensorsiot.github.io/IOTstack/Containers/Zigbee2MQTT/
```

The intention is that user attention will be drawn to the need to update
their service definitions.

The revised service definition:

* includes a `depends_on` clause tying Zigbee2MQTT to Mosquitto (the
default arrangement for IOTstack).
* reduces the `devices` list to just `- /dev/ttyAMA0:/dev/ttyACM0`
in favour of extended "how to" documentation for device discovery.

Addresses issues raised in #402, #423 and #538.

Documentation not changed.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>