### PR TITLE
docs: Console code-block highlighting

### DIFF
--- a/docs/Backups.md.old
+++ b/docs/Backups.md.old
@@ -49,7 +49,7 @@ Run `~/Dropbox-Uploader/dropbox_uploader.sh unlink` and if you have added it key
 
 Confirm by running `~/Dropbox-Uploader/dropbox_uploader.sh` it should ask you for your key if you removed it or show you the following prompt if it has the key:
 
-```
+``` console
  $ ~/Dropbox-Uploader/dropbox_uploader.sh
 Dropbox Uploader v1.0
 Andrea Fabrizi - andrea.fabrizi@gmail.com
@@ -75,9 +75,9 @@ If you ran the command with sudo the remove the old token file if it exists with
 
 To enable rclone to mount on boot you will need to make a user service. Run the following commands
 
-```bash
-mkdir -p ~/.config/systemd/user
-nano ~/.config/systemd/user/gdrive.service
+``` console
+$ mkdir -p ~/.config/systemd/user
+$ nano ~/.config/systemd/user/gdrive.service
 ```
 Copy the following code into the editor, save and exit
 
@@ -99,15 +99,15 @@ ExecStart= \
 WantedBy=default.target
 ```
 enable it to start on boot with: (no sudo)
-```bash
-systemctl --user enable gdrive.service
+``` console
+$ systemctl --user enable gdrive.service
 ```
 start with 
-```bash
-systemctl --user start gdrive.service
+``` console
+$ systemctl --user start gdrive.service
 ```
 if you no longer want it to start on boot then type:
-```bash
-systemctl --user disable gdrive.service
+``` console
+$ systemctl --user disable gdrive.service
 ```
 

--- a/docs/Basic_setup/Accessing-your-Device-from-the-internet.md
+++ b/docs/Basic_setup/Accessing-your-Device-from-the-internet.md
@@ -43,7 +43,7 @@ A behind-the-router technique usually relies on sending updates according to a s
 
 IOTstack provides a solution for DuckDNS. The best approach to running it is:
 
-```bash
+``` console
 $ mkdir -p ~/.local/bin
 $ cp ~/IOTstack/duck/duck.sh ~/.local/bin
 ```
@@ -74,7 +74,7 @@ Note:
 
 Once your credentials are in place, test the result by running:
 
-```bash
+``` console
 $ ~/.local/bin/duck.sh
 ddd, dd mmm yyyy hh:mm:ss ±zzzz - updating DuckDNS
 OK
@@ -89,7 +89,7 @@ Check your work if you get "KO" or any other errors.
 
 Next, assuming `dig` is installed on your Raspberry Pi (`sudo apt install dnsutils`), you can test propagation by sending a directed query to a DuckDNS name server. For example, assuming the domain name you registered was `downunda.duckdns.org`, you would query like this:
 
-```bash
+``` console
 $ dig @ns1.duckdns.org downunda.duckdns.org +short
 ```
 
@@ -132,7 +132,7 @@ If you wish to keep a log of `duck.sh` activity, the following will get the job 
 
 1. Make a directory to hold log files:
 
-	```bash
+	``` console
 	$ mkdir -p ~/Logs
 	```
 
@@ -144,7 +144,7 @@ If you wish to keep a log of `duck.sh` activity, the following will get the job 
 
 Remember to prune the log from time to time. The generally-accepted approach is:
 
-```
+``` console
 $ cat /dev/null >~/Logs/duck.log
 ```
 
@@ -174,7 +174,7 @@ Zerotier is an alternative to PiVPN that doesn't require port forwarding on your
 
 Kevin Zhang has written a how to guide [here](https://iamkelv.in/blog/2017/06/zerotier.html). Just note that the install link is outdated and should be:
 
-```bash
-curl -s 'https://raw.githubusercontent.com/zerotier/ZeroTierOne/master/doc/contact%40zerotier.com.gpg' | gpg --import && \
+``` console
+$ curl -s 'https://raw.githubusercontent.com/zerotier/ZeroTierOne/master/doc/contact%40zerotier.com.gpg' | gpg --import && \
 if z=$(curl -s 'https://install.zerotier.com/' | gpg); then echo "$z" | sudo bash; fi
 ```

--- a/docs/Basic_setup/What-is-sudo.md
+++ b/docs/Basic_setup/What-is-sudo.md
@@ -2,21 +2,21 @@
 
 Many first-time users of IOTstack get into difficulty by misusing the `sudo` command. The problem is best understood by example. In the following, you would expect `~` (tilde) to expand to `/home/pi`. It does:
 
-```bash
+``` console
 $ echo ~/IOTstack
 /home/pi/IOTstack
 ```
 
 The command below sends the same `echo` command to `bash` for execution. This is what happens when you type the name of a shell script. You get a new instance of `bash` to run the script:
 
-```bash
+``` console
 $ bash -c 'echo ~/IOTstack'
 /home/pi/IOTstack
 ```
 
 Same answer. Again, this is what you expect. But now try it with `sudo` on the front:
 
-```bash
+``` console
 $ sudo bash -c 'echo ~/IOTstack'
 /root/IOTstack
 ```
@@ -31,7 +31,7 @@ Please try to minimise your use of `sudo` when you are working with IOTstack. He
 
 1. Is what you are about to run a script? If yes, check whether the script already contains `sudo` commands. Using `menu.sh` as the example:
 
-	```bash
+	``` console
 	$ grep -c 'sudo' ~/IOTstack/menu.sh
 	28
 	```
@@ -40,7 +40,7 @@ Please try to minimise your use of `sudo` when you are working with IOTstack. He
 
 2. Did the command you **just executed** work without `sudo`? Note the emphasis on the past tense. If yes, then your work is done. If no, and the error suggests elevated privileges are necessary, then re-execute the last command like this:
 
-	```bash
+	``` console
 	$ sudo !!
 	```
 

--- a/docs/Basic_setup/index.md
+++ b/docs/Basic_setup/index.md
@@ -30,7 +30,7 @@ IOTstack makes the following assumptions:
 
 3. Your operating system has been updated:
 
-	```bash
+	``` console
 	$ sudo apt update
 	$ sudo apt upgrade -y
 	```
@@ -50,26 +50,26 @@ Please don't read these assumptions as saying that IOTstack will not run on othe
 
 1. Install `curl`:
 
-	```bash
+	``` console
 	$ sudo apt install -y curl
 	```
 
 2. Run the following command:
 
-	```bash
+	``` console
 	$ curl -fsSL https://raw.githubusercontent.com/SensorsIot/IOTstack/master/install.sh | bash
 	```
 
 3. Run the menu and choose your containers:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ ./menu.sh
 	```
 
 4. Bring up your stack:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose up -d
 	```
@@ -78,7 +78,7 @@ Please don't read these assumptions as saying that IOTstack will not run on othe
 
 1. Install `git`:
 
-	```bash
+	``` console
 	$ sudo apt install -y git
 	```
 
@@ -86,19 +86,19 @@ Please don't read these assumptions as saying that IOTstack will not run on othe
 
 	* If you want "new menu":
 
-		```bash
+		``` console
 		$ git clone https://github.com/SensorsIot/IOTstack.git ~/IOTstack
 		```
 
 	* If you prefer "old menu":
 
-		```bash
+		``` console
 		$ git clone -b old-menu https://github.com/SensorsIot/IOTstack.git ~/IOTstack
 		```
 
 3. Run the menu and choose your containers:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ ./menu.sh
 	```
@@ -109,7 +109,7 @@ Please don't read these assumptions as saying that IOTstack will not run on othe
 
 4. Bring up your stack:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose up -d
 	```
@@ -128,7 +128,7 @@ Unless you know what you are doing, assume these are needed.
 
 Run the following commands:
 
-```bash
+``` console
 $ sudo bash -c '[ $(egrep -c "^allowinterfaces eth\*,wlan\*" /etc/dhcpcd.conf) -eq 0 ] && echo "allowinterfaces eth*,wlan*" >> /etc/dhcpcd.conf'
 $ sudo reboot
 ```
