### PR TITLE
20220517 Grafana InfluxDB HealthCheck - old-menu branch - PR 2 of 3

### DIFF
--- a/.templates/grafana/service.yml
+++ b/.templates/grafana/service.yml
@@ -10,3 +10,9 @@
     volumes:
       - ./volumes/grafana/data:/var/lib/grafana
       - ./volumes/grafana/log:/var/log/grafana
+    healthcheck:
+      test: ["CMD", "wget", "-O", "/dev/null", "http://localhost:3000"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s

--- a/.templates/influxdb/service.yml
+++ b/.templates/influxdb/service.yml
@@ -11,3 +11,9 @@
     volumes:
       - ./volumes/influxdb/data:/var/lib/influxdb
       - ./backups/influxdb/db:/var/lib/influxdb/backup
+    healthcheck:
+      test: ["CMD", "curl", "http://localhost:8086"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s


### PR DESCRIPTION
Adds health-check functionality to Grafana and InfluxDB 1.8, as
discussed in #415.

Health-check functionality already added to Mosquitto via #407.

Closes #415

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>