### PR TITLE
Doc improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,68 +15,11 @@ See [Getting Started](https://sensorsiot.github.io/IOTstack/Getting-Started) in 
 
 ### significant change to networking
 
-Networking under both *new menu* (master branch) and *old menu* (old-menu branch) has undergone a significant change. This will not affect new users of IOTstack (who will adopt it automatically). Neither will it affect existing users who do not use the menu to maintain their stacks (see [adopting networking changes by hand](#networkHandEdit) below).
- 
-Users who *do* use the menu to maintain their stacks will also be unaffected *until the next menu run*, at which point it will be prudent to down your stack entirely and re-select all your containers. Downing the stack causes Docker to remove all associated networks as well as the containers.
+After 2022-01-18 the menu has changed to use Docker networks differently. Users from before this need to do [migration](https://sensorsiot.github.io/IOTstack/Updates/migration-network-change/) in order to add new services. In essence, just re-select all your services using the menu. If not done, docker-compose will give you an error like:
 
-These changes mean that networking is **identical** under both *old* and *new* menus. To summarise the changes:
-
-1. Only two internal networks are defined – as follows:
-
-	* "default" which adopts the name `iotstack_default` at runtime.
-	* "nextcloud" which adopts the name `iotstack_nextcloud` at runtime.
-	
-	If you are using docker-compose v2.0.0 or later then the `iotstack_nextcloud` network will only be instantiated if you select NextCloud as one of your services. Earlier versions of docker-compose instantiate all networks even if no service uses them (which is why you get those warnings at "up" time).
-
-2. The only service definitions which now have `networks:` directives are:
-
-	* NextCloud: joins the "default" and "nextcloud" networks; and
-	* NextCloud_DB: joins the "nextcloud" network.
-	
-	All other containers will join the "default" network, automatically, without needing any `networks:` directives.
-
-#### <a name="networkHandEdit"> adopting networking changes by hand </a>
-
-If you maintain your `docker-compose.yml` by hand, you can adopt the networking changes by doing the following:
-
-1. Take your stack down. This causes Docker to remove any existing networks. 
-2. Remove **all** `networks:` directives wherever they appear in your `docker-compose.yml`. That includes: 
-
-	* the `networks:` directives in all service definitions; and
-	* the `networks:` specifications at the end of the file.
-
-3. Append the contents of the following file to your `docker-compose.yml`:
-
-	```
-	~/IOTstack/.templates/env.yml
-	```
-
-	For example:
-	
-	```
-	$ cat ~/IOTstack/.templates/env.yml >>~/IOTstack/docker-compose.yml
-	```
-	
-	The `env.yml` file is the same for both *old-menu* and *master* branches.
-
-4. If you run the NextCloud service then:
-
-	* Add these lines to the NextCloud service definition:
-
-		```
-		networks:
-		  - default
-		  - nextcloud
-		```
-
-	* Add these lines to the NextCloud_DB service definition:
-
-		```
-		networks:
-		  - nextcloud
-		```
-
-5. Bring up your stack.	
+```
+ERROR: Service "influxdb" uses an undefined network "iotstack_nw"
+```
 
 ### contributions
 

--- a/docs/Basic_setup/index.md
+++ b/docs/Basic_setup/index.md
@@ -542,7 +542,7 @@ This is how **most** containers behave. There are exceptions so it's always a go
 
 !!! danger "Breaking update"
     Recent changes will require [manual steps](
-    https://github.com/SensorsIot/IOTstack/blob/master/README.md#significant-change-to-networking)
+    ../Updates/migration-network-change.md)
     or you may get an error like:  
     `ERROR: Service "influxdb" uses an undefined network "iotstack_nw"`
 

--- a/docs/Basic_setup/index.md
+++ b/docs/Basic_setup/index.md
@@ -116,9 +116,8 @@ Please don't read these assumptions as saying that IOTstack will not run on othe
 
 ### scripted
 
-If you prefer to automate your installations using scripts, see:
-
-* [Installing Docker for IOTstack](https://gist.github.com/Paraphraser/d119ae81f9e60a94e1209986d8c9e42f#scripting-iotstack-installations).
+If you prefer to automate your installations using scripts, see
+[PiBuilder](https://github.com/Paraphraser/PiBuilder).
 
 ## Required system patches
 
@@ -130,7 +129,6 @@ Run the following commands:
 
 ``` console
 $ sudo bash -c '[ $(egrep -c "^allowinterfaces eth\*,wlan\*" /etc/dhcpcd.conf) -eq 0 ] && echo "allowinterfaces eth*,wlan*" >> /etc/dhcpcd.conf'
-$ sudo reboot
 ```
 
 See [Issue 219](https://github.com/SensorsIot/IOTstack/issues/219) and [Issue 253](https://github.com/SensorsIot/IOTstack/issues/253) for more information.
@@ -139,32 +137,32 @@ See [Issue 219](https://github.com/SensorsIot/IOTstack/issues/219) and [Issue 25
 
 This patch is **ONLY** for Raspbian Buster. Do **NOT** install this patch if you are running Raspbian Bullseye.
 
-#### step 1: check your OS release
+1.  check your OS release
 
-Run the following command:
+    Run the following command:
 
-``` console
-$ grep "PRETTY_NAME" /etc/os-release
-PRETTY_NAME="Raspbian GNU/Linux 10 (buster)"
-```
+    ``` console
+    $ grep "PRETTY_NAME" /etc/os-release
+    PRETTY_NAME="Raspbian GNU/Linux 10 (buster)"
+    ```
 
-If you see the word "buster", proceed to step 2. Otherwise, skip this patch.
+    If you see the word "buster", proceed to step 2. Otherwise, skip this patch.
 
-#### step 2: if you are indeed running "buster"
+2.  if you are indeed running "buster"
 
-Without this patch on Buster, Docker images will fail if:
+    Without this patch on Buster, Docker images will fail if:
 
-* the image is based on Alpine and the image's maintainer updates to [Alpine 3.13](https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.13.0#time64_requirement); and/or
-* an image's maintainer updates to a library that depends on 64-bit values for *Unix epoch time* (the so-called Y2038 problem).
+    * the image is based on Alpine and the image's maintainer updates to [Alpine 3.13](https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.13.0#time64_requirement); and/or
+    * an image's maintainer updates to a library that depends on 64-bit values for *Unix epoch time* (the so-called Y2038 problem).
 
-To install the patch:
+    To install the patch:
 
-``` console
-$ sudo apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv-keys 04EE7237B7D453EC 648ACFD622F3D138
-$ echo "deb http://httpredir.debian.org/debian buster-backports main contrib non-free" | sudo tee -a "/etc/apt/sources.list.d/debian-backports.list"
-$ sudo apt update
-$ sudo apt install libseccomp2 -t buster-backports
-```
+    ``` console
+    $ sudo apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv-keys 04EE7237B7D453EC 648ACFD622F3D138
+    $ echo "deb http://httpredir.debian.org/debian buster-backports main contrib non-free" | sudo tee -a "/etc/apt/sources.list.d/debian-backports.list"
+    $ sudo apt update
+    $ sudo apt install libseccomp2 -t buster-backports
+    ```
 
 ### patch 3 - kernel control groups
 
@@ -173,10 +171,11 @@ usage. This makes commands like `docker stats` fully work. Also needed for full
 monitoring of docker resource usage by the telegraf container.
 
 Enable by running (takes effect after reboot):
-```
-echo $(cat /boot/cmdline.txt) cgroup_memory=1 cgroup_enable=memory | sudo tee /boot/cmdline.txt
-```
 
+``` console
+$ echo $(cat /boot/cmdline.txt) cgroup_memory=1 cgroup_enable=memory | sudo tee /boot/cmdline.txt
+$ sudo reboot
+```
 
 ## the IOTstack menu
 
@@ -501,33 +500,15 @@ You read this as two paths, separated by a colon. The:
 * external path is `./volumes/nodered/data`
 * internal path is `/data`
 
-In this context, the leading "." means "the folder containing `docker-compose.yml`", so the external path is actually:
+In this context, the leading "." means "the folder containing`docker-compose.yml`", so the external path is actually:
 
 * `~/IOTstack/volumes/nodered/data`
 
-If a process running **inside** the container modifies any file or folder within:
-
-```
-/data
-```
-
-the change is mirrored **outside** the container at the same relative path within:
-
-```
-~/IOTstack/volumes/nodered/data
-```
-
-The same is true in reverse. Any change made to any file or folder **outside** the container within:
-
-```
-~/IOTstack/volumes/nodered/data
-```
-
-is mirrored at the same relative path **inside** the container at:
-
-```
-/data
-```
+This type of volume is a
+[bind-mount](https://docs.docker.com/storage/bind-mounts/), where the
+container's internal path is directly linked to the external path. All
+file-system operations, reads and writes, are mapped to directly to the files
+and folders at the external path.
 
 ### deleting persistent data
 

--- a/docs/Updates/Changelog.md
+++ b/docs/Updates/Changelog.md
@@ -23,5 +23,4 @@
 ## 2022-01-18
 
 - Networking change **requiring** [migration](
-  https://github.com/SensorsIot/IOTstack/#significant-change-to-networking).
-
+  ../Updates/migration-network-change.md).

--- a/docs/Updates/Changelog.md
+++ b/docs/Updates/Changelog.md
@@ -1,0 +1,27 @@
+## Latest
+<!-- what's in open pull requests that will be merged at an unknown date -->
+
+- New service: [Duckdns](../Containers/Duckdns.md), deprecates the
+  `duck/duck.sh` script.
+- Fixes to [bash aliases](../Basic_setup/Docker.md#aliases)
+- Documentation development made easier: [Writing documentation](
+  ../Developers/index.md#writing-documentation)
+
+## 2022-04-26
+
+- New service: [Syncthing](../Containers/Syncthing.md)
+- Zigbee2MQTT: [Service definition change](
+  ../Containers/Zigbee2MQTT.md#service-definition-change)
+- Dropping support for Home Assistant Supervised. Home Assistant **Container**
+  still available.
+- [Homebridge](../Containers/Homebridge.md) is now on port 8581
+- Documentation: Added: [Git Setup](../Developers/Git-Setup.md). Large changes
+  to: [Updates](../Updates/index.md), [InfluxDB](../Containers//InfluxDB.md),
+  [Grafana](../Containers/Grafana.md), [Pi-hole](../Containers/Pi-hole.md),
+  [Docker Logging](../Basic_setup/Docker.md#logging).
+
+## 2022-01-18
+
+- Networking change **requiring** [migration](
+  https://github.com/SensorsIot/IOTstack/#significant-change-to-networking).
+

--- a/docs/Updates/index.md
+++ b/docs/Updates/index.md
@@ -122,7 +122,7 @@ Periodically updates are made to project which include new or modified container
 
 !!! danger "Breaking update"
     Recent changes will require [manual steps](
-    https://github.com/SensorsIot/IOTstack/blob/master/README.md#significant-change-to-networking)
+    ../Updates/migration-network-change.md)
     or you may get an error like:  
     `ERROR: Service "influxdb" uses an undefined network "iotstack_nw"`
 

--- a/docs/Updates/index.md
+++ b/docs/Updates/index.md
@@ -1,8 +1,11 @@
 # Updating the project
 
-There are two different sources: the IOTstack project (github.com) and
-the Docker Hub (hub.docker.com). Both the initial stack creation and updates
-come from these. To illustrate the steps and artifacts of the *update* process:
+There are two different update sources: the IOTstack project (github.com) and
+Docker image registries (e.g. hub.docker.com). Both the initial stack creation
+and updates use both of these. Initial creation is a bit simpler, as the
+intermediate steps are done automatically. For a full update they need to be
+performed explicitly. To illustrate the steps and artifacts of the *update*
+process:
 
 ``` mermaid
 flowchart TD
@@ -21,7 +24,7 @@ flowchart TD
   PULL      --> CACHE[local Docker image cache]
   CACHE     --- UP
 
-  UP        --> CONTAINER[running Docker containers based on the latest cached images]
+  UP        --> CONTAINER[recreated Docker containers based on the latest cached images]
 
   classDef command fill:#9996,stroke-width:0px
   class GITPULL,MENU,UP,PULL command
@@ -57,11 +60,12 @@ fetch the latest images, but it's not unheard of that the latest image may
 break [something](
 https://github.com/node-red/node-red/issues/3461#issuecomment-1076348639).
 
-Thus to *guarantee* a successful rollback, you have to shutdown your RPi and
-save a complete disk image backup of its storage using another machine.
+Thus to *guarantee* a successful rollback to the pre-update state, you have to
+shutdown your RPi and save a complete disk image backup of its storage using
+another machine.
 
-For a hobby project, not having perfect rollback may be a risk you're willing
-to take. Usually container image problems have fixes/workarounds within a day.
+For a hobby project, not having a perfect rollback may be a risk you're willing
+to take. Usually image problems will have fixes/workarounds within a day.
 
 ## Update Raspberry Pi OS
 
@@ -77,10 +81,12 @@ $ sudo apt upgrade -y
 ## Recommended: Update only Docker images
 
 When you built the stack using the menu, it created the Docker Compose file
-`docker-compose.yml`. This file or its linked `Dockerfile`s, use image name and
-tag references (a missing tag defaults to `:latest`) to get the images from
-hub.docker.com. Likewise, when Docker is told to pull updated images, it will
-download the newest image for the tags into its local cache.
+`docker-compose.yml`. This file and any used build instructions
+(`Dockerfile`s), use image name and tag references to images on hub.docker.com
+or other registries. An undefined tag defaults to `:latest`. When Docker is
+told to pull updated images, it will download the images into the local
+cache, based upon what is currently stored at the registry for the used names
+and tags.
 
 Updating the IOTstack project templates and recreating your
 `docker-compose.yml` isn't usually necessary. Doing so isn't likely to provide
@@ -176,7 +182,7 @@ Full update steps:
 * Go to the [IOTstack Discord](https://discord.gg/ZpKHnks) and describe your
   problem. We're happy to help.
 
-## Details, partly outdated
+## Old-menu
 
 !!! warning
     If you ran `git checkout -- 'git ls-files -m'` as suggested in the old wiki entry then please check your duck.sh because it removed your domain and token

--- a/docs/Updates/index.md
+++ b/docs/Updates/index.md
@@ -118,38 +118,61 @@ encountered the same problem and reported the fix.
 
 ## Full update
 
-Periodically updates are made to project which include new or modified container template, changes to backups or additional features. As these are released your local copy of this project will become out of date. This section deals with how to bring your project to the latest published state.
+Periodically updates are made to project which include new or updated container
+template, changes to backups or additional features. To evaluate if this is
+really needed, see the [changelog](Changelog.md) or [merged pull requests](
+https://github.com/SensorsIot/IOTstack/pulls?q=is%3Amerged). To apply all these
+changes all service definitions are recreated. As a drawback, this will wipe
+any custom changes to docker-compose.yml, may change semantics or even require
+manual migration steps.
 
 !!! danger "Breaking update"
-    Recent changes will require [manual steps](
+    A change done 2022-01-18 will require [manual steps](
     ../Updates/migration-network-change.md)
     or you may get an error like:  
     `ERROR: Service "influxdb" uses an undefined network "iotstack_nw"`
 
-## Quick instructions
+Full update steps:
 
-1. shutdown your RPi, remove its storage medium and do a full image backup of
-   it to another machine. Reinstall your storage and power up your RPi.
-2. backup your current settings: `cp docker-compose.yml docker-compose.yml.bak`
-3. check `git status` for any local changes you may have made to project files, ignore any reported "Untracked files". Save and preserve your changes by doing a commit: `git commit -a -m "local customization"`. Or revert them using: `git checkout -- path/to/changed_file`.
-4. update project files from github: `git pull -r origin master`
-5. recreate the compose file and Dockerfile:s: `./menu.sh`, select Build Stack, don't change selections, press enter to build, and then exit.
-4. get latest images from the web: `docker-compose pull`
-5. rebuild localy created images from new Dockerfiles: `docker-compose build --pull --no-cache`
-6. update running containers to latest: `docker-compose up --build -d`
+1. Shutdown your RPi, remove the storage medium and do a [full backup
+   image](https://www.howtogeek.com/341944/how-to-clone-your-raspberry-pi-sd-card-for-foolproof-backup/)
+   of the storage to another machine. Reattach the storage back and power up
+   your RPi.<br />
+   NOTE: To skip this step may cause days of downtime as you debug a problem or
+   wait for fixes.
+2.  check `git status --untracked-files no` for any local changes you may have
+    made to project files. For any listed changes, either:
+
+    1. Save and preserve your change by doing a local commit: `git commit -m
+       "local customization" -- path/to/changed_file`, or
+    2. Revert it using: `git checkout -- path/to/changed_file`
+
+3. Update project files from github: `git pull -r origin master`
+4. Save your current compose file: `cp docker-compose.yml
+   docker-compose.yml.bak`. NOTE: this is really useful, as the next step will
+   overwrite all your previous manual changes to docker-compose.yml.
+5. Recreate the compose file and Dockerfile:s: `./menu.sh`, select Build Stack,
+   for each of your selected services: de- and re-select it, press enter to
+   build, and then exit.
+6. check the changes for obvious errors (e.g. passwords): `diff
+   docker-compose.yml docker-compose.yml.bak`
+7. Perform the Docker image update procedure: ``` console $ docker-compose pull
+   $ docker-compose build --pull --no-cache $ docker-compose up --build -d ```
 
 ### Troubleshooting: if a container fails to start after update
 
 * try restarting the whole stack: `docker-compose restart`
-* backup your stack settings: `cp docker-compose.yml docker-compose.yml.bak`
 * Check log output of the failing service: `docker-compose logs *service-name*`
     * try googling and fixing problems in docker-compose.yml manually.
-* try recreating the failing service definition using menu.sh:
-    1. `./menu.sh`, select Build Stack, unselect the failing service, press
-       enter to build, and then exit.
-    2. `./menu.sh`, select Build Stack, select the service back again, press
-       enter to build, and then exit.
-    3. Try starting now: `docker-compose up -d`
+* check how the container definitions have changed: `diff docker-compose.yml
+    docker-compose.yml.bak`
+* try rebuilding your complete stack from scratch:
+    1. check that you have a backup.
+    2. stop and remove Docker containers: `docker-compose down`
+    3. remove all menu generated files: `rm -r docker-compose.yml services`
+    4. recreate the stack: `./menu.sh`, select Build Stack, select all your
+       services, press enter to build, and then exit.
+    5. try starting: `docker-compose up -d`
 * Go to the [IOTstack Discord](https://discord.gg/ZpKHnks) and describe your
   problem. We're happy to help.
 

--- a/docs/Updates/migration-network-change.md
+++ b/docs/Updates/migration-network-change.md
@@ -1,0 +1,64 @@
+# Migration: network change
+
+Networking under both *new menu* (master branch) and *old menu* (old-menu branch) has undergone a significant change. This will not affect new users of IOTstack (who will adopt it automatically). Neither will it affect existing users who do not use the menu to maintain their stacks (see [adopting networking changes by hand](#networkHandEdit) below).
+ 
+Users who *do* use the menu to maintain their stacks will also be unaffected *until the next menu run*, at which point it will be prudent to down your stack entirely and re-select all your containers. Downing the stack causes Docker to remove all associated networks as well as the containers.
+
+These changes mean that networking is **identical** under both *old* and *new* menus. To summarise the changes:
+
+1. Only two internal networks are defined – as follows:
+
+	* "default" which adopts the name `iotstack_default` at runtime.
+	* "nextcloud" which adopts the name `iotstack_nextcloud` at runtime.
+	
+	If you are using docker-compose v2.0.0 or later then the `iotstack_nextcloud` network will only be instantiated if you select NextCloud as one of your services. Earlier versions of docker-compose instantiate all networks even if no service uses them (which is why you get those warnings at "up" time).
+
+2. The only service definitions which now have `networks:` directives are:
+
+	* NextCloud: joins the "default" and "nextcloud" networks; and
+	* NextCloud_DB: joins the "nextcloud" network.
+	
+	All other containers will join the "default" network, automatically, without needing any `networks:` directives.
+
+#### <a name="networkHandEdit"> adopting networking changes by hand </a>
+
+If you maintain your `docker-compose.yml` by hand, you can adopt the networking changes by doing the following:
+
+1. Take your stack down. This causes Docker to remove any existing networks. 
+2. Remove **all** `networks:` directives wherever they appear in your `docker-compose.yml`. That includes: 
+
+	* the `networks:` directives in all service definitions; and
+	* the `networks:` specifications at the end of the file.
+
+3. Append the contents of the following file to your `docker-compose.yml`:
+
+	```
+	~/IOTstack/.templates/env.yml
+	```
+
+	For example:
+	
+	```
+	$ cat ~/IOTstack/.templates/env.yml >>~/IOTstack/docker-compose.yml
+	```
+	
+	The `env.yml` file is the same for both *old-menu* and *master* branches.
+
+4. If you run the NextCloud service then:
+
+	* Add these lines to the NextCloud service definition:
+
+		```
+		networks:
+		  - default
+		  - nextcloud
+		```
+
+	* Add these lines to the NextCloud_DB service definition:
+
+		```
+		networks:
+		  - nextcloud
+		```
+
+5. Bring up your stack.	

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,10 +13,12 @@ theme:
   favicon: stack-24.svg
   palette:
     - scheme: default
+      media: "(prefers-color-scheme: light)"
       toggle:
         icon: material/weather-sunny
         name: Switch to dark mode
     - scheme: slate
+      media: "(prefers-color-scheme: dark)"
       toggle:
         icon: material/weather-night
         name: Switch to light mode

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.details
   - pymdownx.tabbed:
       alternate_style: true
   - toc:


### PR DESCRIPTION
Collection of purely documentation improvements:

* docs/Updates
  * Add how to do Raspberry OS "apt update"
  * Change full update procedure to recreate from templates
  * Clarify wording
* docs: autoselect initial color-scheme. If user has browser with dark-mode preference, automatically select it.
* docs/Getting Started: Small fixes and improvments
  * Reword volume-mount section for better clarity
  * Fix scripted install section to link to PiBuilder (was linking to deprecated gist)
  * Convert "patch 2" steps to numbered list for better readability
* docs: add changelog
* docs: move network migration to its own page