@@ -143,7 +143,7 @@ This patch is **ONLY** for Raspbian Buster. Do **NOT** install this patch if you
 
 Run the following command:
 
-```bash
+``` console
 $ grep "PRETTY_NAME" /etc/os-release
 PRETTY_NAME="Raspbian GNU/Linux 10 (buster)"
 ```
@@ -159,7 +159,7 @@ Without this patch on Buster, Docker images will fail if:
 
 To install the patch:
 
-```bash
+``` console
 $ sudo apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv-keys 04EE7237B7D453EC 648ACFD622F3D138
 $ echo "deb http://httpredir.debian.org/debian buster-backports main contrib non-free" | sudo tee -a "/etc/apt/sources.list.d/debian-backports.list"
 $ sudo apt update
@@ -188,7 +188,7 @@ The menu is used to install Docker and then build the `docker-compose.yml` file 
 
 Please do **not** try to install `docker` and `docker-compose` via `sudo apt install`. There's more to it than that. Docker needs to be installed by `menu.sh`. The menu will prompt you to install docker if it detects that docker is not already installed. You can manually install it from within the `Native Installs` menu:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ ./menu.sh
 Select "Native Installs"
@@ -205,7 +205,7 @@ Note:
 
 `docker-compose` uses a `docker-compose.yml` file to configure all your services. The `docker-compose.yml` file is created by the menu:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ ./menu.sh
 Select "Build Stack"
@@ -222,7 +222,7 @@ Key point:
 
 The process finishes by asking you to bring up the stack:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose up -d
 ```
@@ -251,7 +251,7 @@ At the time of writing, IOTstack supports three menus:
 
 With a few precautions, you can switch between git branches as much as you like without breaking anything. The basic check you should perform is:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ git status
 ```
@@ -268,7 +268,7 @@ Key point:
 
 The way to avoid potential problems is to move any modified files to one side and restore the unmodified original. For example:
 
-```bash
+``` console
 $ mv .templates/mosquitto/Dockerfile .templates/mosquitto/Dockerfile.save
 $ git checkout -- .templates/mosquitto/Dockerfile
 ```
@@ -277,7 +277,7 @@ When `git status` reports no more "modified" files, it is safe to switch your br
 
 ### current menu (master branch)
 
-```bash
+``` console
 $ cd ~/IOTstack/
 $ git pull
 $ git checkout master
@@ -286,7 +286,7 @@ $ ./menu.sh
 
 ### old menu (old-menu branch)
 
-```bash
+``` console
 $ cd ~/IOTstack/
 $ git pull
 $ git checkout old-menu
@@ -297,7 +297,7 @@ $ ./menu.sh
 
 Switch to the experimental branch to try the latest and greatest features.
 
-```bash
+``` console
 $ cd ~/IOTstack/
 $ git pull
 $ git checkout experimental
@@ -329,7 +329,7 @@ Handy rules:
 
 To start the stack:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose up -d
 ```
@@ -346,7 +346,7 @@ Cannot create container for service [service name here]: unknown log opt 'max-fi
 
 1. Run the command:
 
-	```bash
+	``` console
 	$ sudo nano /etc/docker/daemon.json
 	```
 
@@ -370,7 +370,7 @@ You can also turn logging off or set it to use another option for any service by
 
 To start a particular container:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose up -d «container»
 ```
@@ -379,14 +379,14 @@ $ docker-compose up -d «container»
 
 Stopping aka "downing" the stack stops and deletes all containers, and removes the internal network:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose down
 ```
 
 To stop the stack without removing containers, run:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose stop
 ```
@@ -395,28 +395,28 @@ $ docker-compose stop
 
 `stop` can also be used to stop individual containers, like this:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose stop «container»
 ```
 
 This puts the container in a kind of suspended animation. You can resume the container with
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose start «container»
 ```
 
 There is no equivalent of `down` for a single container. It needs:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose rm --force --stop -v «container»
 ```
 
 To reactivate a container which has been stopped and removed:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose up -d «container»
 ```
@@ -425,13 +425,13 @@ $ docker-compose up -d «container»
 
 You can check the status of containers with:
 
-```bash
+``` console
 $ docker ps
 ```
 
 or
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose ps
 ```
@@ -440,19 +440,19 @@ $ docker-compose ps
 
 You can inspect the logs of most containers like this:
 
-```bash
+``` console
 $ docker logs «container»
 ```
 
 for example:
 
-```bash
+``` console
 $ docker logs nodered
 ```
 
 You can also follow a container's log as new entries are added by using the `-f` flag:
 
-```bash
+``` console
 $ docker logs -f nodered
 ```
 
@@ -462,7 +462,7 @@ Terminate with a Control+C. Note that restarting a container will also terminate
 
 You can restart a container in several ways:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose restart «container»
 ```
@@ -471,7 +471,7 @@ This kind of restart is the least-powerful form of restart. A good way to think 
 
 If you change a `docker-compose.yml` setting for a container and/or an environment variable file referenced by `docker-compose.yml` then a `restart` is usually not enough to bring the change into effect. You need to make `docker-compose` notice the change:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose up -d «container»
 ```
@@ -480,7 +480,7 @@ This type of "restart" rebuilds the container.
 
 Alternatively, to force a container to rebuild (without changing either `docker-compose.yml` or an environment variable file):
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose up -d --force-recreate «container»
 ```
@@ -533,7 +533,7 @@ is mirrored at the same relative path **inside** the container at:
 
 If you need a "clean slate" for a container, you can delete its volumes. Using InfluxDB as an example:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose rm --force --stop -v influxdb
 $ sudo rm -rf ./volumes/influxdb
@@ -549,7 +549,7 @@ When `docker-compose` tries to bring up InfluxDB, it will notice this volume map
 
 and check to see whether `./volumes/influxdb/data` is present. Finding it not there, it does the equivalent of:
 
-```bash
+``` console
 $ sudo mkdir -p ./volumes/influxdb/data
 ```
 
@@ -563,7 +563,7 @@ This is how **most** containers behave. There are exceptions so it's always a go
 
 You should keep your Raspberry Pi up-to-date. Despite the word "container" suggesting that *containers* are fully self-contained, they sometimes depend on operating system components ("WireGuard" is an example).
 
-```bash
+``` console
 $ sudo apt update
 $ sudo apt upgrade -y
 ```
@@ -572,7 +572,7 @@ $ sudo apt upgrade -y
 
 Although the menu will generally do this for you, it does not hurt to keep your local copy of the IOTstack repository in sync with the master version on GitHub.
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ git pull
 ```
@@ -595,7 +595,7 @@ The easiest way to work out which type of image you are looking at is to inspect
 
 If new versions of this type of image become available on DockerHub, your local IOTstack copies can be updated by a `pull` command:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose pull
 $ docker-compose up -d
@@ -630,7 +630,7 @@ Note:
 
 When your Dockerfile changes, you need to rebuild like this:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose up --build -d «container»
 $ docker system prune
@@ -648,7 +648,7 @@ Note:
 
 * You can also use this type of build if you get an error after modifying Node-RED's environment:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose up --build -d nodered
 	```
@@ -657,7 +657,7 @@ Note:
 
 When a newer version of the *base* image appears on DockerHub, you need to rebuild like this:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose build --no-cache --pull «container»
 $ docker-compose up -d «container»
@@ -673,7 +673,7 @@ Then, the Dockerfile is run to produce a new *local* image. The Dockerfile run h
 
 As your system evolves and new images come down from DockerHub, you may find that more disk space is being occupied than you expected. Try running:
 
-```bash
+``` console
 $ docker system prune
 ```
 
@@ -681,7 +681,7 @@ This recovers anything no longer in use. Sometimes multiple `prune` commands are
 
 If you add a container via `menu.sh` and later remove it (either manually or via `menu.sh`), the associated images(s) will probably persist. You can check which images are installed via:
 
