### PR TITLE
docs: add missing code highligt types

### DIFF
--- a/docs/Basic_setup/Custom.md
+++ b/docs/Basic_setup/Custom.md
@@ -17,7 +17,7 @@ The `compose-override.yml` file has been added to the `.gitignore` file, so it s
 If you specify an override for a service, and then rebuild the `docker-compose.yml` file, but deselect the service from the list, then the YAML merging will still produce that override.
 
 For example, lets say NodeRed was selected to have have the following override specified in `compose-override.yml`:
-```
+``` yaml
 services:
   nodered:
     restart: always
@@ -36,7 +36,7 @@ Either remove the override for NodeRed in `compose-override.yml` and rebuild the
 
 ### Overriding default settings
 Lets assume you put the following into the `compose-override.yml` file:
-```
+``` yaml
 services:
   mosquitto:
     ports:
@@ -45,7 +45,7 @@ services:
 ```
 
 Normally the mosquitto service would be built like this inside the `docker-compose.yml` file:
-```
+``` yaml
 version: '3.6'
 services:
   mosquitto:
@@ -67,7 +67,7 @@ services:
 Take special note of the ports list.
 
 If you run the build script with the `compose-override.yml` file in place, and open up the final `docker-compose.yml` file, you will notice that the port list have been replaced with the ones you specified in the `compose-override.yml` file.
-```
+``` yaml
 version: '3.6'
 services:
   mosquitto:
@@ -87,7 +87,7 @@ services:
 ```
 
 Do note that it will replace the entire list, if you were to specify
-```
+``` yaml
 services:
   mosquitto:
     ports:
@@ -95,7 +95,7 @@ services:
 ```
 
 Then the final output will be:
-```
+``` yaml
 version: '3.6'
 services:
   mosquitto:
@@ -117,7 +117,7 @@ services:
 
 If you need or prefer to use *.env files for docker-compose environment variables in a separate file instead of using overrides, you can do so like this:
 
-```
+``` yaml
 services:
   grafana:
     env_file:
@@ -131,7 +131,7 @@ This will remove the default environment variables set in the template, and tell
 
 Custom services can be added in a similar way to overriding default settings for standard services. Lets add a Minecraft and rcon server to IOTstack.
 Firstly, put the following into `compose-override.yml`:
-```
+``` yaml
 services:
   mosquitto:
     ports:
@@ -182,7 +182,7 @@ Then simply run the `./menu.sh` command, and rebuild the stack with what ever se
 
 Using the Mosquitto example above, the final `docker-compose.yml` file will look like:
 
-```
+``` yaml
 version: '3.6'
 services:
   mosquitto:

--- a/docs/Basic_setup/Networking.md
+++ b/docs/Basic_setup/Networking.md
@@ -16,12 +16,12 @@ Check the docker-compose.yml to see which ports have been used
 Many containers try to use popular ports such as 80,443,8080. For example openHAB and Adminer both want to use port 8080 for their web interface. Adminer's port has been moved 9080 to accommodate this. Please check the description of the container in the README to see if there are any changes as they may not be the same as the port you are used to.
 
 Port mapping is done in the docker-compose.yml file. Each service should have a section that reads like this:
-```
+``` yaml
     ports:
       - HOST_PORT:CONTAINER_PORT
 ```
 For adminer:
-```
+``` yaml
     ports:
       - 9080:8080
 ```

--- a/docs/Containers/Adminer.md
+++ b/docs/Containers/Adminer.md
@@ -6,7 +6,7 @@
 ## About
 
 This is a nice tool for managing databases. Web interface has moved to port 9080. There was an issue where openHAB and Adminer were using the same ports. If you have an port conflict edit the docker-compose.yml and under the adminer service change the line to read:
-```
+``` yaml
     ports:
       - 9080:8080
 ```

--- a/docs/Containers/Chronograf.md
+++ b/docs/Containers/Chronograf.md
@@ -52,13 +52,13 @@ If you need to pin to a particular version:
 1. Use your favourite text editor to open `docker-compose.yml`.
 2. Find the line:
 
