### PR TITLE
20220517 Grafana InfluxDB HealthCheck - experimental branch - PR 3 of 3

### DIFF
--- a/.internal/templates/services/grafana/template.yml
+++ b/.internal/templates/services/grafana/template.yml
@@ -26,3 +26,9 @@ grafana:
     options:
       max-size: "5m"
       max-file: "3"
+  healthcheck:
+    test: ["CMD", "wget", "-O", "/dev/null", "http://localhost:3000"]
+    interval: 30s
+    timeout: 10s
+    retries: 3
+    start_period: 30s

--- a/.internal/templates/services/influxdb/template.yml
+++ b/.internal/templates/services/influxdb/template.yml
@@ -22,3 +22,9 @@ influxdb:
     options:
       max-size: "5m"
       max-file: "3"
+  healthcheck:
+    test: ["CMD", "curl", "http://localhost:8086"]
+    interval: 30s
+    timeout: 10s
+    retries: 3
+    start_period: 30s


### PR DESCRIPTION
Adds health-check functionality to Grafana and InfluxDB 1.8, as
discussed in #415.

Health-check functionality already added to Mosquitto via #408.

Closes #415

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>