-```bash
+``` console
 $ docker images
 
 REPOSITORY               TAG                 IMAGE ID            CREATED             SIZE
@@ -696,7 +696,7 @@ portainer/portainer      latest              dbf28ba50432        2 months ago   
 
 Both "Portainer CE" and "Portainer" are in that list. Assuming "Portainer" is no longer in use, it can be removed by using either its repository name or its Image ID. In other words, the following two commands are synonyms:
 
-```bash
+``` console
 $ docker rmi portainer/portainer
 $ docker rmi dbf28ba50432
 ```
@@ -733,7 +733,7 @@ To pin an image to a specific version:
 
 	To apply the change, "up" the container:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose up -d grafana
 	```
@@ -756,7 +756,7 @@ To pin an image to a specific version:
 
 	To apply the change, "up" the container and pass the `--build` flag:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose up -d --build mosquitto
 	```
@@ -765,7 +765,7 @@ To pin an image to a specific version:
 
 If you create a mess and can't see how to recover, try proceeding like this:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose down
 $ cd
@@ -787,21 +787,21 @@ In words:
 
 Now, you have a clean slate. You can either start afresh by running the menu:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ ./menu.sh
 ```
 
 Alternatively, you can mix and match by making selective copies from the old directory. For example:
 
-```bash
+``` console
 $ cd
 $ cp IOTstack.old/docker-compose.yml IOTstack/
 ```
 
 The `IOTstack.old` directory remains available as a reference for as long as you need it. Once you have no further use for it, you can clean it up via:
 
-```bash
+``` console
 $ cd
 $ sudo rm -rf ./IOTstack.old
 ```

--- a/docs/Containers/Chronograf.md
+++ b/docs/Containers/Chronograf.md
@@ -23,7 +23,7 @@ chronograf:
 
 If the Chronograf container is already running when you make this change, run:
 
-```bash
+``` console
 $ cd ~IOTstack
 $ docker-compose up -d chronograf
 ```
@@ -32,7 +32,7 @@ $ docker-compose up -d chronograf
 
 You can update the container via:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose pull
 $ docker-compose up -d
@@ -64,7 +64,7 @@ If you need to pin to a particular version:
 
 4. Save the file and tell `docker-compose` to bring up the container:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose up -d chronograf
 	$ docker system prune

--- a/docs/Containers/Kapacitor.md
+++ b/docs/Containers/Kapacitor.md
@@ -10,7 +10,7 @@
 
 You can update the container via:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose pull
 $ docker-compose up -d
@@ -46,7 +46,7 @@ If you need to pin to a particular version:
 
 4. Save the file and tell `docker-compose` to bring up the container:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose up -d kapacitor
 	$ docker system prune

--- a/docs/Containers/MariaDB.md
+++ b/docs/Containers/MariaDB.md
@@ -35,7 +35,7 @@ You only get the opportunity to change the `MQSL_` prefixed environment variable
 
 	* Stop the container and remove the persistent storage area:
 
-		```
+		``` console
 		$ cd ~/IOTstack
 		$ docker-compose rm --force --stop -v mariadb
 		$ sudo rm -rf ./volumes/mariadb
@@ -44,8 +44,8 @@ You only get the opportunity to change the `MQSL_` prefixed environment variable
 	* Edit `docker-compose.yml` and change the variables.
 	* Bring up the container:
 
-		```
-		$ docker-compose up -d mariadb 
+		``` console
+		$ docker-compose up -d mariadb
 		```
 
 2. Open a terminal window within the container (see below) and change the values by hand.
@@ -56,7 +56,7 @@ You only get the opportunity to change the `MQSL_` prefixed environment variable
 
 You can open a terminal session within the mariadb container via:
 
-```
+``` console
 $ docker exec -it mariadb bash
 ```
 
@@ -97,7 +97,7 @@ Portainer's *Containers* display contains a *Status* column which shows health-c
 
 You can also use the `docker ps` command to monitor health-check results. The following command narrows the focus to mariadb:
 
-```bash
+``` console
 $ docker ps --format "table {{.Names}}\t{{.Status}}"  --filter name=mariadb
 ```
 
@@ -168,7 +168,7 @@ You can customise the operation of the health-check agent by editing the `mariad
 
 To update the `mariadb` container:
 
-```
+``` console
 $ cd ~/IOTstack
 $ docker-compose build --no-cache --pull mariadb
 $ docker-compose up -d mariadb

--- a/docs/Containers/Node-RED.md
+++ b/docs/Containers/Node-RED.md
@@ -72,7 +72,7 @@ Choosing add-on nodes in the menu causes the *Dockerfile* to be created.
 
 On a first install of IOTstack, you are told to do this:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose up -d
 ```
@@ -117,7 +117,7 @@ Notes:
 
 When you run the `docker images` command after Node-RED has been built, you *may* see two rows for Node-RED:
 
-```bash
+``` console
 $ docker images
 REPOSITORY               TAG                 IMAGE ID            CREATED             SIZE
 iotstack_nodered         latest              b0b21a97b8bb        4 days ago          462MB
@@ -141,7 +141,7 @@ You should not remove the *base* image, even though it appears to be unused.
 
 After you install Node-RED, you should set an encryption key. Completing this step will silence the warning you will see when you run:
 
-```bash
+``` console
 $ docker logs nodered
 …
 ---------------------------------------------------------------------
@@ -162,7 +162,7 @@ Setting an encryption key also means that any credentials you create will be *po
 
 The encryption key can be any string. For example, if you have UUID support installed (`sudo apt install -y uuid-runtime`), you could generate a UUID as your key:
 
-```bash
+``` console
 $ uuidgen
 2deb50d4-38f5-4ab3-a97e-d59741802e2d
 ```
@@ -187,7 +187,7 @@ Un-comment the line and replace `a-secret-key` with your chosen key. Do not remo
 
 Save the file and then restart Node-RED:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose restart nodered
 ```
@@ -196,7 +196,7 @@ $ docker-compose restart nodered
 
 To secure Node-RED you need a password hash. Run the following command, replacing `PASSWORD` with your own password:
 
-```bash
+``` console
 $ docker exec nodered node -e "console.log(require('bcryptjs').hashSync(process.argv[1], 8));" PASSWORD
 ```
 
@@ -260,7 +260,7 @@ To communicate with your Raspberry Pi's GPIO you need to do the following:
 
 1. Install dependencies:
 
-	```bash
+	``` console
 	$ sudo apt update
 	$ sudo apt install pigpio python-pigpio python3-pigpio
 	```
@@ -312,7 +312,7 @@ The leading "." on the external path implies "the folder containing the *Compose
 
 If you write to the **internal** path from **inside** the Node-RED container, the Raspberry Pi will see the results at the **external** path, and vice versa. Example:
 
-```bash
+``` console
 $ docker exec -it nodered bash
 # echo "The time now is $(date)" >/data/example.txt
 # cat /data/example.txt 
@@ -380,7 +380,7 @@ An "exec" node works as expected when Node-RED is running as a native service bu
 
 To help you understand the difference, consider this command:
 
-```bash
+``` console
 $ grep "^PRETTY_NAME=" /etc/os-release
 ```
 
@@ -404,7 +404,7 @@ Docker doesn't provide any mechanism for a container to execute an arbitrary com
 
 Be able to use a Node-RED `exec` node to perform the equivalent of:
 
-```bash
+``` console
 $ ssh «HOSTNAME» «COMMAND»
 ```
 
@@ -424,7 +424,7 @@ These instructions are specific to IOTstack but the underlying concepts should a
 
 These instructions make frequent use of the ability to run commands "inside" the Node-RED container. For example, suppose you want to execute:
 
-```bash
+``` console
 $ grep "^PRETTY_NAME=" /etc/os-release
 ```
 
@@ -432,13 +432,13 @@ You have several options:
 
 1. You can do it from the normal Raspberry Pi command line using a Docker command. The basic syntax is:
 
-	```bash
+	``` console
 	$ docker exec {-it} «containerName» «command and parameters»
 	```
 
 	The actual command you would need would be:
 	
