### PR TITLE
docs/Home: add full site page listing

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ hide:
     IOTstack is a builder for docker-compose to easily make and maintain IoT
     stacks on the Raspberry Pi
 
-Welcome to the IOTstack Wiki:
+Welcome to IOTstack:
 
 * <span class="show-when-wide-layout">
   Use the top tabs and then the left list to explore this Wiki.
@@ -24,3 +24,7 @@ Welcome to the IOTstack Wiki:
 * You're always welcome to ask questions on the [IOTStack Discord](https://discord.gg/ZpKHnks).
 
 * Fixes and improvements welcome, see [Contributing](Developers/)
+
+!!! cite inline end "Full site page listing"
+
+    {nav}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,8 @@ theme:
     - navigation.sections
 
 plugins:
+  - awesome-pages # Required for pagenav-generator
+  - pagenav-generator
   - search
   - redirects:
       # Forward renamed pages to avoid breaking old links.

--- a/requirements-mkdocs.txt
+++ b/requirements-mkdocs.txt
@@ -10,6 +10,7 @@ mkdocs==1.2.3
 mkdocs-awesome-pages-plugin==2.7.0
 mkdocs-material==8.2.3
 mkdocs-material-extensions==1.0.3
+mkdocs-pagenav-generator @ git+https://github.com/Andre601/mkdocs-pagenav-generator@acb5b1561695e8f69d67fda029779f40e4b0beef
 mkdocs-redirects==1.0.3
 packaging==21.3
 Pygments==2.11.2


### PR DESCRIPTION
Preview available at my fork: https://ukkopahis.github.io/IOTstack/

Resolves #520
![image](https://user-images.githubusercontent.com/95980324/166111991-32b1b2db-9bd6-4624-9fe2-0b4caaaa80a4.png)

Makes the page a bit tall, but that's an acceptable compromise:
![image](https://user-images.githubusercontent.com/95980324/166112092-612f773c-606b-4966-bd70-27e4e4c7f36c.png)

