### PR TITLE
Docs: Refactor to define anchors using attribute list

### DIFF
--- a/docs/Containers/AdGuardHome.md
+++ b/docs/Containers/AdGuardHome.md
@@ -9,7 +9,7 @@
 
 AdGuard Home and PiHole perform similar functions. They use the same ports so you can **not** run both at the same time. You must choose one or the other.
 
-## <a name="quickStart"></a>Quick Start
+## Quick Start { #quickStart }
 
 When you first install AdGuard Home:
 

--- a/docs/Containers/Blynk_server.md
+++ b/docs/Containers/Blynk_server.md
@@ -2,7 +2,7 @@
 
 This document discusses an IOTstack-specific version of Blynk-Server. It is built on top of an [Ubuntu](https://hub.docker.com/_/ubuntu) base image using a *Dockerfile*.
 
-## <a name="references"></a>References
+## References { #references }
 
 - [Ubuntu base image](https://hub.docker.com/_/ubuntu) at DockerHub
 - [Peter Knight Blynk-Server fork](https://github.com/Peterkn2001/blynk-server) at GitHub (includes documentation)
@@ -18,7 +18,7 @@ Acknowledgement:
 
 - Original writeup from @877dev
 
-## <a name="significantFiles"></a>Significant directories and files
+## Significant directories and files { #significantFiles }
 
 ```
 ~/IOTstack
@@ -56,19 +56,19 @@ Everything in ❽:
 * will be replaced if it is not present when the container starts; but
 * will never be overwritten if altered by you.
 
-## <a name="howBlynkServerIOTstackGetsBuilt"></a>How Blynk Server gets built for IOTstack
+## How Blynk Server gets built for IOTstack { #howBlynkServerIOTstackGetsBuilt }
 
-### <a name="dockerHubImages"></a>GitHub Updates 
+### GitHub Updates  { #dockerHubImages }
 
 Periodically, the source code is updated and a new version is released. You can check for the latest version at the [releases page](https://github.com/Peterkn2001/blynk-server/releases/).
  
-### <a name="iotstackMenu"></a>IOTstack menu
+### IOTstack menu { #iotstackMenu }
 
 When you select Blynk Server in the IOTstack menu, the *template service definition* is copied into the *Compose* file.
 
 > Under old menu, it is also copied to the *working service definition* and then not really used.
 
-### <a name="iotstackFirstRun"></a>IOTstack first run 
+### IOTstack first run  { #iotstackFirstRun }
 
 On a first install of IOTstack, you run the menu, choose your containers, and are told to do this:
 
@@ -131,7 +131,7 @@ You *may* see the same pattern in *Portainer*, which reports the ***base image**
 
 > Whether you see one or two rows depends on the version of `docker-compose` you are using and how your version of `docker-compose` builds local images.
 
-## <a name="logging"></a>Logging
+## Logging { #logging }
 
 You can inspect Blynk Server's log by:
 
@@ -139,7 +139,7 @@ You can inspect Blynk Server's log by:
 $ docker logs blynk_server
 ```
 
-## <a name="editConfiguration"></a>Changing Blynk Server's configuration
+## Changing Blynk Server's configuration { #editConfiguration }
 
 The first time you launch the `blynk_server` container, the following structure will be created in the persistent storage area:
 
@@ -158,7 +158,7 @@ $ cd ~/IOTstack
 $ docker-compose restart blynk_server
 ```
 
-## <a name="cleanSlate"></a>Getting a clean slate
+## Getting a clean slate { #cleanSlate }
 
 Erasing Blynk Server's persistent storage area triggers self-healing and restores known defaults:
 
@@ -178,7 +178,7 @@ Note:
 	$ docker-compose restart blynk_server
 	```
 
-## <a name="upgradingBlynkServer"></a>Upgrading Blynk Server
+## Upgrading Blynk Server { #upgradingBlynkServer }
 
 To find out when a new version has been released, you need to visit the [Blynk-Server releases](https://github.com/Peterkn2001/blynk-server/releases/) page at GitHub.
 
@@ -220,11 +220,11 @@ At the time of writing, version 0.41.16 was the most up-to-date. Suppose that ve
 
 		The second `prune` will only be needed if there is an old *base image* and that, in turn, depends on the version of `docker-compose` you are using and how your version of `docker-compose` builds local images.
 
-## <a name="usingBlynkServer"></a>Using Blynk Server
+## Using Blynk Server { #usingBlynkServer }
 
 See the [References](#references) for documentation links.
 
-### <a name="blynkAdmin"></a>Connecting to the administrative UI
+### Connecting to the administrative UI { #blynkAdmin }
 
 To connect to the administrative interface, navigate to:
 
@@ -237,7 +237,7 @@ You may encounter browser security warnings which you will have to acknowledge i
 - username = `admin@blynk.cc`
 - password = `admin`
 
-### <a name="changePassword"></a>Change username and password
+### Change username and password { #changePassword }
 
 1. Click on Users > "email address" and edit email, name and password. 
 2. Save changes.
@@ -248,19 +248,19 @@ You may encounter browser security warnings which you will have to acknowledge i
 	$ docker-compose restart blynk_server
 	```
 
-### <a name="gmailSetup"></a>Setup gmail
+### Setup gmail { #gmailSetup }
 
 Optional step, useful for getting the auth token emailed to you.
 (To be added once confirmed working....)
 
-### <a name="mobileSetup"></a>iOS/Android app setup
+### iOS/Android app setup { #mobileSetup }
 
 1. When setting up the application on your mobile be sure to select "custom" setup [see](https://github.com/Peterkn2001/blynk-server#app-and-sketch-changes).
 2. Press "New Project"
 3. Give it a name, choose device "Raspberry Pi 3 B" so you have plenty of [virtual pins](http://help.blynk.cc/en/articles/512061-what-is-virtual-pins) available, and lastly select WiFi.
 4. Create project and the [auth token](https://docs.blynk.cc/#getting-started-getting-started-with-the-blynk-app-4-auth-token) will be emailed to you (if emails configured). You can also find the token in app under the phone app settings, or in the admin web interface by clicking Users>"email address" and scroll down to token.
 
-### <a name="quickAppGuide"></a>Quick usage guide for app
+### Quick usage guide for app { #quickAppGuide }
 
 1. Press on the empty page, the widgets will appear from the right.
 2. Select your widget, let's say a button.
@@ -273,7 +273,7 @@ Optional step, useful for getting the auth token emailed to you.
 
 Enter Node-Red.....
 
-### <a name="enterNodeRed"></a>Node-RED
+### Node-RED { #enterNodeRed }
 
 1. Install `node-red-contrib-blynk-ws` from Manage Palette.
 2. Drag a "write event" node into your flow, and connect to a debug node

--- a/docs/Containers/Home-Assistant.md
+++ b/docs/Containers/Home-Assistant.md
@@ -2,7 +2,7 @@
 
 Home Assistant is a home automation platform. It is able to track and control all devices at your home and offer a platform for automating control.
 
-## <a name="references"></a>References
+## References { #references }
 
 - [Home Assistant home page](https://www.home-assistant.io/)
 
@@ -13,7 +13,7 @@ Home Assistant is a home automation platform. It is able to track and control al
 - [DockerHub](https://hub.docker.com/r/homeassistant/home-assistant/)
 
 
-## <a name="twoVersions"></a>Home Assistant: two versions
+## Home Assistant: two versions { #twoVersions }
 
 There are two versions of Home Assistant:
 
@@ -36,7 +36,7 @@ If Home Assistant Container will not do what you want then, basically, you will 
 * One running Raspberry Pi OS ("Raspbian") hosting IOTstack; and
 * Another dedicated to running [Home Assistant Operating System](https://www.home-assistant.io/installation/raspberrypi).
 
-## <a name="installHAContainer"></a>Installing Home Assistant Container
+## Installing Home Assistant Container { #installHAContainer }
 
 Home Assistant (Container) can be found in the `Build Stack` menu. Selecting it in this menu results in a service definition being added to:
 
@@ -61,7 +61,7 @@ $ cd ~/IOTstack
 $ docker-compose up -d
 ```
 
-## <a name="usingBluetooth"></a>Using bluetooth from the container
+## Using bluetooth from the container { #usingBluetooth }
 
 In order to be able to use BT & BLE devices from HA integrations, make sure that Bluetooth is enabled:
 
@@ -98,7 +98,7 @@ If `AutoEnable` is either missing or not set to `true`, then:
 
 See also: [Scribles: Auto Power On Bluetooth Adapter on Boot-up](https://scribles.net/auto-power-on-bluetooth-adapter-on-boot-up/).
 
-## <a name="httpsWithSSLcert"></a>HTTPS with a valid SSL certificate
+## HTTPS with a valid SSL certificate { #httpsWithSSLcert }
 
 Some HA integrations (e.g google assistant) require your HA API to be
 accessible via https with a valid certificate. You can configure HA to do this:
@@ -227,7 +227,7 @@ your RPi hostname is raspberrypi)
     `https://homeassistant.<yourdomain>.duckdns.org/` Now the certificate
     should work without any warnings.
 
-## <a name="hassioBackground"></a>about Supervised Home Assistant
+## about Supervised Home Assistant { #hassioBackground }
 
 IOTstack used to offer a menu entry leading to a convenience script that could install Supervised Home Assistant. That script stopped working when Home Assistant changed their approach. The script's author [made it clear](https://github.com/Kanga-Who/home-assistant/blob/master/Supervised%20on%20Raspberry%20Pi%20with%20Debian.md) that script's future was bleak so the affordance was [removed from IOTstack](https://github.com/SensorsIot/IOTstack/pull/493).
 

--- a/docs/Containers/MariaDB.md
+++ b/docs/Containers/MariaDB.md
@@ -68,9 +68,9 @@ To close the terminal session, either:
 * type "exit" and press <kbd>return</kbd>; or
 * press <kbd>control</kbd>+<kbd>d</kbd>.
 
-## <a name="healthCheck"></a>Container health check
+## Container health check { #healthCheck }
 
-### <a name="healthCheckTheory"></a>theory of operation
+### theory of operation { #healthCheckTheory }
 
 A script , or "agent", to assess the health of the MariaDB container has been added to the *local image* via the *Dockerfile*. In other words, the script is specific to IOTstack.
 
@@ -92,7 +92,7 @@ The agent is invoked 30 seconds after the container starts, and every 30 seconds
 
 4. If all of those steps succeed, the agent concludes that MariaDB is functioning properly and returns "healthy".
 
-### <a name="healthCheckMonitor"></a>monitoring health-check
+### monitoring health-check { #healthCheckMonitor }
 
 Portainer's *Containers* display contains a *Status* column which shows health-check results for all containers that support the feature.
 
@@ -125,7 +125,7 @@ Possible reply patterns are:
 	mariadb   Up About a minute (unhealthy)
 	```
 
-### <a name="healthCheckCustom"></a>customising health-check
+### customising health-check { #healthCheckCustom }
 
 You can customise the operation of the health-check agent by editing the `mariadb` service definition in your *Compose* file:
 

--- a/docs/Containers/Mosquitto.md
+++ b/docs/Containers/Mosquitto.md
@@ -159,7 +159,7 @@ You *may* see the same pattern in Portainer, which reports the *base image* as "
 
 > Whether you see one or two rows depends on the version of `docker-compose` you are using and how your version of `docker-compose` builds local images.
 
-### <a name="migration"></a>Migration considerations
+### Migration considerations { #migration }
 
 Under the original IOTstack implementation of Mosquitto (just "as it comes" from *DockerHub*), the service definition expected the configuration files to be at:
 
@@ -518,7 +518,7 @@ The agent is invoked 30 seconds after the container starts, and every 30 seconds
 * Subscribes to the same broker for the same topic for a single message event.
 * Compares the payload sent with the payload received. If the payloads (ie time-stamps) match, the agent concludes that the Mosquitto broker (the process running inside the same container) is functioning properly for round-trip messaging.
 
-### <a name="healthCheckMonitor"></a>monitoring health-check
+### monitoring health-check { #healthCheckMonitor }
 
 Portainer's *Containers* display contains a *Status* column which shows health-check results for all containers that support the feature.
 
@@ -564,7 +564,7 @@ Notes:
 * If you enable authentication for your Mosquitto broker, you will need to add `-u «user»` and `-P «password»` parameters to this command.
 * You should expect to see a new message appear approximately every 30 seconds. That indicates the health-check agent is functioning normally. Use <kbd>control</kbd>+<kbd>c</kbd> to terminate the command.
 
-### <a name="healthCheckCustom"></a>customising health-check
+### customising health-check { #healthCheckCustom }
 
 You can customise the operation of the health-check agent by editing the `mosquitto` service definition in your *Compose* file:
 
@@ -655,7 +655,7 @@ Your existing Mosquitto container continues to run while the rebuild proceeds. O
 
 The `prune` is the simplest way of cleaning up. The first call removes the old *local image*. The second call cleans up the old *base image*. Whether an old *base image* exists depends on the version of `docker-compose` you are using and how your version of `docker-compose` builds local images.
 
-### <a name="versionPinning"></a>Mosquitto version pinning
+### Mosquitto version pinning { #versionPinning }
 
 If an update to Mosquitto introduces a breaking change, you can revert to an earlier know-good version by pinning to that version. Here's how:
 

--- a/docs/Containers/NextCloud.md
+++ b/docs/Containers/NextCloud.md
@@ -1,6 +1,6 @@
 # Nextcloud
 
-## <a name="serviceDefinition"></a>Service definition
+## Service definition { #serviceDefinition }
 
 This is the **core** of the IOTstack Nextcloud service definition:
 
@@ -54,7 +54,7 @@ Under new-menu, the menu can generate random passwords for you. You can either u
 
 The passwords need to be set before you bring up the Nextcloud service for the first time but the following initialisation steps assume you might not have done that and always start over from a clean slate.
 
-## <a name="initialisation"></a>Initialising Nextcloud 
+## Initialising Nextcloud  { #initialisation }
 
 1. Be in the correct directory:
 
@@ -174,7 +174,7 @@ The passwords need to be set before you bring up the Nextcloud service for the f
 
 	![Dashboard](./images/nextcloud-dashboard.png)
 
-## <a name="untrustedDomain"></a>"Access through untrusted domain"
+## "Access through untrusted domain" { #untrustedDomain }
 
 During Nextcloud initialisation you had to choose between an IP address, a domain name or a host name. Now that Nextcloud is running, you have the opportunity to expand your connection options.
 
@@ -243,7 +243,7 @@ See also:
 
 * [Nextcloud documentation - trusted domains](https://docs.nextcloud.com/server/21/admin_manual/installation/installation_wizard.html#trusted-domains).
 
-### <a name="dnsAlias"></a>Using a DNS alias for your Nextcloud service
+### Using a DNS alias for your Nextcloud service { #dnsAlias }
 
 The examples above include using a DNS alias (a CNAME record) for your Nextcloud service. If you decide to do that, you may see this warning in the log:
 
@@ -257,17 +257,17 @@ You can silence the warning by editing the Nextcloud service definition in `dock
     hostname: nextcloud.mydomain.com
 ```
 
-## <a name="security"></a>Security considerations
+## Security considerations { #security }
 
 Nextcloud traffic is not encrypted. Do **not** expose it to the web by opening a port on your home router. Instead, use a VPN like Wireguard to provide secure access to your home network, and let your remote clients access Nextcloud over the VPN tunnel.
 
-## <a name="healthCheck"></a>Container health check 
+## Container health check  { #healthCheck }
 
 A script , or "agent", to assess the health of the MariaDB container has been added to the *local image* via the *Dockerfile*. In other words, the script is specific to IOTstack.
 
 Because it is an instance of MariaDB, Nextcloud_DB inherits the health-check agent. See the [IOTstack MariaDB](MariaDB.md) documentation for more information.
 
-## <a name="updatingNextcloud"></a>Keeping Nextcloud up-to-date
+## Keeping Nextcloud up-to-date { #updatingNextcloud }
 
 To update the `nextcloud` container:
 
@@ -290,7 +290,7 @@ $ docker system prune
 
 The first "prune" removes the old *local* image, the second removes the old *base* image. Whether an old *base image* exists depends on the version of `docker-compose` you are using and how your version of `docker-compose` builds local images.
 
-## <a name="backups"></a>Backups
+## Backups { #backups }
 
 Nextcloud is currently excluded from the IOTstack-supplied backup scripts due to its potential size.
 

--- a/docs/Containers/Node-RED.md
+++ b/docs/Containers/Node-RED.md
@@ -1,13 +1,13 @@
 # Node-RED
 
-## <a name=references></a>References
+## References { #references }
 
 - [nodered.org home](https://nodered.org/)
 - [GitHub: node-red/node-red-docker](https://github.com/node-red/node-red-docker)
 - [DockerHub: nodered/node-red](https://hub.docker.com/r/nodered/node-red)
 - [Tutorial: from MQTT to InfluxDB via Node-Red](https://gist.github.com/Paraphraser/c9db25d131dd4c09848ffb353b69038f)
 
-## <a name="significant-files"></a>Significant files
+## Significant files { #significant-files }
 
 ```
 ~/IOTstack
@@ -33,13 +33,13 @@
 6. Data directory (mapped volume).
 7. SSH directory (mapped volume).
 
-## <a name="iotstackBuild"></a>How Node-RED gets built for IOTstack
+## How Node-RED gets built for IOTstack { #iotstackBuild }
 
-### <a name="gitHubSource"></a>Node-RED source code ([GitHub](https://github.com))
+### Node-RED source code ([GitHub](https://github.com)) { #gitHubSource }
 
 The source code for Node-RED lives at [GitHub node-red/node-red-docker](https://github.com/node-red/node-red-docker).
 
-### <a name="dockerHubImages"></a>Node-RED images ([DockerHub](https://hub.docker.com))
+### Node-RED images ([DockerHub](https://hub.docker.com)) { #dockerHubImages }
 
 Periodically, the source code is recompiled and pushed to [nodered/node-red](https://hub.docker.com/r/nodered/node-red/tags?page=1&ordering=last_updated) on *DockerHub*. There's a lot of stuff at that page but it boils down to variations on two basic themes:
 
@@ -53,7 +53,7 @@ The suffixes refer to the version of "Node.js" installed when the image was buil
 
 As you will see a bit further down, the current default for IOTstack is an image tag of `latest-12` which means Node-RED 2.x.x with Node.js version 12. 
  
-### <a name="iotstackMenu"></a>IOTstack menu
+### IOTstack menu { #iotstackMenu }
 
 When you select Node-RED in the IOTstack menu, the *template service definition* is copied into the *Compose* file.
 
@@ -68,7 +68,7 @@ Key points:
 
 Choosing add-on nodes in the menu causes the *Dockerfile* to be created.
 
-### <a name="iotstackFirstRun"></a>IOTstack first run
+### IOTstack first run { #iotstackFirstRun }
 
 On a first install of IOTstack, you are told to do this:
 
@@ -135,9 +135,9 @@ You should not remove the *base* image, even though it appears to be unused.
 
 > Whether you see one or two rows depends on the version of `docker-compose` you are using and how your version of `docker-compose` builds local images.
 
-## <a name="securingNodeRed"></a>Securing Node-RED
+## Securing Node-RED { #securingNodeRed }
 
-### <a name="encryptionKey"></a>Setting an encryption key for your credentials
+### Setting an encryption key for your credentials { #encryptionKey }
 
 After you install Node-RED, you should set an encryption key. Completing this step will silence the warning you will see when you run:
 
@@ -192,7 +192,7 @@ $ cd ~/IOTstack
 $ docker-compose restart nodered
 ```
 
-### <a name="credentials"></a>Setting a username and password for Node-RED
+### Setting a username and password for Node-RED { #credentials }
 
 To secure Node-RED you need a password hash. Run the following command, replacing `PASSWORD` with your own password:
 
@@ -208,7 +208,7 @@ $2a$08$gTdx7SkckJVCw1U98o4r0O7b8P.gd5/LAPlZI6geg5LRg4AUKuDhS
 
 Copy that text to your clipboard, then follow the instructions at [Node-RED User Guide - Securing Node-RED - Username & Password-based authentication](https://nodered.org/docs/user-guide/runtime/securing-node-red#usernamepassword-based-authentication).
 
-## <a name="containerNames"></a>Referring to other containers
+## Referring to other containers { #containerNames }
 
 Node-RED can run in two modes. By default, it runs in "non-host mode" but you can also move the container to "host mode" by editing the Node-RED service definition in your *Compose* file to:
 
@@ -220,7 +220,7 @@ Node-RED can run in two modes. By default, it runs in "non-host mode" but you ca
 	
 2. Remove the `ports` directive and the mapping of port 1880.
 
-### <a name="nonHostMode"></a>When Node-RED is not in host mode
+### When Node-RED is not in host mode { #nonHostMode }
 
 Most examples on the web assume Node-RED and other services in the MING (Mosquitto, InfluxDB, Node-RED, Grafana) stack have been installed natively, rather than in Docker containers. Those examples typically include the loopback address + port syntax, like this:
 
@@ -244,7 +244,7 @@ influxdb:8086
 
 Behind the scenes, Docker maintains a table similar to an `/etc/hosts` file mapping container names to the IP addresses on the internal bridged network that are assigned, dynamically, by Docker when it spins up each container.
 
-### <a name="hostmode"></a>When Node-RED is in host mode
+### When Node-RED is in host mode { #hostmode }
 
 This is where you use loopback+port syntax, such as the following to communicate with Mosquitto:
 
@@ -254,7 +254,7 @@ This is where you use loopback+port syntax, such as the following to communicate
 
 What actually occurs is that Docker is listening to external port 1883 on behalf of Mosquitto. It receives the packet and routes it (layer three) to the internal bridged network, performing network address translation (NAT) along the way to map the external port to the internal port. Then the packet is delivered to Mosquitto. The reverse happens when Mosquitto replies. It works but is less efficient than when all containers are in non-host mode. 
 
-## <a name="accessGPIO"></a>GPIO Access
+## GPIO Access { #accessGPIO }
 
 To communicate with your Raspberry Pi's GPIO you need to do the following:
 
@@ -281,7 +281,7 @@ To communicate with your Raspberry Pi's GPIO you need to do the following:
 
 4. Drag a gpio node onto the canvas and configure it using the IP address of your Raspberry Pi (eg 192.168.1.123). Don't try to use 127.0.0.1 because that is the loopback address of the Node-RED container.
 
-## <a name="fileSharing"></a>Sharing files between Node-RED and the Raspberry Pi
+## Sharing files between Node-RED and the Raspberry Pi { #fileSharing }
 
 Containers run in a sandboxed environment. A process running inside a container can't see the Raspberry Pi's file system. Neither can a process running outside a container access files inside the container.
 
@@ -372,7 +372,7 @@ Deploying the flow and clicking on the Inject node results in the debug message 
 
 You can reverse this process. Any file you place within the path `~/IOTstack/volumes/nodered/data` can be read by a "File in" node.
 
-## <a name="sshOutside"></a>Executing commands outside the Node-RED container
+## Executing commands outside the Node-RED container { #sshOutside }
 
 A reasonably common requirement in a Node-RED flow is the ability to execute a command on the host system. The standard tool for this is an "exec" node.
 
@@ -400,7 +400,7 @@ The same thing will happen if a Node-RED "exec" node executes that `grep` comman
 
 Docker doesn't provide any mechanism for a container to execute an arbitrary command **outside** of its container. A workaround is to utilise SSH. This remainder of this section explains how to set up the SSH scaffolding so that "exec" nodes running in a Node-RED container can invoke arbitrary commands **outside** container-space.
 
-### <a name="sshTaskGoal"></a>Task Goal
+### Task Goal { #sshTaskGoal }
 
 Be able to use a Node-RED `exec` node to perform the equivalent of:
 
@@ -413,14 +413,14 @@ where:
 * `«HOSTNAME»` is any host under your control (not just the Raspberry Pi running IOTstack); and
 * `«COMMAND»` is any command known to the target host.
 
-### <a name="sshAssumptions"></a>Assumptions
+### Assumptions { #sshAssumptions }
 
 * [SensorsIot/IOTstack](https://github.com/SensorsIot/IOTstack) is installed on your Raspberry Pi.
 * The Node-RED container is running.
 
 These instructions are specific to IOTstack but the underlying concepts should apply to any installation of Node-RED in a Docker container. 
 
-### <a name="dockerExec"></a>Executing commands "inside" a container
+### Executing commands "inside" a container { #dockerExec }
 
 These instructions make frequent use of the ability to run commands "inside" the Node-RED container. For example, suppose you want to execute:
 
@@ -466,11 +466,11 @@ You have several options:
 
 3. Run the command from Portainer by selecting the container, then clicking the ">_ console" link. This is identical to opening a shell.
 
-### <a name="variableDefinitions"></a>Variable definitions
+### Variable definitions { #variableDefinitions }
 
 You will need to have a few concepts clear in your mind before you can set up SSH successfully. I use double-angle quote marks (guillemets) to mean "substitute the appropriate value here".  
 
-#### <a name="sshHostname"></a>«HOSTNAME» (required)
+#### «HOSTNAME» (required) { #sshHostname }
 
 The name of your Raspberry Pi. When you first booted your RPi, it had the name "raspberrypi" but you probably changed it using `raspi-config`. Example:
 
@@ -478,7 +478,7 @@ The name of your Raspberry Pi. When you first booted your RPi, it had the name "
 iot-dev
 ```
 
-#### <a name="sshHostAddr"></a>«HOSTADDR» (required)
+#### «HOSTADDR» (required) { #sshHostAddr }
 
 Either or both of the following:
 
@@ -507,7 +507,7 @@ Either or both of the following:
 	* a static DHCP assignment configured on your DHCP server (eg your router) which always returns the same IP address for a given MAC address; or
 	* a static IP address configured on your Raspberry Pi.
 
-#### <a name="sshUserID"></a>«USERID» (required)
+#### «USERID» (required) { #sshUserID }
 
 The user ID of the account on «HOSTNAME» where you want Node-RED flows to be able to run commands. Example:
 
@@ -515,7 +515,7 @@ The user ID of the account on «HOSTNAME» where you want Node-RED flows to be a
 pi
 ```
 
-### <a name="sshStep1"></a>Step 1: *Generate SSH key-pair for Node-RED* (one time)
+### Step 1: *Generate SSH key-pair for Node-RED* (one time) { #sshStep1 }
 
 Create a key-pair for Node-RED. This is done by executing the `ssh-keygen` command **inside** the container:
 
@@ -531,7 +531,7 @@ Notes:
 	* press "y" to overwrite (and lose the old keys)
 	* press "n" to terminate the command, after which you can investigate why a key-pair already exists.
 
-### <a name="sshStep2"></a>Step 2: *Exchange keys with target hosts* (once per target host)
+### Step 2: *Exchange keys with target hosts* (once per target host) { #sshStep2 }
 
 Node-RED's public key needs to be copied to the user account on *each* target machine where you want a Node-RED "exec" node to be able to execute commands. At the same time, the Node-RED container needs to learn the public host key of the target machine. The `ssh-copy-id` command does both steps. The required syntax is:
 
@@ -581,7 +581,7 @@ and check to make sure that only the key(s) you wanted were added.
 
 If you do not see an indication that a key has been added, you may need to retrace your steps.
 
-### <a name="sshStep3"></a>Step 3: *Perform the recommended test*
+### Step 3: *Perform the recommended test* { #sshStep3 }
 
 The output above recommends a test. The test needs to be run **inside** the Node-RED container so the syntax is:
 
@@ -602,9 +602,9 @@ If everything works as expected, you should see a list of the files in your IOTs
 
 Assuming success, think about what just happened? You told SSH **inside** the Node-RED container to run the `ls` command **outside** the container on your Raspberry Pi. You broke through the containerisation.
 
-### <a name="sshWhatsWhere"></a>Understanding what's where and what each file does
+### Understanding what's where and what each file does { #sshWhatsWhere }
 
-#### <a name="sshFileLocations"></a>What files are where
+#### What files are where { #sshFileLocations }
 
 Six files are relevant to Node-RED's ability to execute commands outside of container-space:
 
@@ -654,7 +654,7 @@ Six files are relevant to Node-RED's ability to execute commands outside of cont
 		
 		Note that providing the correct password at the command line will auto-repair the `authorized_keys` file.
 
-#### <a name="sshFilePurpose"></a>What each file does
+#### What each file does { #sshFilePurpose }
 
 SSH running **inside** the Node-RED container uses the Node-RED container's private key to provide assurance to SSH running **outside** the container that it (the Node-RED container) is who it claims to be.
 
@@ -664,7 +664,7 @@ SSH running **outside** container-space uses the Raspberry Pi's private host key
 
 SSH running **inside** the Node-RED container verifies that assurance by using its copy of the Raspberry Pi's public host key stored in `known_hosts`.
 
-### <a name="sshConfig"></a>Config file (optional)
+### Config file (optional) { #sshConfig }
 
 You don't **have** to do this step but it will simplify your exec node commands and reduce your maintenance problems if you do.
 
@@ -741,7 +741,7 @@ $ sudo chown root:root config
 $ sudo mv config ./volumes/nodered/ssh
 ```
 
-#### <a name="sshConfigTest"></a>Re-test with config file in place
+#### Re-test with config file in place { #sshConfigTest }
 
 The previous test used this syntax:
 
@@ -763,7 +763,7 @@ $ docker exec nodered ssh «HOSTNAME» ls -1 /home/pi/IOTstack
 
 The result should be the same as the earlier test. 
 
-### <a name="sshTestFlow"></a>A test flow
+### A test flow { #sshTestFlow }
 
 ![node-red-exec-node-ssh-test](./images/nodered-exec-node-ssh-test.jpeg)
 
@@ -805,7 +805,7 @@ In the Node-RED GUI:
 	
 	The first line is the result of running the command inside the Node-RED container. The second line is the result of running the same command outside the Node-RED container on the Raspberry Pi.
 
-### <a name="addHostname"></a>Suppose you want to add another «HOSTNAME»
+### Suppose you want to add another «HOSTNAME» { #addHostname }
 
 1. Exchange keys with the new target host using:
 
@@ -821,7 +821,7 @@ In the Node-RED GUI:
 	
 	to define the new host. Remember to use `sudo` to edit the file. There is no need to restart Node-RED or recreate the container.
 
-## <a name="upgradeNodeRed"></a>Upgrading Node-RED
+## Upgrading Node-RED { #upgradeNodeRed }
 
 You can update most containers like this:
 
@@ -863,7 +863,7 @@ Your existing Node-RED container continues to run while the rebuild proceeds. On
 The `prune` is the simplest way of cleaning up old images. Sometimes you need to run this twice, the first time to clean up the old local image, the second time for the old base image. Whether an old base image exists depends on the version of `docker-compose` you are using and how your version of `docker-compose` builds local images.
 
 
-## <a name="customiseNodeRed"></a>Customising Node-RED
+## Customising Node-RED { #customiseNodeRed }
 
 You customise your *local* image of Node-RED by making changes to:
 
@@ -871,7 +871,7 @@ You customise your *local* image of Node-RED by making changes to:
 ~/IOTstack/services/nodered/Dockerfile
 ```
 
-<a name="applyDockerfileChange">You apply a Dockerfile change like this:</a>
+##### Apply Dockerfile changes { #applyDockerfileChange }
 
 ``` console
 $ cd ~/IOTstack
@@ -881,7 +881,7 @@ $ docker system prune
 
 The `--build` option on the `up` command (as distinct from a `docker-compose build` command) works in this situation because you've made a substantive change to your *Dockerfile*.
 
-### <a name="nodeJSversion"></a>Node.js version
+### Node.js version { #nodeJSversion }
 
 Out of the box, IOTstack starts the Node-RED *Dockerfile* with:
 
@@ -905,7 +905,7 @@ FROM nodered/node-red:latest-10
 
 Once you have made that change, follow the steps at [apply *Dockerfile* changes](#applyDockerfileChange).
 
-### <a name="addPackage"></a>Adding extra packages
+### Adding extra packages { #addPackage }
 
 As well as providing the Node-RED service, the nodered container is an excellent testbed. Installing the DNS tools, Mosquitto clients and tcpdump will help you to figure out what is going on **inside** container-space.
 
@@ -929,7 +929,7 @@ You can add as many extra packages as you like. They will persist until you chan
 
 Once you have made this change, follow the steps at [apply *Dockerfile* changes](#applyDockerfileChange).
 
-### <a name="addNodes"></a>Adding extra nodes
+### Adding extra nodes { #addNodes }
 
 You can install nodes by:
 
@@ -997,7 +997,7 @@ If you're wondering about "backup", nodes installed via:
 
 Basically, if you're running IOTstack backups then your add-on nodes will be backed-up.
 
-### <a name="nodePrecedence"></a>Node precedence
+### Node precedence { #nodePrecedence }
 
 Add-on nodes that are installed via *Dockerfile* wind up at the **internal** path:
 
@@ -1037,7 +1037,7 @@ take precedence over those installed at:
 
 Or, to put it more simply: in any contest, Manage Palette prevails over *Dockerfile*.
 
-### <a name="fixDuplicateNodes"></a>Resolving node duplication
+### Resolving node duplication { #fixDuplicateNodes }
 
 Sometimes, even when you are 100% certain that **you** didn't do it, an add-on node will turn up in both places. There is probably some logical reason for this but I don't know what it is.
 

--- a/docs/Containers/Pi-hole.md
+++ b/docs/Containers/Pi-hole.md
@@ -2,13 +2,13 @@
 
 Pi-hole is a fantastic utility to reduce ads.
 
-## <a name="references"></a>References
+## References { #references }
 
 * [Pi-hole on GitHub](https://github.com/pi-hole/docker-pi-hole)
 * [Pi-hole on Dockerhub](https://hub.docker.com/r/pihole/pihole)
 * [Pi-hole environment variables](https://github.com/pi-hole/docker-pi-hole#environment-variables)
 
-## <a name="envVars"></a>Environment variables 
+## Environment variables  { #envVars }
 
 In conjunction with controls in Pi-hole's web GUI, environment variables govern much of Pi-hole's behaviour. If you are running new menu (master branch), the variables are inline in `docker-compose.yml`. If you are running old menu, the variables will be in:
 
@@ -23,7 +23,7 @@ Pi-hole's authoritative list of environment variables can be found [here](https:
 1. If you ever need to reset Pi-hole by [erasing its persistent storage area](#cleanSlate), configuration options set using environment variables will persist while those set through the GUI may be lost; and
 2. On at least two occasions in its history, Pi-hole upgrades have had the effect of wiping configuration options set through the GUI, whereas options set using environment variables survived. 
 
-### <a name="adminPassword"></a>Admin password
+### Admin password { #adminPassword }
 
 The first time Pi-hole is launched, it checks for the `WEBPASSWORD` environment variable. If found, the right hand side becomes the administrative password.
 
@@ -82,7 +82,7 @@ $ docker exec pihole pihole -a -p mybigsecret
 
 > replacing "mybigsecret" with your choice of password.
 
-### <a name="otherVars"></a>Other variables
+### Other variables { #otherVars }
 
 Most of Pi-hole's environment variables are self-explanatory but some can benefit from elaboration.
 
@@ -162,9 +162,9 @@ Pi-hole has its own built-in DNS server which can answer both kinds of queries. 
 
 	When you set `REV_SERVER_CIDR=192.168.1.0/24` you are telling Pi-hole that *reverse queries* for the host range 192.168.1.1 through 192.168.1.254 should be sent to the `REV_SERVER_TARGET=192.168.1.5`.
 
-## <a name="webGUI"></a>Pi-hole Web GUI
+## Pi-hole Web GUI { #webGUI }
 
-### <a name="connectGUI"></a>Connecting to the GUI
+### Connecting to the GUI { #connectGUI }
 
 Point your browser to:
 
@@ -178,7 +178,7 @@ where «your_ip» can be:
 * The domain name of the Raspberry Pi running Pi-hole.
 * The multicast DNS name (eg "raspberrypi.local") of the Raspberry Pi running Pi-hole.
 
-### <a name="localNames"></a>Adding local domain names
+### Adding local domain names { #localNames }
 
 Login to the Pi-hole web interface: `http://raspberrypi.local:8089/admin`:
 
@@ -190,15 +190,15 @@ Now you can use `raspberrypi.home.arpa` as the domain name for the Raspberry Pi
 in your whole local network. You can also add domain names for your other
 devices, provided they too have static IPs.
 
-#### <a name="homeArpa"></a>why .home.arpa?
+#### why .home.arpa? { #homeArpa }
 
 Instead of `.home.arpa` - which is the real standard, but a mouthful - you may
 use `.internal`. Using `.local` would technically also work, but it should be
 reserved only for mDNS use.
 
-## <a name="rpiConfig"></a>Configuring the Raspberry Pi running Pi-hole
+## Configuring the Raspberry Pi running Pi-hole { #rpiConfig }
 
-### <a name="rpiFixedIP"></a>Assign a fixed IP address
+### Assign a fixed IP address { #rpiFixedIP }
 
 If you want clients on your network to use Pi-hole for their DNS, the Raspberry Pi running Pi-hole **must** have a fixed IP address. It does not have to be a *static* IP address (in the sense of being hard-coded into the Raspberry Pi). The Raspberry Pi can still obtain its IP address from DHCP at boot time, providing your DHCP server (usually your home router) always returns the same IP address. This is usually referred to as a *static binding* and associates the Raspberry Pi's MAC address with a fixed IP address.
 
@@ -221,7 +221,7 @@ In the above:
 
 If a physical interface does not exist, the command returns "Device does not exist" for that interface. If you prefer, you can also substitute the `ifconfig` command for `ip link show`. It's just a little more wordy.
 
-### <a name="rpiDNS"></a>Decide how the Raspberry Pi obtains its own DNS
+### Decide how the Raspberry Pi obtains its own DNS { #rpiDNS }
 
 The Raspberry Pi itself does **not** have to use the Pi-hole container for its own DNS services. Some chicken-and-egg situations can exist if, for example, the Pi-hole container is down when another process (eg `apt` or `docker-compose`) needs to do something that depends on DNS services being available.
 
@@ -257,7 +257,7 @@ In words:
 3. `resolv_conf_local_only=NO` is needed so that 127.0.0.1 and 8.8.8.8 can coexist.
 4. The `resolvconf -u` command instructs Raspberry Pi OS to rebuild the active resolver configuration. In principle, that means parsing `/etc/resolvconf.conf` to derive `/etc/resolv.conf`. This command can sometimes return the error "Too few arguments". You should ignore that error.
 
-#### <a name="rpiDNSExample"></a>Example configuration
+#### Example configuration { #rpiDNSExample }
 
 Make these assumptions:
 
@@ -315,7 +315,7 @@ Notes:
 
 	Then, when you refer to a host by a short name (eg "fred") the Raspberry Pi will also consider "fred.home.arpa" when trying to discover the IP address.
 
-## <a name="piholePrimary"></a>Using Pi-hole as your DNS resolver
+## Using Pi-hole as your DNS resolver { #piholePrimary }
 
 In order for Pi-hole to block ads or resolve anything, clients need to be told to use it as their DNS server. You can either:
 
@@ -334,7 +334,7 @@ Option 1 (whole-of-network) is the simplest approach. Assuming your Raspberry Pi
 
 Option 2 (case-by-case) generally involves finding the IP configuration options for each host and setting the DNS server manually. Manual changes are usually effective immediately without needing a reboot.
 
-### <a name="advancedConfig"></a>advanced configurations
+### advanced configurations { #advancedConfig }
 
 Setting up a combination of Pi-hole (for ad-blocking services), and/or a local upstream DNS resolver (eg BIND9) to be authoritative for a local domain and reverse-resolution for your local IP addresses, and decisions about where each DNS server forwards queries it can't answer (eg your ISP's DNS servers, or Google's 8.8.8.8, or Cloudflare's 1.1.1.1) is a complex topic and depends on your specific needs.
 
@@ -342,7 +342,7 @@ The same applies to setting up a DHCP server (eg DHCPD) which is capable of dist
 
 If you need help, try asking questions on the [IOTstack Discord channel](https://discord.gg/ZpKHnks).
 
-## <a name="debugging"></a>Testing and Troubleshooting
+## Testing and Troubleshooting { #debugging }
 
 Install dig:
 
@@ -370,17 +370,17 @@ If this fails to resolve the IP, check that the server in the response is
 `192.168.1.10`. If it's `127.0.0.xx` check `/etc/resolv.conf` begins with
 `nameserver 192.168.1.10`.
 
-## <a name="iotConfig"></a>Microcontrollers
+## Microcontrollers { #iotConfig }
 
 If you want to avoid hardcoding your Raspberry Pi IP to your ESPhome devices,
 you need a DNS server that will do the resolving. This can be done using the
 Pi-hole container as described above.
 
-### <a name="esp32mDNS"></a>`*.local` won't work for ESPhome
+### `*.local` won't work for ESPhome { #esp32mDNS }
 
 There is a special case for resolving `*.local` addresses. If you do a `ping raspberrypi.local` on your desktop Linux or the Raspberry Pi, it will first try using mDNS/bonjour to resolve the IP address raspberrypi.local. If this fails it will then ask the DNS server. ESPhome devices can't use mDNS to resolve an IP address. You need a proper DNS server to respond to queries made by an ESP. As such, `dig raspberrypi.local` will fail, simulating ESPhome device behavior. This is as intended, and you should use raspberrypi.home.arpa as the address on your ESP-device.
 
-## <a name="cleanSlate"></a>Getting a clean slate
+## Getting a clean slate { #cleanSlate }
 
 If Pi-hole misbehaves, you can always try starting from a clean slate by erasing Pi-hole's persistent storage area. Erasing the persistent storage area causes PiHole to re-initialise its data structures on the next launch. You will lose:
 

--- a/docs/Containers/Portainer-ce.md
+++ b/docs/Containers/Portainer-ce.md
@@ -1,11 +1,11 @@
 # Portainer CE
 
-## <a name="references"></a>References
+## References { #references }
  
 - [Docker](https://hub.docker.com/r/portainer/portainer-ce/)
 - [Website](https://www.portainer.io/portainer-ce/)
 
-## <a name="definitions"></a>Definition
+## Definition { #definitions }
 
 - "#yourip" means any of the following:
 
@@ -13,7 +13,7 @@
 	- the multicast domain name of your Raspberry Pi (eg `iot-hub.local`)
 	- the domain name of your Raspberry Pi (eg `iot-hub.mydomain.com`) 
 
-## <a name="about"></a>About *Portainer CE*
+## About *Portainer CE* { #about }
 
 *Portainer CE* (Community Edition) is an application for managing Docker. It is a successor to *Portainer*. According to [the *Portainer CE* documentation](https://www.portainer.io/2020/08/portainer-ce-2-0-what-to-expect/)
 
@@ -21,7 +21,7 @@
 
 From that it should be clear that *Portainer* is deprecated and that *Portainer CE* is the way forward.
 
-## <a name="installation"></a>Installing *Portainer CE*
+## Installing *Portainer CE* { #installation }
 
 Run the menu:
 
@@ -40,7 +40,7 @@ Ignore any message like this:
 
 > WARNING: Found orphan containers (portainer) for this project …
 
-## <a name="firstRun"></a>First run of *Portainer CE*
+## First run of *Portainer CE* { #firstRun }
 
 In your web browser navigate to `#yourip:9000/`:
 
@@ -51,7 +51,7 @@ From there, you can click on the "Local" group and take a look around. One of th
 
 There are 'Quick actions' to view logs and other stats. This can all be done from terminal commands but *Portainer CE* makes it easier. 
 
-## <a name="setPublicIP"></a>Setting the Public IP address for your end-point
+## Setting the Public IP address for your end-point { #setPublicIP }
 
 If you click on a "Published Port" in the "Containers" list, your browser may return an error saying something like "can't connect to server" associated with an IP address of "0.0.0.0".
 
@@ -79,7 +79,7 @@ Keep in mind that clicking on a "Published Port" does not guarantee that your br
 
 > All things considered, you will get more consistent behaviour if you simply bookmark the URLs you want to use for your IOTstack services.
 
-## <a name="forgotPassword"></a>If you forget your password
+## If you forget your password { #forgotPassword }
 
 If you forget the password you created for *Portainer CE*, you can recover by doing the following:
 

--- a/docs/Containers/Prometheus.md
+++ b/docs/Containers/Prometheus.md
@@ -1,6 +1,6 @@
 # Prometheus
 
-## <a name="references"></a>References
+## References { #references }
 
 * [*Prometheus* home](https://prometheus.io)
 * *GitHub*:
@@ -15,7 +15,7 @@
 	- [*CAdvisor*](https://hub.docker.com/r/zcube/cadvisor)
 	- [*Node Exporter*](https://hub.docker.com/r/prom/node-exporter)
 
-## <a name="overview"></a>Overview
+## Overview { #overview }
 
 Prometheus is a collection of three containers:
 
@@ -25,9 +25,9 @@ Prometheus is a collection of three containers:
 
 The [default configuration](#activeConfig) for *Prometheus* supplied with IOTstack scrapes information from all three containers.
 
-## <a name="installProm"></a>Installing Prometheus
+## Installing Prometheus { #installProm }
 
-### <a name="installPromNewMenu"></a>*if you are running New Menu …*
+### *if you are running New Menu …* { #installPromNewMenu }
 
 When you select *Prometheus* in the IOTstack menu, you must also select:
 
@@ -36,7 +36,7 @@ When you select *Prometheus* in the IOTstack menu, you must also select:
 
 If you do not select all three containers, Prometheus will not start.
 
-### <a name="installPromOldMenu"></a>*if you are running Old Menu …*
+### *if you are running Old Menu …* { #installPromOldMenu }
 
 When you select *Prometheus* in the IOTstack menu, the service definition includes the three containers:
 
@@ -44,7 +44,7 @@ When you select *Prometheus* in the IOTstack menu, the service definition includ
 *	*prometheus-cadvisor;* and
 * 	*prometheus-nodeexporter*.
 
-## <a name="significantFiles"></a>Significant directories and files
+## Significant directories and files { #significantFiles }
 
 ```
 ~/IOTstack
@@ -77,23 +77,23 @@ When you select *Prometheus* in the IOTstack menu, the service definition includ
 7. The *persistent storage area*.
 8. The [configuration directory](#configDir).
 
-## <a name="howPrometheusIOTstackGetsBuilt"></a>How *Prometheus* gets built for IOTstack
+## How *Prometheus* gets built for IOTstack { #howPrometheusIOTstackGetsBuilt }
 
-### <a name="githubSourceCode"></a>*Prometheus* source code ([*GitHub*](https://github.com))
+### *Prometheus* source code ([*GitHub*](https://github.com)) { #githubSourceCode }
 
 The source code for *Prometheus* lives at [*GitHub* prometheus/prometheus](https://github.com/prometheus/prometheus).
 
-### <a name="dockerHubImages"></a>*Prometheus* images ([*DockerHub*](https://hub.docker.com))
+### *Prometheus* images ([*DockerHub*](https://hub.docker.com)) { #dockerHubImages }
 
 Periodically, the source code is recompiled and the resulting image is pushed to [prom/prometheus](https://hub.docker.com/r/prom/prometheus) on *DockerHub*.
  
-### <a name="iotstackMenu"></a>IOTstack menu
+### IOTstack menu { #iotstackMenu }
 
 When you select *Prometheus* in the IOTstack menu, the *template service definition* is copied into the *Compose* file.
 
 > Under old menu, it is also copied to the *working service definition* and then not really used.
 
-### <a name="iotstackFirstRun"></a>IOTstack first run
+### IOTstack first run { #iotstackFirstRun }
 
 On a first install of IOTstack, you run the menu, choose *Prometheus* as one of your containers, and are told to do this:
 
@@ -158,15 +158,15 @@ You *may* see the same pattern in Portainer, which reports the *base image* as "
 
 > Whether you see one or two rows depends on the version of `docker-compose` you are using and how your version of `docker-compose` builds local images.
 
-### <a name="dependencies"></a>Dependencies: *CAdvisor* and *Node Exporter*
+### Dependencies: *CAdvisor* and *Node Exporter* { #dependencies }
 
 The *CAdvisor* and *Node Exporter* are included in the *Prometheus* service definition as dependent containers. What that means is that each time you start *Prometheus*, `docker-compose` ensures that *CAdvisor* and *Node Exporter* are already running, and keeps them running.
 
 The [default configuration](#activeConfig) for *Prometheus* assumes *CAdvisor* and *Node Exporter* are running and starts scraping information from those targets as soon as it launches.
 
-## <a name="configuringPrometheus"></a>Configuring **Prometheus**
+## Configuring **Prometheus** { #configuringPrometheus }
 
-### <a name="configDir"></a>Configuration directory
+### Configuration directory { #configDir }
 
 The configuration directory for the IOTstack implementation of *Prometheus* is at the path:
 
@@ -183,7 +183,7 @@ If you delete either file, *Prometheus* will replace it with a default the next 
 
 Unless you [decide to change it](#environmentVars), the `config` folder and its contents are owned by "pi:pi". This means you can edit the files in the configuration directory without needing the `sudo` command. Ownership is enforced each time the container restarts.
 
-#### <a name="activeConfig"></a>Active configuration file
+#### Active configuration file { #activeConfig }
 
 The file named `config.yml` is the active configuration. This is the file you should edit if you want to make changes. The default structure of the file is:
 
@@ -213,7 +213,7 @@ Note:
 
 * The YAML parser used by *Prometheus* seems to be ***exceptionally*** sensitive to syntax errors (far less tolerant than `docker-compose`). For this reason, you should **always** check the *Prometheus* log after any configuration change.
 
-#### <a name="referenceConfig"></a>Reference configuration file
+#### Reference configuration file { #referenceConfig }
 
 The file named `prometheus.yml` is a reference configuration. It is a **copy** of the original configuration file that ships inside the *Prometheus* container at the path:
 
@@ -231,7 +231,7 @@ $ docker-compose restart prometheus
 $ docker logs prometheus
 ```
 
-### <a name="environmentVars"></a>Environment variables
+### Environment variables { #environmentVars }
 
 The IOTstack implementation of *Prometheus* supports two environment variables:
 
@@ -245,7 +245,7 @@ Those variables control ownership of the [Configuration directory](#configDir) a
 
 If you delete those environment variables from your *Compose* file, the [Configuration directory](#configDir) will be owned by "nobody:nobody"; otherwise the directory and its contents will be owned by whatever values you pass for those variables.
 
-### <a name="migration"></a>Migration considerations
+### Migration considerations { #migration }
 
 Under the original IOTstack implementation of *Prometheus* (just "as it comes" from *DockerHub*), the service definition expected the configuration file to be at:
 
@@ -276,7 +276,7 @@ Note:
 
 * The YAML parser used by *Prometheus* is very sensitive to syntax errors. Always check the *Prometheus* log after any configuration change.
 
-## <a name="upgradingPrometheus"></a>Upgrading *Prometheus*
+## Upgrading *Prometheus* { #upgradingPrometheus }
 
 You can update `cadvisor` and `nodeexporter` like this:
 
@@ -320,7 +320,7 @@ The `prune` is the simplest way of cleaning up. The first call removes the old *
 
 > Whether an old *base image* exists depends on the version of `docker-compose` you are using and how your version of `docker-compose` builds local images.
 
-### <a name="versionPinning"></a>*Prometheus* version pinning
+### *Prometheus* version pinning { #versionPinning }
 
 If you need to pin *Prometheus* to a particular version:
 

--- a/docs/Containers/Python.md
+++ b/docs/Containers/Python.md
@@ -1,12 +1,12 @@
 # Python
 
-## <a name="references"></a>references
+## references { #references }
 
 * [Python.org](https://www.python.org)
 * [Dockerhub image library](https://hub.docker.com/_/python)
 * [GitHub docker-library/python](https://github.com/docker-library/python)
 
-## <a name="menuPython"></a>selecting Python in the IOTstack menu
+## selecting Python in the IOTstack menu { #menuPython }
 
 When you select Python in the menu:
 
@@ -42,7 +42,7 @@ When you select Python in the menu:
 	  - ./volumes/python/app:/usr/src/app
 	```
 
-### <a name="customisingPython"></a>customising your Python service definition
+### customising your Python service definition { #customisingPython }
 
 The service definition contains a number of customisation points:
 
@@ -70,7 +70,7 @@ $ cd ~/IOTstack
 $ docker-compose up -d python
 ```
 
-## <a name="firstLaunchPython"></a>Python - first launch
+## Python - first launch { #firstLaunchPython }
 
 After running the menu, you are told to run the commands:
 
@@ -139,7 +139,7 @@ This is what happens:
 
 	Pressing <kbd>control</kbd>+<kbd>c</kbd> terminates the log display but does not terminate the running container.
 
-## <a name="stopPython"></a>stopping the Python service
+## stopping the Python service { #stopPython }
 
 To stop the container from running, either:
 
@@ -157,7 +157,7 @@ To stop the container from running, either:
 	$ docker-compose rm --force --stop -v python
 	```
 
-## <a name="startPython"></a>starting the Python service
+## starting the Python service { #startPython }
 
 To bring up the container again after you have stopped it, either:
 
@@ -175,7 +175,7 @@ To bring up the container again after you have stopped it, either:
 	$ docker-compose up -d python
 	```
 
-## <a name="reLaunchPython"></a>Python - second-and-subsequent launch
+## Python - second-and-subsequent launch { #reLaunchPython }
 
 Each time you launch the Python container *after* the first launch:
 
@@ -183,7 +183,7 @@ Each time you launch the Python container *after* the first launch:
 2. The `docker-entrypoint.sh` script runs and performs "self-repair" by replacing any files that have gone missing from the persistent storage area. Self-repair does **not** overwrite existing files! 
 3. The `app.py` Python script is run.
 
-## <a name="debugging"></a>when things go wrong - check the log
+## when things go wrong - check the log { #debugging }
 
 If the container misbehaves, the log is your friend:
 
@@ -191,7 +191,7 @@ If the container misbehaves, the log is your friend:
 $ docker logs python
 ```
 
-## <a name="yourPythonScript"></a>project development life-cycle
+## project development life-cycle { #yourPythonScript }
 
 It is **critical** that you understand that **all** of your project development should occur within the folder:
 
@@ -201,7 +201,7 @@ It is **critical** that you understand that **all** of your project development 
 
 So long as you are performing some sort of routine backup (either with a supplied script or a third party solution like [Paraphraser/IOTstackBackup](https://github.com/Paraphraser/IOTstackBackup)), your work will be protected.
 
-### <a name="gettingStarted"></a>getting started
+### getting started { #gettingStarted }
 
 Start by editing the file:
 
@@ -222,7 +222,7 @@ $ cd ~/IOTstack
 $ docker-compose restart python
 ```
 
-### <a name="persistentStorage"></a>reading and writing to disk
+### reading and writing to disk { #persistentStorage }
 
 Consider this line in the service definition:
 
@@ -249,7 +249,7 @@ What it means is that:
 
 If your script writes into any other directory inside the container, the data will be lost when the container re-launches.
 
-### <a name="cleanSlate"></a>getting a clean slate
+### getting a clean slate { #cleanSlate }
 
 If you make a mess of things and need to start from a clean slate, erase the persistent storage area:
 
@@ -262,7 +262,7 @@ $ docker-compose up -d python
 
 The container will re-initialise the persistent storage area from its defaults.
 
-### <a name="addingPackages"></a>adding packages
+### adding packages { #addingPackages }
 
 As you develop your project, you may find that you need to add supporting packages. For this example, we will assume you want to add "[Flask](https://pypi.org/project/Flask/)" and "[beautifulsoup4](https://pypi.org/project/beautifulsoup4/)".
 
@@ -340,7 +340,7 @@ Note:
 
 	The `requirements.txt` file will be recreated and it will be a copy of the version in the *services* directory as of the last image rebuild.
 
-### <a name="scriptBaking"></a>making your own Python script the default
+### making your own Python script the default { #scriptBaking }
 
 Suppose the Python script you have been developing reaches a major milestone and you decide to "freeze dry" your work up to that point so that it becomes the default when you ask for a [clean slate](#cleanSlate). Proceed like this:
 
@@ -406,7 +406,7 @@ Suppose the Python script you have been developing reaches a major milestone and
 	$ docker system prune -f
 	```
 
-### <a name="scriptCanning"></a>canning your project
+### canning your project { #scriptCanning }
 
 Suppose your project has reached the stage where you wish to put it into production as a service under its own name. Make two further assumptions:
 
@@ -471,7 +471,7 @@ Remember:
 	~/IOTstack/volumes/wishbone/app
 	``` 
 
-## <a name="routineMaintenance"></a>routine maintenance 
+## routine maintenance  { #routineMaintenance }
 
 To make sure you are running from the most-recent **base** image of Python from Dockerhub:
 

--- a/docs/Containers/Telegraf.md
+++ b/docs/Containers/Telegraf.md
@@ -7,13 +7,13 @@ The purpose of the Dockerfile is to:
 * tailor the default configuration to be IOTstack-ready; and
 * enable the container to perform self-repair if essential elements of the persistent storage area disappear.
  
-## <a name="references"></a>References
+## References { #references }
 
 - [*influxdata Telegraf* home](https://www.influxdata.com/time-series-platform/telegraf/)
 - [*GitHub*: influxdata/influxdata-docker/telegraf](https://github.com/influxdata/influxdata-docker/tree/master/telegraf)
 - [*DockerHub*: influxdata Telegraf](https://hub.docker.com/_/telegraf)
 
-## <a name="significantFiles"></a>Significant directories and files
+## Significant directories and files { #significantFiles }
 
 ```
 ~/IOTstack
@@ -53,19 +53,19 @@ Everything in the persistent storage area ❼:
 * will be replaced if it is not present when the container starts; but
 * will never be overwritten if altered by you.
 
-## <a name="howTelegrafIOTstackGetsBuilt"></a>How Telegraf gets built for IOTstack
+## How Telegraf gets built for IOTstack { #howTelegrafIOTstackGetsBuilt }
 
-### <a name="dockerHubImages"></a>Telegraf images ([*DockerHub*](https://hub.docker.com))
+### Telegraf images ([*DockerHub*](https://hub.docker.com)) { #dockerHubImages }
 
 Periodically, the source code is recompiled and the resulting image is pushed to [influxdata Telegraf](https://hub.docker.com/_/telegraf?tab=tags&page=1&ordering=last_updated) on *DockerHub*.
  
-### <a name="iotstackMenu"></a>IOTstack menu
+### IOTstack menu { #iotstackMenu }
 
 When you select Telegraf in the IOTstack menu, the *template service definition* is copied into the *Compose* file.
 
 > Under old menu, it is also copied to the *working service definition* and then not really used.
 
-### <a name="iotstackFirstRun"></a>IOTstack first run
+### IOTstack first run { #iotstackFirstRun }
 
 On a first install of IOTstack, you run the menu, choose your containers, and are told to do this:
 
@@ -134,7 +134,7 @@ You *may* see the same pattern in *Portainer*, which reports the ***base image**
 
 > Whether you see one or two rows depends on the version of `docker-compose` you are using and how your version of `docker-compose` builds local images.
 
-### <a name="migration"></a>Migration considerations
+### Migration considerations { #migration }
 
 Under the original IOTstack implementation of Telegraf (just "as it comes" from *DockerHub*), the service definition expected `telegraf.conf` to be at:
 
@@ -156,7 +156,7 @@ With one exception, all prior and current versions of the default configuration 
 
 The exception is `[[inputs.mqtt_consumer]]` which is now provided as an optional addition. If your existing Telegraf configuration depends on that input, you will need to apply it. See [applying optional additions](#optionalAdditions).
 
-## <a name="logging"></a>Logging
+## Logging { #logging }
 
 You can inspect Telegraf's log by:
 
@@ -166,7 +166,7 @@ $ docker logs telegraf
 
 These logs are ephemeral and will disappear when your Telegraf container is rebuilt.
 
-### <a name="logTelegrafDB"></a>log message: *database "telegraf" creation failed*
+### log message: *database "telegraf" creation failed* { #logTelegrafDB }
 
 The following log message can be misleading:
 
@@ -178,7 +178,7 @@ If InfluxDB is not running when Telegraf starts, the `depends_on:` clause in Tel
 
 What this error message *usually* means is that Telegraf has tried to communicate with InfluxDB before the latter is ready to accept connections. Telegraf typically retries after a short delay and is then able to communicate with InfluxDB.
 
-## <a name="editConfiguration"></a>Changing Telegraf's configuration
+## Changing Telegraf's configuration { #editConfiguration }
 
 The first time you launch the Telegraf container, the following structure will be created in the persistent storage area:
 
@@ -219,7 +219,7 @@ $ cd ~/IOTstack
 $ docker-compose restart telegraf
 ```
 
-### <a name="autoInclude"></a>Automatic includes to telegraf.conf
+### Automatic includes to telegraf.conf { #autoInclude }
 
 * `inputs.docker.conf` instructs Telegraf to collect metrics from Docker. Requires kernel control
   groups to be enabled to collect memory usage data. If not done during initial installation,
@@ -229,7 +229,7 @@ $ docker-compose restart telegraf
   ```
 * `inputs.cpu_temp.conf' collects cpu temperature.
  
-### <a name="optionalAdditions"></a>Applying optional additions
+### Applying optional additions { #optionalAdditions }
 
 The *additions folder* (see [Significant directories and files](#significantFiles)) is a mechanism for additional *IOTstack-ready* configuration options to be provided for Telegraf.
 
@@ -249,9 +249,9 @@ $ docker-compose restart telegraf
 
 The `grep` strips comment lines and the `sudo tee` is a safe way of appending the result to `telegraf.conf`. The `restart` causes Telegraf to notice the change.
 
-## <a name="cleanSlate"></a>Getting a clean slate
+## Getting a clean slate { #cleanSlate }
 
-### <a name="resetDB"></a>Erasing the persistent storage area
+### Erasing the persistent storage area { #resetDB }
 
 Erasing Telegraf's persistent storage area triggers self-healing and restores known defaults:
 
@@ -272,7 +272,7 @@ Note:
 	$ docker-compose restart telegraf
 	```
 
-### <a name="resetDB"></a>Resetting the InfluxDB database
+### Resetting the InfluxDB database { #resetDB }
 
 To reset the InfluxDB database that Telegraf writes into, proceed like this:
 
@@ -293,7 +293,7 @@ In words:
 * Delete the `telegraf` database, and then exit the CLI.
 * Start the Telegraf container. This re-creates the database automatically. 
 
-## <a name="upgradingTelegraf"></a>Upgrading Telegraf
+## Upgrading Telegraf { #upgradingTelegraf }
 
 You can update most containers like this:
 
@@ -335,7 +335,7 @@ Your existing Telegraf container continues to run while the rebuild proceeds. On
 
 The `prune` is the simplest way of cleaning up. The first call removes the old ***local image***. The second call cleans up the old ***base image***. Whether an old ***base image*** exists depends on the version of `docker-compose` you are using and how your version of `docker-compose` builds local images.
 
-### <a name="versionPinning"></a>Telegraf version pinning
+### Telegraf version pinning { #versionPinning }
 
 If you need to pin Telegraf to a particular version:
 

--- a/docs/Containers/Telegraf.md
+++ b/docs/Containers/Telegraf.md
@@ -55,10 +55,6 @@ Everything in the persistent storage area ❼:
 
 ## How Telegraf gets built for IOTstack { #howTelegrafIOTstackGetsBuilt }
 
-### Telegraf images ([*DockerHub*](https://hub.docker.com)) { #dockerHubImages }
-
-Periodically, the source code is recompiled and the resulting image is pushed to [influxdata Telegraf](https://hub.docker.com/_/telegraf?tab=tags&page=1&ordering=last_updated) on *DockerHub*.
- 
 ### IOTstack menu { #iotstackMenu }
 
 When you select Telegraf in the IOTstack menu, the *template service definition* is copied into the *Compose* file.
@@ -101,7 +97,7 @@ FROM telegraf:latest
 
 > If you need to pin to a particular version of Telegraf, the *Dockerfile* is the place to do it. See [Telegraf version pinning](#versionPinning).
 
-The `FROM` statement tells the build process to pull down the ***base image*** from [*DockerHub*](https://hub.docker.com).
+The `FROM` statement tells the build process to pull down the ***base image*** from [*DockerHub*](https://hub.docker.com/_/telegraf?tab=tags&page=1&ordering=last_updated&name=latest).
 
 > It is a ***base*** image in the sense that it never actually runs as a container on your Raspberry Pi.
 

--- a/docs/Containers/WireGuard.md
+++ b/docs/Containers/WireGuard.md
@@ -11,11 +11,11 @@ Assumptions:
 * These instructions assume that you have privileges to configure your network's gateway (router). If you are not able to make changes to your network's firewall settings, then you will not be able to finish this setup.
 * In common with most VPN technologies, WireGuard assumes that the WAN side of your network's gateway has a public IP address which is reachable directly. WireGuard may not work if that assumption does not hold. If you strike this problem, you have to take it up with your ISP.
 
-## <a name="installWireguard"></a>Installing WireGuard under IOTstack
+## Installing WireGuard under IOTstack { #installWireguard }
 
 You increase your chances of a trouble-free installation by performing the installation steps in the following order.
 
-### <a name="updateRaspbian"></a>Step 1: Update your Raspberry Pi OS
+### Step 1: Update your Raspberry Pi OS { #updateRaspbian }
 
 To be able to run WireGuard successfully, your Raspberry Pi needs to be **fully** up-to-date. If you want to understand why, see [the read only flag](#readOnlyFlag).
 
@@ -24,14 +24,14 @@ $ sudo apt update
 $ sudo apt upgrade -y
 ```
 
-### <a name="obtainDDNS"></a>Step 2: Set up a Dynamic DNS name
+### Step 2: Set up a Dynamic DNS name { #obtainDDNS }
 
 Before you can use WireGuard (or any VPN solution), you need a mechanism for your remote clients to reach your home router. You have two choices:
 
 1. Obtain a permanent IP address for your home router from your Internet Service Provider (ISP). Approach your ISP if you wish to pursue this option. It generally involves additional charges.
 2. Use a Dynamic DNS service. See IOTstack documentation [Accessing your device from the internet](../Basic_setup/Accessing-your-Device-from-the-internet.md). The rest of this documentation assumes you have chosen this option.
 
-### <a name="serviceDefinition"></a>Step 3: Understand the Service Definition
+### Step 3: Understand the Service Definition { #serviceDefinition }
 
 This is the service definition *template* that IOTstack uses for WireGuard:
 
@@ -68,11 +68,11 @@ Key points:
 
 * Everything in the `environment:` section from `SERVERURL=` down to `PEERDNS=` (inclusive) affects WireGuard's generated configurations (the QR codes). In other words, any time you change any of those values, any existing QR codes will stop working.
 
-### <a name="configureWhat"></a>Step 4: Decide what to configure
+### Step 4: Decide what to configure { #configureWhat }
 
 With most containers, you can continue to tweak environment variables and settings without upsetting the container's basic behaviour. WireGuard is a little different. You really need to think, carefully, about how you want to configure the service before you start. If you change your mind later, you generally have to [start from a clean slate](#cleanSlate).
 
-#### <a name="configureAlways"></a>Fields that you should always configure
+#### Fields that you should always configure { #configureAlways }
 
 * `TZ=` should be set to your local timezone. Example:
 
@@ -100,7 +100,7 @@ With most containers, you can continue to tweak environment variables and settin
 
 	- Many examples on the web use "PEERS=n" where "n" is a number. In practice, that approach seems to be a little fragile and is not recommended for IOTstack.
 
-#### <a name="configurePeerDNS"></a>Optional configuration - DNS resolution for peers
+#### Optional configuration - DNS resolution for peers { #configurePeerDNS }
 
 You have several options for how your remote peers resolve DNS requests:
 
@@ -112,7 +112,7 @@ You have several options for how your remote peers resolve DNS requests:
 	    
 	* The default value of `auto` instructs the WireGuard *service* running within the WireGuard *container* to use a DNS-service, coredns, also running in the Wireguard container. Coredns by default directs queries to 127.0.0.11, which Docker intercepts and forwards to whichever resolvers are specified in the Raspberry Pi's `/etc/resolv.conf`.
 
-* <a name="customContInit"></a>`PEERDNS=auto` with `custom-cont-init`
+* `PEERDNS=auto` with `custom-cont-init` { #customContInit }
 
 	This configuration instructs WireGuard to forward DNS queries from remote peers to any host daemon or **container** which is listening on port 53. This is the option you will want to choose if you are running an ad-blocking DNS server (eg *PiHole* or *AdGuardHome*) in a container on the same host as WireGuard, and you want your remote clients to obtain DNS resolution via the ad-blocker, but don't want your Raspberry Pi host to use it.
 
@@ -167,7 +167,7 @@ You have several options for how your remote peers resolve DNS requests:
 
 	Do note that changes to `PEERDNS` will not be updated to existing clients, and as such you may want to use `PEERDNS=auto` unless you have a very specific requirement.
 
-#### <a name="configurePorts"></a>Optional configuration - WireGuard ports
+#### Optional configuration - WireGuard ports { #configurePorts }
 
 The WireGuard service definition template follows the convention of using UDP port "51820" in three places. You can leave it like that and it will just work. There is no reason to change the defaults unless you want to.
 
@@ -202,7 +202,7 @@ Rule #3:
 
 See [Understanding WireGuard's port numbers](#understandingPorts) if you want more information on how the various port numbers are used.
 
-### <a name="configureWireGuard"></a>Step 5: Configure WireGuard
+### Step 5: Configure WireGuard { #configureWireGuard }
 
 There are two approaches:
 
@@ -211,7 +211,7 @@ There are two approaches:
 
 Of the two, the first is generally the simpler and means you don't have to re-run the menu whenever you want to change WireGuard's configuration.
 
-#### <a name="editCompose"></a>Method 1: Configure WireGuard by editing `docker-compose.yml`
+#### Method 1: Configure WireGuard by editing `docker-compose.yml` { #editCompose }
 
 1. Run the menu:
 
@@ -229,7 +229,7 @@ Of the two, the first is generally the simpler and means you don't have to re-ru
 8. Implement the decisions you took in [decide what to configure](#configureWhat).
 9. Save your work.
 
-#### <a name="editOverride"></a>Method 2: Configure WireGuard using `compose-override.yml`
+#### Method 2: Configure WireGuard using `compose-override.yml` { #editOverride }
 
 The [Custom services and overriding default settings for IOTstack](../Basic_setup/Custom.md) page describes how to use an override file to allow the menu to incorporate your custom configurations into the final `docker-compose.yml` file.
 
@@ -282,7 +282,7 @@ You will need to create the `compose-override.yml` **before** running the menu t
 
 	and verify that the `wireguard` service definition is as you expect.
 
-### <a name="startWireGuard"></a>Step 6: Start WireGuard
+### Step 6: Start WireGuard { #startWireGuard }
 
 1. To start WireGuard, bring up your stack:
 
@@ -346,7 +346,7 @@ You will need to create the `compose-override.yml` **before** running the menu t
 
 	Notice how each element in the `PEERS=` list is represented by a sub-directory prefixed with `peer_`. You should expect the same pattern for your peers.
 
-### <a name="clientQRcodes"></a>Step 7: Save your WireGuard client configuration files (QR codes)
+### Step 7: Save your WireGuard client configuration files (QR codes) { #clientQRcodes }
 
 The first time you launch WireGuard, it generates cryptographically protected configurations for your remote clients and encapsulates those configurations in QR codes. You can see the QR codes by running:
 
@@ -387,7 +387,7 @@ In this case:
 
 Keep in mind that each QR code contains everything needed for **any** device to access your home network via WireGuard. Treat your `.png` files as "sensitive documents".
 
-### <a name="routerNATConfig"></a>Step 8: Configure your router with a NAT rule
+### Step 8: Configure your router with a NAT rule { #routerNATConfig }
 
 A typical home network will have a firewall that effectively blocks all incoming attempts from the Internet to open a new connection with a device on your network.
 
@@ -432,7 +432,7 @@ A typical configuration process goes something like this:
 	* *Public Port* or *External Port* needs to be the value you chose for «public» in the WireGuard service definition (51820 if you didn't change it).
 	* *Service Name* (or *Service Type*) is typically a text field, an editable menu (where you can either make a choice or type your own value), or a button approximating an editable menu. If you are given the option of choosing "WireGuard", do that, otherwise just type that name into the field. It has no significance other than reminding you what the rule is for. 
 
-### <a name="configureClients"></a>Step 9: Configure your remote WireGuard clients
+### Step 9: Configure your remote WireGuard clients { #configureClients }
 
 This is a massive topic and one which is well beyond the scope of this guide. You really will have to work it out for yourself. Start by Googling:
 
@@ -448,7 +448,7 @@ For portable devices (eg iOS and Android) it usually boils down to:
 4. Point the device's camera at the QR code.
 5. Follow your nose.
 
-## <a name="understandingPorts"></a>Understanding WireGuard's port numbers
+## Understanding WireGuard's port numbers { #understandingPorts }
 
 Here's a concrete example configuration using three different port numbers:
 
@@ -499,9 +499,9 @@ Even if you use port 51820 everywhere (the default), all this Network Address Tr
 
 This model is a slight simplification because the remote client may also be also operating behind a router performing Network Address Translation. It is just easier to understand the basic concepts if you assume the remote client has a publicly-routable IP address.
 
-## <a name="debugging"></a>Debugging techniques
+## Debugging techniques { #debugging }
 
-### <a name="tcpdumpExternal"></a>Monitor WireGuard traffic between your router and your Raspberry Pi
+### Monitor WireGuard traffic between your router and your Raspberry Pi { #tcpdumpExternal }
 
 If `tcpdump` is not installed on your Raspberry Pi, you can install it by:
 
@@ -517,7 +517,7 @@ $ sudo tcpdump -i eth0 -n udp port «external»
 
 Press <kbd>ctrl</kbd><kbd>c</kbd> to terminate the capture.
 
-### <a name="tcpdumpInternal"></a>Monitor WireGuard traffic between your Raspberry Pi and the WireGuard container
+### Monitor WireGuard traffic between your Raspberry Pi and the WireGuard container { #tcpdumpInternal }
 
 First, you need to add `tcpdump` to the container. You only need to do this once per debugging session. The package will remain in place until the next time you re-create the container.
 
@@ -533,7 +533,7 @@ $ docker exec -t wireguard tcpdump -i eth0 -n udp port «internal»
 
 Press <kbd>ctrl</kbd><kbd>c</kbd> to terminate the capture.
 
-### <a name="listenExternal"></a>Is Docker listening on the Raspberry Pi's «external» port?
+### Is Docker listening on the Raspberry Pi's «external» port? { #listenExternal }
 
 ``` console
 $ PORT=«external»; sudo nmap -sU -p $PORT 127.0.0.1 | grep "$PORT/udp"
@@ -546,7 +546,7 @@ There will be a short delay. The expected answer is either:
 
 Success implies that the container is also listening.
 
-### <a name="listenPublic"></a>Is your router listening on the «public» port?
+### Is your router listening on the «public» port? { #listenPublic }
 
 ``` console
 $ PORT=«public»; sudo nmap -sU -p $PORT downunda.duckdns.org | grep "$PORT/udp"
@@ -561,7 +561,7 @@ Note:
 
 * Some routers always return the same answer irrespective of whether the router is or isn't listening to the port being checked. This stops malicious users from working out which ports might be open. This test will not be useful if your router behaves like that. You will have to rely on `tcpdump` telling you whether your router is forwarding traffic to your Raspberry Pi.
 
-## <a name="readOnlyFlag"></a>The read-only flag
+## The read-only flag { #readOnlyFlag }
 
 The `:ro` at the end of the following line in WireGuard's service definition means "read only":
 
@@ -577,7 +577,7 @@ Writing into `/lib/modules` is not needed on a Raspberry Pi, providing that Rasp
 
 If WireGuard refuses to install and you have good reason to suspect that WireGuard may be trying to write to `/lib/modules` then you can *consider* removing the `:ro` flag and re-trying. Just be aware that WireGuard will likely be modifying your operating system.  
 
-## <a name="pullWireguard"></a>Updating WireGuard
+## Updating WireGuard { #pullWireguard }
 
 To update the WireGuard container:
 
@@ -593,7 +593,7 @@ $ docker-compose up -d wireguard
 $ docker system prune
 ```
 
-## <a name="cleanSlate"></a>Getting a clean slate
+## Getting a clean slate { #cleanSlate }
 
 If WireGuard misbehaves, you can start over from a clean slate. You *may* also need to do this if you change any of the following environment variables:
 

--- a/docs/Containers/Zigbee2MQTT.md
+++ b/docs/Containers/Zigbee2MQTT.md
@@ -20,7 +20,7 @@
 	~/IOTstack/docker-compose.yml
 	```
 
-## <a name="basicProcess"></a>Basic process for new users
+## Basic process for new users { #basicProcess }
 
 1. Run the IOTstack menu and choose both "Mosquitto" and "Zigbee2MQTT". That adds the service definitions for both of those containers to your *compose file*.
 
@@ -33,7 +33,7 @@
 
 	This is a good basis for getting started. If it sounds like it will meet your needs, you will not need to make any changes. Otherwise, review the [environment variables](#envVars) and make appropriate changes to the service definition in your *compose file*.
 
-5. <a name="upStack"></a>Bring up your stack:
+5. Bring up your stack: { #upStack }
 
 	```console
 	$ cd ~/IOTstack
@@ -48,7 +48,7 @@
 
 7. [Connect to the web front end](#connectGUI) and start adding your Zigbee devices.
 
-## <a name="prepareAdapter"></a>Prepare your Zigbee adapter
+## Prepare your Zigbee adapter { #prepareAdapter }
 
 Zigbee adapters usually need to be "flashed" before they can be used by Zigbee2MQTT. To prepare your adatper:
 
@@ -60,7 +60,7 @@ Note:
 
 * If you can't find your adapter in the list of supported devices, you may not be able to get the Zigbee2MQTT container to connect to it. This kind of problem is outside the scope of IOTstack. You will have to raise the issue with the [Zigbee2MQTT](https://www.zigbee2mqtt.io) project.
 
-## <a name="identifyAdapter"></a>Identify your Zigbee adapter
+## Identify your Zigbee adapter { #identifyAdapter }
 
 This section covers adapters that connect to your Raspberry Pi via USB.
 
@@ -151,9 +151,9 @@ For those reasons, it is better to take the time to identify your Zigbee adapter
 10. Save your work.
 11. Continue from [bring up your stack](#upStack).
 
-## <a name="configuration"></a>Configuration
+## Configuration { #configuration }
 
-### <a name="envVars"></a>Environment variables
+### Environment variables { #envVars }
 
 Any value that can be set in a Zigbee2MQTT [configuration file](#confFile) can also be set using an environment variable.
 
@@ -176,7 +176,7 @@ The default service definition provided with IOTstack includes the following env
 
 	You should replace `Etc/UTC` with a value that is correct for your location.
 
-* <a name="mqttServer"></a>`ZIGBEE2MQTT_CONFIG_MQTT_SERVER=mqtt://mosquitto:1883`
+* `ZIGBEE2MQTT_CONFIG_MQTT_SERVER=mqtt://mosquitto:1883` { #mqttServer }
 
 	Typical values for this are:
 
@@ -199,11 +199,11 @@ The default service definition provided with IOTstack includes the following env
 
 		The `depends_on` clause ensures that the Mosquitto container starts alongside the Zigbee2MQTT container. That would not be appropriate if Mosquitto was running on a separate computer.
 	
-* <a name="frontEndEnable"></a>`ZIGBEE2MQTT_CONFIG_FRONTEND=true`
+* `ZIGBEE2MQTT_CONFIG_FRONTEND=true` { #frontEndEnable }
 
 	This variable activates the Zigbee2MQTT web interface on port 8080. If you want to change the port number where you access the Zigbee2MQTT web interface, see [connecting to the web GUI](#connectGUI).
 
-* <a name="logSymlink"></a>`ZIGBEE2MQTT_CONFIG_ADVANCED_LOG_SYMLINK_CURRENT=true`
+* `ZIGBEE2MQTT_CONFIG_ADVANCED_LOG_SYMLINK_CURRENT=true` { #logSymlink }
 
 	Defining this variable causes Zigbee2MQTT to create a symlink pointing to the current log **folder** at the path:
 
@@ -213,7 +213,7 @@ The default service definition provided with IOTstack includes the following env
 
 	See [Checking the log](#checkLog) for more information about why this is useful.
 
-### <a name="confFile"></a>Configuration file
+### Configuration file { #confFile }
 
 Zigbee2MQTT creates a default configuration file at the path:
 
@@ -239,9 +239,9 @@ Note:
 
 * If you start Zigbee2MQTT from a clean slate (ie where the configuration file does not exist) **and** your *compose file* does not define the [`… MQTT_SERVER`](#mqttServer) environment variable discussed above, the container will go into a restart loop. This happens because the Zigbee2MQTT container defaults to trying to reach the Mosquitto broker at `localhost:1883` instead of `mosquitto:1883`. That usually fails.
 
-## <a name="verifyOperation"></a>Verifying basic operation
+## Verifying basic operation { #verifyOperation }
 
-### <a name="checkStatus"></a>Checking status
+### Checking status { #checkStatus }
 
 ```console
 $ docker ps | grep -e mosquitto -e zigbee2mqtt
@@ -254,7 +254,7 @@ mosquitto     33 seconds ago   Up 31 seconds (healthy)
 
 You are looking for evidence that the container is restarting (ie the "Status" column only ever shows a low number of seconds when compared with the "Created" column).
 
-### <a name="checkLog"></a>Checking the log
+### Checking the log { #checkLog }
 
 You can't use `docker logs zigbee2mqtt` to inspect the Zigbee2MQTT container's logs. That's because Zigbee2MQTT writes its logging information to the path:
 
@@ -276,7 +276,7 @@ You can use commands like `cat` and `tail` to examine the *current* log. Example
 $ cat ~/IOTstack/volumes/zigbee2mqtt/data/log/current/log.txt
 ```
 
-### <a name="checkMQTT"></a>Checking Mosquitto connectivity
+### Checking Mosquitto connectivity { #checkMQTT }
 
 To perform this check, you will need to have the Mosquitto clients installed:
 
@@ -304,7 +304,7 @@ One of two things will happen:
 
 Terminate the `mosquitto_sub` command with a <kbd>Control</kbd><kbd>c</kbd>.
 
-## <a name="connectGUI"></a>Connecting to the web GUI
+## Connecting to the web GUI { #connectGUI }
 
 Open a browser, and point it to port 8080 on your Raspberry Pi. For example:
 
@@ -339,7 +339,7 @@ Notes:
 	$ docker-compose up -d zigbee2mqtt
 	```
 
-## <a name="openShell"></a>Shell access to the container
+## Shell access to the container { #openShell }
 
 To open a shell inside the Zigbee2MQTT container, run:
 
@@ -351,7 +351,7 @@ $ docker exec -it zigbee2mqtt ash
 
 To close the shell and leave the container, either type "exit" and press <kbd>return</kbd>, or press <kbd>Control</kbd><kbd>d</kbd>.
 
-## <a name="pullUpgrade"></a>Container maintenance
+## Container maintenance { #pullUpgrade }
 
 When you become aware of a new version of Zigbee2MQTT on [DockerHub](https://hub.docker.com/r/koenkk/zigbee2mqtt/tags), do the following:
 
@@ -371,7 +371,7 @@ In words:
 
 You can omit the `zigbee2mqtt` arguments from the `pull` and `up` commands, in which case `docker-compose` makes an attempt to pull any available updates for all non-Dockerfile-based images, and then instantiates any new images it has downloaded.
 
-## <a name="update202204"></a>Service definition change
+## Service definition change { #update202204 }
 
 This information is for existing users of the Zigbee2MQTT container.
 
@@ -445,7 +445,7 @@ The changes you should make to your existing Zigbee2MQTT service definition are:
 
 	This ensures the Mosquitto container is brought up alongside Zigbee2MQTT. The Zigbee2MQTT container goes into a restart loop if Mosquitto is not reachable so this change enforces that business rule. See [`… MQTT_SERVER`](#mqttServer) for the situation where this might not be appropriate.
 
-### <a name="confExists"></a>pre-existing configuration file
+### pre-existing configuration file { #confExists }
 
 Environment variables in your *compose file* override corresponding values set in the *configuration file* at:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ extra_javascript:
   - javascript/fix-codeblock-console-copy-button.js
 
 markdown_extensions:
+  - attr_list
   - pymdownx.highlight:
       pygments_lang_class: true
   - admonition


### PR DESCRIPTION
See reasoning from #558

Change mostly done by command:
`git grep -l '# <a name=' -- docs | xargs -n 1 sed -i -E 's%(#* )<a name="?(.*)"?></a>(.*)%\1\3 { #\2 }%'`

Also a removal of redundant section with its link placed at a more logical place.

Closes #558