-	```bash
+	``` console
 	$ docker exec nodered grep "^PRETTY_NAME=" /etc/os-release
 	```
 	
@@ -448,7 +448,7 @@ You have several options:
 	
 2. You can open a shell into the container, run as many commands as you like inside the container, and then exit. For example:
 
-	```bash
+	``` console
 	$ docker exec -it nodered bash
 	# grep "^PRETTY_NAME=" /etc/os-release
 	# whoami
@@ -519,7 +519,7 @@ pi
 
 Create a key-pair for Node-RED. This is done by executing the `ssh-keygen` command **inside** the container:
 
-```bash
+``` console
 $ docker exec -it nodered ssh-keygen -q -t ed25519 -C "Node-RED container key-pair" -N ""
 ```
 
@@ -535,13 +535,13 @@ Notes:
 
 Node-RED's public key needs to be copied to the user account on *each* target machine where you want a Node-RED "exec" node to be able to execute commands. At the same time, the Node-RED container needs to learn the public host key of the target machine. The `ssh-copy-id` command does both steps. The required syntax is:
 
-```bash
+``` console
 $ docker exec -it nodered ssh-copy-id «USERID»@«HOSTADDR»
 ```
 
 * Examples:
 
-	```bash
+	``` console
 	$ docker exec -it nodered ssh-copy-id pi@iot-dev.mydomain.com
 	$ docker exec -it nodered ssh-copy-id pi@192.168.132.9
 	```
@@ -585,13 +585,13 @@ If you do not see an indication that a key has been added, you may need to retra
 
 The output above recommends a test. The test needs to be run **inside** the Node-RED container so the syntax is:
 
-```bash
+``` console
 $ docker exec -it nodered ssh «USERID»@«HOSTADDR» ls -1 /home/pi/IOTstack
 ```
 
 * Examples:
 
-	```bash
+	``` console
 	$ docker exec -it nodered ssh pi@iot-dev.mydomain.com ls -1 /home/pi/IOTstack
 	$ docker exec -it nodered ssh pi@192.168.132.9 ls -1 /home/pi/IOTstack
 	```
@@ -670,13 +670,13 @@ You don't **have** to do this step but it will simplify your exec node commands 
 
 At this point, SSH commands can be executed from **inside** the container using this syntax:
 
-```bash
+``` console
 # ssh «USERID»@«HOSTADDR» «COMMAND»
 ```
 
 A `config` file is needed to achieve the task goal of the simpler syntax:
 
-```bash
+``` console
 # ssh «HOSTNAME» «COMMAND»
 ```
 
@@ -692,7 +692,7 @@ The file needs the ownership and permissions shown. There are several ways of go
 
 Start in a directory where you can create a file without needing `sudo`. The IOTstack folder is just as good as anywhere else:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ touch config
 ```
@@ -735,7 +735,7 @@ Save the file.
 
 Change the config file's ownership and permissions, and move it into the correct directory:
 
-```bash
+``` console
 $ chmod 644 config
 $ sudo chown root:root config
 $ sudo mv config ./volumes/nodered/ssh
@@ -745,19 +745,19 @@ $ sudo mv config ./volumes/nodered/ssh
 
 The previous test used this syntax:
 
-```bash
+``` console
 $ docker exec nodered ssh «USERID»@«HOSTADDR» ls -1 /home/pi/IOTstack
 ```
 
 Now that the config file is in place, the syntax changes to:
 
-```bash
+``` console
 $ docker exec nodered ssh «HOSTNAME» ls -1 /home/pi/IOTstack
 ```
 
 * Example:
 
-	```bash
+	``` console
 	$ docker exec nodered ssh iot-dev ls -1 /home/pi/IOTstack
 	```
 
@@ -809,7 +809,7 @@ In the Node-RED GUI:
 
 1. Exchange keys with the new target host using:
 
-	```bash
+	``` console
 	$ docker exec -it nodered ssh-copy-id «USERID»@«HOSTADDR»
 	```
 
@@ -825,7 +825,7 @@ In the Node-RED GUI:
 
 You can update most containers like this:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose pull
 $ docker-compose up -d
@@ -844,7 +844,7 @@ The only way to know when an update to Node-RED is available is to check the [no
 
 Once a new version appears on [*DockerHub*](https://hub.docker.com), you can upgrade Node-RED like this:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose build --no-cache --pull nodered
 $ docker-compose up -d nodered
@@ -873,7 +873,7 @@ You customise your *local* image of Node-RED by making changes to:
 
 <a name="applyDockerfileChange">You apply a Dockerfile change like this:</a>
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose up --build -d nodered
 $ docker system prune
@@ -893,7 +893,7 @@ The `-12` suffix means "`node.js` is pinned at version 12.x.x". That's the lates
 
 If you want to check which version of `node.js` is installed on your system, you can do it like this:
 
-```bash
+``` console
 $ docker exec nodered node --version
 ```
 
@@ -911,7 +911,7 @@ As well as providing the Node-RED service, the nodered container is an excellent
 
 There are two ways to add extra packages. The first method is to add them to the running container. For example, to add the Mosquitto clients:
 
-```bash
+``` console
 $ docker exec nodered apk add --no-cache mosquitto-clients
 ```
 
@@ -939,7 +939,7 @@ You can install nodes by:
 
 2. Adding, removing or updating nodes in Manage Palette. Node-RED will remind you to restart Node-RED and that is something you have to do by hand:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose restart nodered
 	```
@@ -948,7 +948,7 @@ You can install nodes by:
 	
 	* Some users have reported misbehaviour from Node-RED if they do too many iterations of:
 	
-		```bash
+		``` console
 		[make a single change in Manage Palette]
 		$ docker-compose restart nodered
 
@@ -960,14 +960,14 @@ You can install nodes by:
 
 		It is better to:
 
-		```bash
+		``` console
 		[do ALL your Manage Palette changes]
 		$ docker-compose restart nodered
 		```
 
 3. Installing nodes inside the container via npm:
 
-	```bash
+	``` console
 	$ docker exec -it nodered bash
 	# cd /data
 	# npm install «node-name» /data
@@ -982,7 +982,7 @@ You can install nodes by:
 	* See also the note above about restarting too frequently.
 	* You can use this approach if you need to force the installation of a specific version (which you don't appear to be able to do in Manage Palette). For example, to install version 4.0.0 of the "moment" node:
 
-		```bash
+		``` console
 		# npm install node-red-contrib-moment@4.0.0 /data
 		```
 
@@ -1049,7 +1049,7 @@ The problem this creates is that a later version of an add-on node installed via
 
 The `nodered_list_installed_nodes.sh` script helps discover when this situation exists. For example:
 
-```bash
+``` console
 $ ~/IOTstack/scripts/nodered_list_installed_nodes.sh 
 
 Nodes installed by Dockerfile INSIDE the container at /usr/src/node-red/node_modules
@@ -1078,31 +1078,31 @@ Notice how `node-red-node-email` appears in both lists. To fix this problem:
 
 1. Move into the correct external directory:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack/volumes/nodered/data/node_modules
 	```
 	
 2. Create a sub-directory to be the equivalent of a local trash can:
 
-	```bash
+	``` console
 	$ sudo mkdir duplicates
 	```
 	
 3. Move each duplicate node into the `duplicates` directory. For example, to move `node-red-node-email` you would:
 
-	```bash
+	``` console
 	$ sudo mv node-red-node-email duplicates
 	```
 	
 4. Tell Node-RED to restart. This causes it to forget about the nodes which have just been moved out of the way:
 
-	```bash
+	``` console
 	$ docker-compose -f ~/IOTstack/docker-compose.yml restart nodered
 	```
 	
 5. Finish off by erasing the `duplicates` folder:
 