-	```
+	``` yaml
 	image: chronograf:latest
 	```
 
 3. Replace `latest` with the version you wish to pin to. For example, to pin to version 1.9.0:
 
-	```
+	``` yaml
 	image: chronograf:1.9.0
 	```
 

--- a/docs/Containers/Kapacitor.md
+++ b/docs/Containers/Kapacitor.md
@@ -30,13 +30,13 @@ If you need to pin to a particular version:
 1. Use your favourite text editor to open `docker-compose.yml`.
 2. Find the line:
 
-	```
+	``` yaml
    image: kapacitor:1.5
 	```
 
 3. Replace `1.5` with the version you wish to pin to. For example, to pin to version 1.5.9:
 
-	```
+	``` yaml
    image: kapacitor:1.5.9
 	```
 	

--- a/docs/Containers/Node-RED.md
+++ b/docs/Containers/Node-RED.md
@@ -79,7 +79,7 @@ $ docker-compose up -d
 
 `docker-compose` reads the *Compose* file. When it arrives at the `nodered` fragment, it finds:
 
-```
+``` yaml
   nodered:
     container_name: nodered
     build: ./services/nodered/.
@@ -94,7 +94,7 @@ The `build` statement tells `docker-compose` to look for:
 
 The *Dockerfile* begins with:
 
-```
+``` Dockerfile
 FROM nodered/node-red:latest-12
 ```
 
@@ -214,7 +214,7 @@ Node-RED can run in two modes. By default, it runs in "non-host mode" but you ca
 
 1. Add the following directive:
 
-	```
+	``` yml
 	network_mode: host
 	```
 	
@@ -295,7 +295,7 @@ Key point:
 
 The Node-RED service definition in the *Compose* file includes the following:
 
-```
+``` yaml
 volumes:
   - ./volumes/nodered/data:/data
 ```
@@ -699,7 +699,7 @@ $ touch config
 
 Select the following text, copy it to the clipboard.
 
-```
+``` sshconfig
 host «HOSTNAME»
   hostname «HOSTADDR»
   user «USERID»
@@ -713,7 +713,7 @@ Replace the «delimited» keys. Completed examples:
 
 * If you are using the `«HOSTFQDN»` form:
 
-	```
+	``` sshconfig
 	host iot-dev
 	  hostname iot-dev.mydomain.com
 	  user pi
@@ -723,7 +723,7 @@ Replace the «delimited» keys. Completed examples:
 
 * If you are using the `«HOSTIP»` form:
 
-	```
+	``` sshconfig
 	host iot-dev
 	  hostname 192.168.132.9
 	  user pi
@@ -885,7 +885,7 @@ The `--build` option on the `up` command (as distinct from a `docker-compose bui
 
 Out of the box, IOTstack starts the Node-RED *Dockerfile* with:
 
-```
+``` Dockerfile
 FROM nodered/node-red:latest-12
 ```
 
@@ -899,7 +899,7 @@ $ docker exec nodered node --version
 
 In the unlikely event that you need to run an add-on node that needs version 10 of `node.js`, you can pin to version 10.x.x by changing the first line of your *Dockerfile* like this:
 
-```
+``` Dockerfile
 FROM nodered/node-red:latest-10
 ```
 