-	```bash
+	``` console
 	$ sudo rm -rf duplicates
 	```
 

--- a/docs/Containers/Octoprint.md
+++ b/docs/Containers/Octoprint.md
@@ -40,7 +40,7 @@ If the OctoPrint container is up when the device number changes, the container w
 
 The "xxxxxxxx" is (usually) unique to your 3D printer. To find it, connect your printer to your Raspberry Pi, then run the command:
 
-```
+``` console
 $ ls -1 /dev/serial/by-id
 ```
 
@@ -77,7 +77,7 @@ Suppose your 3D printer is a MasterDisaster5000Pro, and that you would like to b
 
 Start by disconnecting your 3D printer from your Raspberry Pi. Next, run this command:
 
-```
+``` console
 $ tail -f /var/log/messages
 ```
 
@@ -118,7 +118,7 @@ SUBSYSTEM=="tty", ATTRS{idVendor}=="dead", ATTRS{idProduct}=="beef", ATTRS{seria
 
 Next, ensure the required file exists by executing the following command:
 
-```
+``` console
 $ sudo touch /etc/udev/rules.d/99-usb-serial.rules
 ```
 
@@ -208,7 +208,7 @@ To start a print session:
 1. Turn the 3D printer on.
 2. Bring up the container:
 
-	```
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose up -d octoprint
 	```
@@ -324,7 +324,7 @@ Whichever method you choose will result in a refresh of the OctoPrint user inter
 
 Run the following commands:
 
-```
+``` console
 $ cd ~/IOTstack
 $ docker-compose restart octoprint
 ```
@@ -355,7 +355,7 @@ Unless you intend to leave your printer switched on 24 hours a day, you will als
 
 1. Terminate the container:
 
-	```
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose stop octoprint
 	$ docker-compose rm -f octoprint
@@ -381,7 +381,7 @@ To silence the warning:
 
 1. Terminate the container if it is running:
 
-	```
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose stop octoprint
 	$ docker-compose rm -f octoprint
@@ -412,7 +412,7 @@ To silence the warning:
 4. Save the file.
 5. Bring up the container: 
 
-	```
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose up -d octoprint
 	```
@@ -421,7 +421,7 @@ To silence the warning:
 
 You can check for updates like this:
 
-```
+``` console
 $ cd ~/IOTstack
 $ docker-compose pull octoprint
 $ docker-compose up -d octoprint
@@ -432,7 +432,7 @@ $ docker system prune
 
 You can view a list of usernames like this:
 
-```
+``` console
 $ docker exec octoprint octoprint --basedir /octoprint/octoprint user list
 ```
 
@@ -440,19 +440,19 @@ To reset a user's password:
 
 1. Use the following line as a template and replace `«username»` and `«password»` with appropriate values:
 
-	```
-	docker exec octoprint octoprint --basedir /octoprint/octoprint user password --password «password» «username»
+	``` console
+	$ docker exec octoprint octoprint --basedir /octoprint/octoprint user password --password «password» «username»
 	```
 	
 2. Execute the edited command. For example, to set the password for user "me" to "verySecure":
 
-	```
+	``` console
 	$ docker exec octoprint octoprint --basedir /octoprint/octoprint user password --password verySecure me
 	```
 
 3. Restart OctoPrint:
 
-	```
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose restart octoprint
 	```
@@ -461,7 +461,7 @@ Note:
 
 * OctoPrint supports more than one username. To explore the further:
 
-	```
+	``` console
 	$ docker exec octoprint octoprint --basedir /octoprint/octoprint user --help
 	```
 
@@ -469,7 +469,7 @@ Note:
 
 If the OctoPrint container seems to be misbehaving, you can get a "clean slate" by:
 
-```
+``` console
 $ cd ~/IOTstack
 $ docker-compose stop octoprint
 $ docker-compose rm -f octoprint

--- a/docs/Containers/OpenHab.md
+++ b/docs/Containers/OpenHab.md
@@ -24,7 +24,7 @@ If you want to change either of the first two:
 
 2. Recreate the openHAB container:
 
-	```
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose up -d openhab
 	```

--- a/docs/Containers/Prometheus.md
+++ b/docs/Containers/Prometheus.md
@@ -97,7 +97,7 @@ When you select *Prometheus* in the IOTstack menu, the *template service definit
 
 On a first install of IOTstack, you run the menu, choose *Prometheus* as one of your containers, and are told to do this:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose up -d
 ```
@@ -144,7 +144,7 @@ The *local image* is instantiated to become your running container.
 
 When you run the `docker images` command after *Prometheus* has been built, you *may* see two rows for *Prometheus*:
 
-```bash
+``` console
 $ docker images
 REPOSITORY           TAG         IMAGE ID       CREATED          SIZE
 iotstack_prometheus  latest      1815f63da5f0   23 minutes ago   169MB
@@ -203,7 +203,7 @@ scrape_configs:
 
 To cause a running instance of *Prometheus* to notice a change to this file:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose restart prometheus
 $ docker logs prometheus
@@ -223,7 +223,7 @@ The file named `prometheus.yml` is a reference configuration. It is a **copy** o
 
 Editing `prometheus.yml` has no effect. It is provided as a convenience to help you follow examples on the web. If you want to make the contents of `prometheus.yml` the active configuration, you need to do this:
 
-```bash
+``` console
 $ cd ~/IOTstack/volumes/prometheus/data/config
 $ cp prometheus.yml config.yml
 $ cd ~/IOTstack
@@ -267,7 +267,7 @@ You should compare the old and new versions and decide which settings need to be
 
 If you change the configuration file, restart *Prometheus* and then check the log for errors:
 
-```bash
+``` console
 $ docker-compose restart prometheus
 $ docker logs prometheus
 ```
@@ -280,7 +280,7 @@ Note:
 
 You can update `cadvisor` and `nodeexporter` like this:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose pull cadvisor nodeexporter
 $ docker-compose up -d
@@ -299,7 +299,7 @@ The only way to know when an update to *Prometheus* is available is to check the
 
 Once a new version appears on *DockerHub*, you can upgrade *Prometheus* like this:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose build --no-cache --pull prometheus
 $ docker-compose up -d prometheus
@@ -344,7 +344,7 @@ If you need to pin *Prometheus* to a particular version:
 
 4. Save the file and tell `docker-compose` to rebuild the local image:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose up -d --build prometheus
 	$ docker system prune

--- a/docs/Containers/Python.md
+++ b/docs/Containers/Python.md
@@ -12,7 +12,7 @@ When you select Python in the menu:
 
 1. The following folder and file structure is created:
 
-	```
+	``` console
 	$ tree ~/IOTstack/services/python
 	/home/pi/IOTstack/services/python
 	├── app
@@ -65,7 +65,7 @@ The service definition contains a number of customisation points:
 
 If your Python container is already running when you make a change to its service definition, you can apply it via:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose up -d python
 ```
@@ -74,7 +74,7 @@ $ docker-compose up -d python
 
 After running the menu, you are told to run the commands:
 
-```
+``` console
 $ cd ~/IOTstack
 $ docker-compose up -d
 ```
@@ -115,7 +115,7 @@ This is what happens:
 4. The `iotstack_python` image is instantiated to become the running container.
 5. When the container starts, the `docker-entrypoint.sh` script runs and initialises the container's persistent storage area:
 
-	```bash
+	``` console
 	$ tree -pu ~/IOTstack/volumes
 	/home/pi/IOTstack/volumes
 	└── [drwxr-xr-x root    ]  python
@@ -129,7 +129,7 @@ This is what happens:
 
 5. The initial `app.py` Python script is a "hello world" placeholder. It runs as an infinite loop emitting messages every 10 seconds until terminated. You can see what it is doing by running:
 
-	```bash
+	``` console
 	$ docker logs -f python
 	The world is born. Hello World.
 	The world is re-born. Hello World.
@@ -145,14 +145,14 @@ To stop the container from running, either:
 
 * take down your whole stack:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose down
 	```
 
 * terminate the python container
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose rm --force --stop -v python
 	```
@@ -163,14 +163,14 @@ To bring up the container again after you have stopped it, either:
 
 * bring up your whole stack:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose up -d
 	```
 
 * bring up the python container
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose up -d python
 	```
@@ -187,7 +187,7 @@ Each time you launch the Python container *after* the first launch:
 
 If the container misbehaves, the log is your friend:
 
-```
+``` console
 $ docker logs python
 ```
 
@@ -217,7 +217,7 @@ If you need other supporting scripts or data files, also add those to the direct
 
 Any time you change something in the `app` folder, tell the running python container to notice the change by:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose restart python
 ```
@@ -253,7 +253,7 @@ If your script writes into any other directory inside the container, the data wi
 
 If you make a mess of things and need to start from a clean slate, erase the persistent storage area:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose rm --force --stop -v python
 $ sudo rm -rf ./volumes/python
@@ -268,13 +268,13 @@ As you develop your project, you may find that you need to add supporting packag
 
 If you were developing a project outside of container-space, you would simply run:
 
-```
+``` console
 $ pip3 install -U Flask beautifulsoup4
 ```
 
 You *can* do the same thing with the running container:
 
-```
+``` console
 $ docker exec python pip3 install -U Flask beautifulsoup4
 ```
 
@@ -284,7 +284,7 @@ To make *Flask* and *beautifulsoup4* a permanent part of your container:
 
 1. Change your working directory:
 
-	```
+	``` console
 	$ cd ~/IOTstack/services/python/app
 	```
 
@@ -297,7 +297,7 @@ To make *Flask* and *beautifulsoup4* a permanent part of your container:
 
 3. Tell Docker to rebuild the local Python image:
 
-	```
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose build --force-rm python
 	$ docker-compose up -d --force-recreate python
@@ -310,7 +310,7 @@ To make *Flask* and *beautifulsoup4* a permanent part of your container:
 
 4. Confirm that the packages have been added:
 
-	```
+	``` console
 	$ docker exec python pip3 freeze | grep -e "Flask" -e "beautifulsoup4"
 	beautifulsoup4==4.10.0
 	Flask==2.0.1
@@ -332,7 +332,7 @@ Note:
 
 	If you want to bring the copy of `requirements.txt` in the *volumes* directory up-to-date:
 
-	```
+	``` console
 	$ cd ~/IOTstack
 	$ rm ./volumes/python/app/requirements.txt
 	$ docker-compose restart python
@@ -346,7 +346,7 @@ Suppose the Python script you have been developing reaches a major milestone and
 
 1. If you have added any packages by following the steps in [adding packages](#adding-packages), run the following command:
 
-	```bash
+	``` console
 	$ docker exec python bash -c 'pip3 freeze >requirements.txt'
 	```
 