@@ -921,7 +921,7 @@ Packages installed this way will persist until the container is re-created (eg a
 
 The second method changes the *Dockerfile* to add the packages permanently to your build. You just append the packages to the end of the existing `apk add`:
 
-```
+``` Dockerfile
 RUN apk update && apk add --no-cache eudev-dev mosquitto-clients bind-tools tcpdump
 ```
 
@@ -1013,7 +1013,7 @@ Add-on nodes installed via Manage Palette wind up at the **external** path:
 
 The *Compose* file volumes mapping:
 
-```
+``` yaml
 ./volumes/nodered/data:/data
 ```
 

--- a/docs/Containers/Octoprint.md
+++ b/docs/Containers/Octoprint.md
@@ -14,7 +14,7 @@ title: Octoprint
 
 When you select "OctoPrint" in the IOTstack menu, the service definition in your `docker-compose.yml`, contains the following under the `devices:` heading:
 
-```
+``` yaml
 devices:
   - /dev/ttyAMA0:/dev/ttyACM0
 # - /dev/video0:/dev/video0
@@ -57,7 +57,7 @@ Note:
 
 Assuming the above example output was the answer, edit `docker-compose.yml` to look like this:
 
-```
+``` yaml
 devices:
   - /dev/serial/by-id/usb-Silicon_Labs_CP2102N_USB_to_UART_Bridge_Controller_3b14eaa48a154d5e87032d59459d5206-if00-port0:/dev/ttyACM0
 ```
@@ -136,7 +136,7 @@ $ ls /dev
 
 You should expect to see the human-readable name you chose in the list of devices. You can then edit `docker-compose.yml` to use the name in the device mapping.
 
-```
+``` yaml
 devices:
   - /dev/MasterDisaster5000Pro:/dev/ttyACM0
 ```
@@ -160,7 +160,7 @@ To activate a Raspberry Pi camera attached via ribbon cable:
 2. Confirm the presence of `/dev/video0`.
 3. Edit `docker-compose.yml` and uncomment **all** of the commented-out lines in the following:
 
-	```
+	``` yaml
 	devices:
 	# - /dev/video0:/dev/video0
 	environment:
@@ -175,7 +175,7 @@ To activate a Raspberry Pi camera attached via ribbon cable:
 
 The three environment variables are required:
 
-```
+``` yaml
 environment:
   - ENABLE_MJPG_STREAMER=true
   - MJPG_STREAMER_INPUT=-r 640x480 -f 10 -y
@@ -193,7 +193,7 @@ The typical specs for a baseline Raspberry Pi camera are:
 
 For that type of camera, the following is probably more appropriate:
 
-```
+``` yaml
   - MJPG_STREAMER_INPUT=-r 1152x648 -f 10
 ```
 
@@ -395,7 +395,7 @@ To silence the warning:
 
 3. Implement the following pattern:
 
-	```
+	``` yaml
 	server:
 	  …
 	  ipCheck:

--- a/docs/Containers/Python.md
+++ b/docs/Containers/Python.md
@@ -84,7 +84,7 @@ This is what happens:
 1. *docker-compose* reads your `docker-compose.yml`.
 2. When it finds the service definition for Python, it encounters:
 
-	```
+	``` yaml
 	build: ./services/python/.
 	```
 
@@ -437,7 +437,7 @@ Proceed like this:
 
 4. Edit the `python` service definition in `docker-compose.yml` and replace references to `python` with the name of your project. In the following, the original is on the left, the edited version on the right, and the lines that need to change are indicated with a "|": 
 
-	```
+	``` yaml
 	python:                                  |  wishbone:
 	  container_name: python                 |    container_name: wishbone
 	  build: ./services/python/.             |    build: ./services/wishbone/.

--- a/docs/Containers/Telegraf.md
+++ b/docs/Containers/Telegraf.md
@@ -78,7 +78,7 @@ $ docker-compose up -d
 
 `docker-compose` reads the *Compose* file. When it arrives at the `telegraf` fragment, it finds:
 
-```
+``` yaml
   telegraf:
     container_name: telegraf
     build: ./.templates/telegraf/.

--- a/docs/Developers/BuildStack-RandomPassword.md
+++ b/docs/Developers/BuildStack-RandomPassword.md
@@ -9,7 +9,7 @@ Many services often set a password on their initial spin up and store it interna
 
 ## A basic example
 Inside the service's `service.yml` file, a special string can be added in for the build script to find and replace. Commonly the string is `%randomPassword%`, but technically any string can be used. The same string can be used multiple times for the same password to be used multiple times, and/or multiple difference strings can be used for multiple passwords.
-```
+``` yaml
   mariadb:
     image: linuxserver/mariadb
     container_name: mariadb

--- a/docs/Developers/BuildStack-Services.md
+++ b/docs/Developers/BuildStack-Services.md
@@ -9,7 +9,7 @@ A service only requires 2 files:
 
 ### A basic service
 Inside the `service.yml` is where the service data for docker-compose is housed, for example:
-```
+``` yaml
 adminer:
   container_name: adminer
   image: adminer


### PR DESCRIPTION
Add code-block highlight type (mostly yaml) to code blocks missing them (and not added in any other pull-request).