@@ -358,7 +358,7 @@ Suppose the Python script you have been developing reaches a major milestone and
 
 2. Make your work the default:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ cp -r ./volumes/python/app/* ./services/python/app
 	```
@@ -375,7 +375,7 @@ Suppose the Python script you have been developing reaches a major milestone and
 
 3. Terminate the Python container and erase its persistent storage area:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose rm --force --stop -v python
 	$ sudo rm -rf ./volumes/python
@@ -385,14 +385,14 @@ Suppose the Python script you have been developing reaches a major milestone and
 
 	* If erasing the persistent storage area feels too risky, just move it out of the way:
 
-		```
+		``` console
 		$ cd ~/IOTstack/volumes
 		$ sudo mv python python.off
 		```
 
 4. Rebuild the local image:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose build --force-rm python
 	$ docker-compose up -d --force-recreate python
@@ -402,7 +402,7 @@ Suppose the Python script you have been developing reaches a major milestone and
 
 5. Clean up by removing the old local image:
 
-	```bash
+	``` console
 	$ docker system prune -f
 	```
 
@@ -417,20 +417,20 @@ Proceed like this:
 
 1. Stop the development project:
 
-	```
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose rm --force --stop -v python
 	```
 
 2. Remove the existing local image:
 
-	```
+	``` console
 	$ docker rmi iotstack_python
 	```
 
 3. Rename the `python` services directory to the name of your project:
 
-	```
+	``` console
 	$ cd ~/IOTstack/services
 	$ mv python wishbone
 	```
@@ -458,7 +458,7 @@ Proceed like this:
 
 5. Start the renamed service:
 
-	```
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose up -d wishbone
 	```
@@ -475,7 +475,7 @@ Remember:
 
 To make sure you are running from the most-recent **base** image of Python from Dockerhub:
 
-```
+``` console
 $ cd ~/IOTstack
 $ docker-compose build --no-cache --pull python
 $ docker-compose up -d python

--- a/docs/Containers/RTL_433-docker.md
+++ b/docs/Containers/RTL_433-docker.md
@@ -3,7 +3,7 @@ Requirements, you will need to have a SDR dongle for you to be able to use RTL. 
 
 Make sure you can see your receiver by running `lsusb`
 
-```bash
+``` console
 $ lsusb
 Bus 003 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
 Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub

--- a/docs/Containers/Telegraf.md
+++ b/docs/Containers/Telegraf.md
@@ -69,7 +69,7 @@ When you select Telegraf in the IOTstack menu, the *template service definition*
 
 On a first install of IOTstack, you run the menu, choose your containers, and are told to do this:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose up -d
 ```
@@ -120,7 +120,7 @@ The ***local image*** is instantiated to become your running container.
 
 When you run the `docker images` command after Telegraf has been built, you *may* see two rows for Telegraf:
 
-```bash
+``` console
 $ docker images
 REPOSITORY          TAG      IMAGE ID       CREATED       SIZE
 iotstack_telegraf   latest   59861b7fe9ed   2 hours ago   292MB
@@ -160,7 +160,7 @@ The exception is `[[inputs.mqtt_consumer]]` which is now provided as an optional
 
 You can inspect Telegraf's log by:
 
-```
+``` console
 $ docker logs telegraf
 ```
 
@@ -214,7 +214,7 @@ The intention of this structure is that you:
 
 When you make a change to `telegraf.conf`, you activate it by restarting the container:
 
-```
+``` console
 $ cd ~/IOTstack
 $ docker-compose restart telegraf
 ```
@@ -224,8 +224,8 @@ $ docker-compose restart telegraf
 * `inputs.docker.conf` instructs Telegraf to collect metrics from Docker. Requires kernel control
   groups to be enabled to collect memory usage data. If not done during initial installation,
   enable by running (reboot required):
-  ```
-  echo $(cat /boot/cmdline.txt) cgroup_memory=1 cgroup_enable=memory | sudo tee /boot/cmdline.txt
+  ``` console
+  $ echo $(cat /boot/cmdline.txt) cgroup_memory=1 cgroup_enable=memory | sudo tee /boot/cmdline.txt
   ```
 * `inputs.cpu_temp.conf' collects cpu temperature.
  
@@ -240,7 +240,7 @@ Currently there is one addition:
 Using `inputs.mqtt_consumer.conf` as the example, applying that addition to
 your Telegraf configuration file involves:
 
-```
+``` console
 $ cd ~/IOTstack/volumes/telegraf
 $ grep -v "^#" additions/inputs.mqtt_consumer.conf | sudo tee -a telegraf.conf >/dev/null
 $ cd ~/IOTstack
@@ -255,7 +255,7 @@ The `grep` strips comment lines and the `sudo tee` is a safe way of appending th
 
 Erasing Telegraf's persistent storage area triggers self-healing and restores known defaults:
 
-```
+``` console
 $ cd ~/IOTstack
 $ docker-compose rm --force --stop -v telegraf
 $ sudo rm -rf ./volumes/telegraf
@@ -266,7 +266,7 @@ Note:
 
 * You can also remove individual files within the persistent storage area and then trigger self-healing. For example, if you decide to edit `telegraf-reference.conf` and make a mess, you can restore the original version like this:
 
-	```
+	``` console
 	$ cd ~/IOTstack
 	$ sudo rm ./volumes/telegraf/telegraf-reference.conf
 	$ docker-compose restart telegraf
@@ -276,7 +276,7 @@ Note:
 
 To reset the InfluxDB database that Telegraf writes into, proceed like this:
 
-```
+``` console
 $ cd ~/IOTstack
 $ docker-compose rm --force --stop -v telegraf
 $ docker exec -it influxdb influx -precision=rfc3339
@@ -297,7 +297,7 @@ In words:
 
 You can update most containers like this:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose pull
 $ docker-compose up -d
@@ -316,7 +316,7 @@ The only way to know when an update to Telegraf is available is to check the [Te
 
 Once a new version appears on *DockerHub*, you can upgrade Telegraf like this:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose build --no-cache --pull telegraf
 $ docker-compose up -d telegraf
@@ -359,7 +359,7 @@ If you need to pin Telegraf to a particular version:
 
 4. Save the file and tell `docker-compose` to rebuild the ***local image***:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose up -d --build telegraf
 	$ docker system prune

--- a/docs/Containers/WireGuard.md
+++ b/docs/Containers/WireGuard.md
@@ -19,7 +19,7 @@ You increase your chances of a trouble-free installation by performing the insta
 
 To be able to run WireGuard successfully, your Raspberry Pi needs to be **fully** up-to-date. If you want to understand why, see [the read only flag](#the-read-only-flag).
 
-```bash
+``` console
 $ sudo apt update
 $ sudo apt upgrade -y
 ```
@@ -134,7 +134,7 @@ You have several options for how your remote peers resolve DNS requests:
 	1. Make sure your WireGuard service definition contains `PEERDNS=auto`.
 	2. Start the WireGuard container by executing:
 
-		```bash
+		``` console
 		$ cd ~/IOTstack
 		$ docker-compose up -d wireguard
 		```
@@ -143,7 +143,7 @@ You have several options for how your remote peers resolve DNS requests:
 
 	3. Run the following commands:  
 
-		```bash
+		``` console
 		$ cd ~/IOTstack
 		$ sudo cp ./.templates/wireguard/use-container-dns.sh ./volumes/wireguard/custom-cont-init.d/
 		$ docker-compose restart wireguard
@@ -162,7 +162,7 @@ You have several options for how your remote peers resolve DNS requests:
 
 	Once activated, this feature will remain active until you decide to deactivate it. If you ever wish to deactivate it, run the following commands:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ sudo rm ./volumes/wireguard/custom-cont-init.d/use-container-dns.sh
 	$ docker-compose restart wireguard
@@ -227,7 +227,7 @@ Of the two, the first is generally the simpler and means you don't have to re-ru
 
 1. Run the menu:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ ./menu.sh
 	```
@@ -277,7 +277,7 @@ You will need to create the `compose-override.yml` **before** running the menu t
 3. Save your work.
 4. Run the menu:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ ./menu.sh
 	```
@@ -288,7 +288,7 @@ You will need to create the `compose-override.yml` **before** running the menu t
 8. Choose Exit.
 9. Check your work by running:
 
-	```bash
+	``` console
 	$ cat docker-compose.yml
 	```
 
@@ -298,20 +298,20 @@ You will need to create the `compose-override.yml` **before** running the menu t
 
 1. To start WireGuard, bring up your stack:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose up -d
 	```
 
 2. Confirm that WireGuard has started properly by running:
 
-	```bash
+	``` console
 	$ docker ps --format "table {{.Names}}\t{{.RunningFor}}\t{{.Status}}" --filter name=wireguard
 	```
 
 	Repeat the command a few times with a short delay in between. You are looking for signs that the WireGuard container is restarting. If the container seems to be restarting then this command is your friend:
 
-	```bash
+	``` console
 	$ docker logs wireguard
 	```
 
@@ -325,7 +325,7 @@ You will need to create the `compose-override.yml` **before** running the menu t
 
 	you would expect a result something like this:
 
-	```bash
+	``` console
 	$ tree ./volumes/wireguard
 	volumes/wireguard/
 	├── coredns
@@ -362,7 +362,7 @@ You will need to create the `compose-override.yml` **before** running the menu t
 
 The first time you launch WireGuard, it generates cryptographically protected configurations for your remote clients and encapsulates those configurations in QR codes. You can see the QR codes by running:
 
-```bash
+``` console
 $ docker logs wireguard
 ```
 
@@ -378,7 +378,7 @@ If, however, your Raspberry Pi is running headless, you will need to copy the `.
 
 For example, to copy **all** PNG files from your Raspberry Pi to a target system:
 
-```bash
+``` console
 $ find ~/IOTstack/volumes/wireguard -name "*.png" -exec scp {} user@hostorip:. \;
 ```
 
@@ -389,7 +389,7 @@ Note:
 
 If you want to work in the other direction (ie from the GUI-capable system), you can try:
 
-```bash
+``` console
 $ scp pi@hostorip:IOTstack/volumes/wireguard/peer_jill-macbook/peer_jill-macbook.png .
 ```
 
@@ -517,13 +517,13 @@ This model is a slight simplification because the remote client may also be also
 
 If `tcpdump` is not installed on your Raspberry Pi, you can install it by:
 
-```bash
+``` console
 $ sudo apt install tcpdump
 ```
 
 After that, you can capture traffic between your router and your Raspberry Pi by:
 
-```bash
+``` console
 $ sudo tcpdump -i eth0 -n udp port «external»
 ```
 
@@ -533,7 +533,7 @@ Press <kbd>ctrl</kbd><kbd>c</kbd> to terminate the capture.
 
 First, you need to add `tcpdump` to the container. You only need to do this once per debugging session. The package will remain in place until the next time you re-create the container.
 
-```bash
+``` console
 $ docker exec wireguard bash -c 'apt update ; apt install -y tcpdump'
 ```
 
@@ -547,7 +547,7 @@ Press <kbd>ctrl</kbd><kbd>c</kbd> to terminate the capture.
 
 ### Is Docker listening on the Raspberry Pi's «external» port?
 
-```bash
+``` console
 $ PORT=«external»; sudo nmap -sU -p $PORT 127.0.0.1 | grep "$PORT/udp"
 ```
 
@@ -560,7 +560,7 @@ Success implies that the container is also listening.
 
 ### Is your router listening on the «public» port?
 
-```bash
+``` console
 $ PORT=«public»; sudo nmap -sU -p $PORT downunda.duckdns.org | grep "$PORT/udp"
 ```                                           
 
@@ -589,14 +589,14 @@ If WireGuard refuses to install and you have good reason to suspect that WireGua
 
 To update the WireGuard container:
 
-```bash
+``` console
 $ cd ~/IOTstack
 $ docker-compose pull wireguard
 ```
 
 If a new image comes down, then:
 
-```
+``` console
 $ docker-compose up -d wireguard
 $ docker system prune
 ```
@@ -616,14 +616,14 @@ The procedure is:
 
 1. If WireGuard is running, terminate it:
 
-	```bash
+	``` console
 	$ cd ~/IOTstack
 	$ docker-compose rm --force --stop -v wireguard
 	```
 
 2. Erase the persistent storage area (essential):
 
-	```bash
+	``` console
 	$ sudo rm -rf ./volumes/wireguard
 	```
 
@@ -636,7 +636,7 @@ The procedure is:
 
 3. Start WireGuard:
 
-	```bash
+	``` console
 	$ docker-compose up -d wireguard
 	```
 

--- a/docs/Updates/gcgarner-migration.md
+++ b/docs/Updates/gcgarner-migration.md
@@ -12,7 +12,7 @@ The probability of conflicts developing increases as a function of time since th
 
 Make sure that you are, *actually*, on gcgarner. Don't assume!
 
-```
+``` console
 $ git remote -v
 origin	https://github.com/gcgarner/IOTstack.git (fetch)
 origin	https://github.com/gcgarner/IOTstack.git (push)
@@ -24,7 +24,7 @@ Do not proceed if you don't see those URLs!
 
 Take your stack down. This is not *strictly* necessary but we'll be moving the goalposts a bit so it's better to be on the safe side.
 
-```
+``` console
 $ cd ~/IOTstack
 $ docker-compose down
 ```
@@ -48,7 +48,7 @@ If you are already stuck or you try the first approach and get a mess, or it all
 
 Make sure you are on the master branch (you probably are so this is just a precaution), and then see if Git thinks you have made any local changes:
 
-```
+``` console
 $ cd ~/IOTstack
 $ git checkout master
 $ git status
@@ -68,19 +68,19 @@ The simplest way to deal with modified files is to rename them to move them out 
 
 	Here I'm assuming your initials are "jqh":
 
-	```
+	``` console
 	$ mv menu.sh menu.sh.jqh
 	```
 	
 2. Tell git to restore the unmodified version:
 
-	```
+	``` console
 	$ git checkout -- menu.sh
 	```
 	
 3. Now, repeat the Git command that complained about the file:
 
-	```
+	``` console
 	$ git status
 	```
 	
@@ -97,7 +97,7 @@ The simplest way to deal with modified files is to rename them to move them out 
 
 Make sure your local copy of gcgarner is in sync with GitHub.
 
-```
+``` console
 $ git pull
 ```
 
@@ -107,7 +107,7 @@ There may or may not be any "upstream" set. The most likely reason for this to h
 
 The next command will probably return an error, which you should ignore. It's just a precaution.
 
-```
+``` console
 $ git remote remove upstream
 ```
 
@@ -115,7 +115,7 @@ $ git remote remove upstream
 
 Change your local repository to point to SensorsIot.
 
-```
+``` console
 $ git remote set-url origin https://github.com/SensorsIot/IOTstack.git
 ```
 
@@ -125,7 +125,7 @@ This is where things can get a bit tricky so please read these instructions care
 
 When you run the next command, it will probably give you a small fright by opening a text-editor window. Don't panic - just keep reading. Now, run this command:
 
-```
+``` console
 $ git pull -X theirs origin master
 ```
 
@@ -178,7 +178,7 @@ If you don't use `someRandomService` then you could safely ignore this on the ba
 
 At this point, only the migrated master branch is present on your local copy of the repository. The next command brings you fully in-sync with GitHub:
 
-```
+``` console
 $ git pull
 ```
 
@@ -190,7 +190,7 @@ If you have been following the process correctly, your IOTstack will already be 
 
 Move your old IOTstack folder out of the way, like this:
 
-```
+``` console
 $ cd ~
 $ mv IOTstack IOTstack.old
 ```
@@ -201,13 +201,13 @@ Note:
 
 ##### Fetch a clean clone of SensorsIot/IOTstack
 
-```
+``` console
 $ git clone https://github.com/SensorsIot/IOTstack.git ~/IOTstack
 ```
 
 Explore the result:
 
-```
+``` console
 $ tree -aFL 1 --noreport ~/IOTstack
 /home/pi/IOTstack
 ├── .bash_aliases
@@ -244,7 +244,7 @@ From this, it should be self-evident that a clean checkout from GitHub is the fa
 
 Execute the following commands:
 
-```
+``` console
 $ mv ~/IOTstack.old/docker-compose.yml ~/IOTstack
 $ mv ~/IOTstack.old/services ~/IOTstack
 $ sudo mv ~/IOTstack.old/volumes ~/IOTstack 
@@ -254,21 +254,21 @@ You should not need to use `sudo` for the first two commands. However, if you ge
 
 * docker-compose.yml
 
-	```
+	``` console
 	$ sudo mv ~/IOTstack.old/docker-compose.yml ~/IOTstack
 	$ sudo chown pi:pi ~/IOTstack/docker-compose.yml
 	```
 
 * services
 
-	```
+	``` console
 	$ sudo mv ~/IOTstack.old/services ~/IOTstack
 	$ sudo chown -R pi:pi ~/IOTstack/services
 	```
 
 There is no need to migrate the `backups` directory. You are better off creating it by hand:
 
-```
+``` console
 $ mkdir ~/IOTstack/backups
 ```
 
@@ -333,19 +333,19 @@ You also give up the `compose-override.yml` functionality. On the other hand, Do
 
 If you want to switch to the old menu:
 
-```
+``` console
 $ git checkout old-menu
 ```
 
 Any time you want to switch back to the new menu:
 
-```
+``` console
 $ git checkout master
 ```
 
 You can switch back and forth as much as you like and as often as you like. It's no harm, no foul. The branch you are on just governs what you see when you run:
 
-```
+``` console
 $ ./menu.sh
 ```
 
@@ -357,7 +357,7 @@ Even so, nothing will change **until** you run your chosen menu to completion an
 
 Unless you have gotten ahead of yourself and have already run the menu (old or new) then nothing will have changed in the parts of your `~/IOTstack` folder that define your IOTstack implementation. You can safely:
 
-```
+``` console
 $ docker-compose up -d
 ```
 

--- a/docs/javascript/fix-codeblock-console-copy-button.js
+++ b/docs/javascript/fix-codeblock-console-copy-button.js
@@ -1,0 +1,34 @@
+document.addEventListener("DOMContentLoaded", function() {
+  fixCopyOnlyUserSelectable();
+});
+
+function fixCopyOnlyUserSelectable() {
+  buttonsToFix = document.querySelectorAll(
+    '.language-console button.md-clipboard');
+  if (buttonsToFix.length)
+    console.log('Fixing copy-to-clipboard text of console code-blocks.');
+  buttonsToFix.forEach((btn) => {
+    var content = extractUserSelectable(btn.dataset.clipboardTarget);
+    btn.dataset.clipboardText = content;
+  });
+}
+
+function extractUserSelectable(selector) {
+  var result = '';
+  var element = document.querySelector(selector);
+  element.childNodes.forEach((child) => {
+    if (child instanceof Element) {
+      var s=window.getComputedStyle(child);
+      if (s.getPropertyValue('user-select') == 'none' ||
+        s.getPropertyValue('-webkit-user-select') == 'none' ||
+        s.getPropertyValue('-ms-user-select') == 'none')
+      {
+        return;
+      }
+    }
+    result += child.textContent;
+  });
+  // remove empty lines
+  result = result.replace(/^\s*\n/gm, '')
+  return result;
+}

--- a/docs/style.css
+++ b/docs/style.css
@@ -5,6 +5,13 @@
     display: none;
 }
 
+/* prevent selection of prefix and output for console syntax */
+.language-console .gp, .language-console .go {
+  user-select: none;
+  -webkit-user-select: none; /* Chrome/Safari */
+  -ms-user-select: none; /* IE10+ */
+}
+
 @media screen and (max-width:76.25em) {
   .show-when-wide-layout {
     display:none

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,8 @@ extra_css:
   - style.css
 
 markdown_extensions:
+  - pymdownx.highlight:
+      pygments_lang_class: true
   - admonition
   - pymdownx.superfences
   - toc:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,8 @@ plugins:
 
 extra_css:
   - style.css
+extra_javascript:
+  - javascript/fix-codeblock-console-copy-button.js
 
 markdown_extensions:
   - pymdownx.highlight:


### PR DESCRIPTION
Use the correct `console` highlighting for shell-session code-blocks and prevent user-selection of the leading `$` and lines representing the command output. Do this in order to help the end-user to just copy just the relevant commands to be executed.

* update code blocks where there are both commands and output to use the `console` highlighting.
* prevent user from selecting the leading $ or the command output
  making it easier to copy-paste just all the commands. Done using css. Screenshot of how selection skips unwanted parts:
![image](https://user-images.githubusercontent.com/95980324/163711633-6024c21a-3c17-41da-9505-b8cd89cfce91.png)
* fix the copy button to only copy the user-selectable parts of the code-block. Done with javascript.