### PR TITLE
20220602 InfluxDB 2 - old-menu branch - PR 2 of 3

### DIFF
--- a/.templates/influxdb2/service.yml
+++ b/.templates/influxdb2/service.yml
@@ -1,0 +1,26 @@
+  influxdb2:
+    container_name: influxdb2
+    image: "influxdb:latest"
+    restart: unless-stopped
+    environment:
+      - TZ=Etc/UTC
+      - DOCKER_INFLUXDB_INIT_USERNAME=me
+      - DOCKER_INFLUXDB_INIT_PASSWORD=mypassword
+      - DOCKER_INFLUXDB_INIT_ORG=myorg
+      - DOCKER_INFLUXDB_INIT_BUCKET=mybucket
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=my-super-secret-auth-token
+      - DOCKER_INFLUXDB_INIT_MODE=setup
+    # - DOCKER_INFLUXDB_INIT_MODE=upgrade
+    ports:
+      - "8087:8086"
+    volumes:
+      - ./volumes/influxdb2/data:/var/lib/influxdb2
+      - ./volumes/influxdb2/config:/etc/influxdb2
+      - ./volumes/influxdb2/backup:/var/lib/backup
+    # - ./volumes/influxdb.migrate/data:/var/lib/influxdb:ro
+    healthcheck:
+      test: ["CMD", "influx", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s

--- a/menu.sh
+++ b/menu.sh
@@ -24,6 +24,7 @@ declare -A cont_array=(
 	[portainer_agent]="Portainer agent"
 	[nodered]="Node-RED"
 	[influxdb]="InfluxDB"
+	[influxdb2]="InfluxDB 2 (requires full 64-bit OS)"
 	[telegraf]="Telegraf (Requires InfluxDB and Mosquitto)"
 	[chronograf]="Chronograf (Requires InfluxDB, Kapacitor optional)"
 	[kapacitor]="Kapacitor (Requires InfluxDB)"
@@ -65,11 +66,12 @@ declare -A cont_array=(
 	# add yours here
 )
 
-declare -a armhf_keys=(
+declare -a keylist=(
 	"portainer-ce"
 	"portainer_agent"
 	"nodered"
 	"influxdb"
+	"influxdb2"
 	"grafana"
 	"mosquitto"
 	"telegraf"
@@ -109,7 +111,6 @@ declare -a armhf_keys=(
 	"home_assistant"
 	# add yours here
 )
-sys_arch=$(uname -m)
 
 #timezones
 timezones() {
@@ -455,14 +456,6 @@ case $mainmenu_selection in
 	message=$'Use the [SPACEBAR] to select which containers you would like to install'
 	entry_options=()
 
-	#check architecture and display appropriate menu
-	if [ $(echo "$sys_arch" | grep -c "arm") ]; then
-		keylist=("${armhf_keys[@]}")
-	else
-		echo "your architecture is not supported yet"
-		exit
-	fi
-
 	#loop through the array of descriptions
 	for index in "${keylist[@]}"; do
 		entry_options+=("$index")
@@ -470,7 +463,7 @@ case $mainmenu_selection in
 
 		#check selection
 		if [ -f ./services/selection.txt ]; then
-			[ $(grep "$index" ./services/selection.txt) ] && entry_options+=("ON") || entry_options+=("OFF")
+			[ $(grep "^$index\$" ./services/selection.txt) ] && entry_options+=("ON") || entry_options+=("OFF")
 		else
 			entry_options+=("OFF")
 		fi


### PR DESCRIPTION
Adds InfluxDB 2 container. Documentation on Master branch.

`menu.sh` changes:

1. Adds InfluxDB 2 to menu.
2. Removes problematic if-test, renames `armhf_keys` array to `keylist`,
removes `sys_arch` declaration. Rationale:

	- Original code fragments:

		```
		declare -a armhf_keys=(
			...
		)
		sys_arch=$(uname -m)
		```

		```
		if [ $(echo "$sys_arch" | grep -c "arm") ]; then
			keylist=("${armhf_keys[@]}")
		else
			echo "your architecture is not supported yet"
			exit
		fi
		```

	- Analysis:

		1. The if test always succeeds because it is testing the
		exit-code of `grep` rather than the value returned by the
		`-c` option.
		2. This explains why the old menu has been working when
		`uname -m` returns "aarch64" on Pis with a 64-bit kernel (if
		not necessarily a 64-bit user mode).

			It also explains why old-menu works on macOS with Docker
			Desktop when `uname -m` returns "x86_64" (or who-knows-what
			on M1 Macs).

			The logical conclusion is that the intended "architecture
			check" was never necessary and should be removed. Removal
			continues the current desirable multi-arch behaviour whereas
			repairing the code would break any system that wasn't full
			32-bit arm.

		3. The only effect of the if-test always succeeding is to
		copy `armhf_keys` to `keylist`. Aside from its declaration,
		the if-test is the only place `armhf_keys` is referenced so
		the copy operation can be avoided by renaming `armhf_keys` to
		`keylist`, and removing the if-test entirely.

			The only place `keylist` is referenced is the for-loop
		immediately below the if-test. Also, `keylist` implies nothing
		about platform architecture so it is a better descriptor than
		`armhf_keys`. It's really an index-lookup mechanism.

		4. Finally, aside from its declaration/assignment, the if-test
		is the only place where `sys_arch` is referenced so that
		declaration can be removed too.

3. Pattern-matching against `./services/selection.txt` does not check
for exact whole-of-line match. This means "influx" will match
"influxdb2" (but not vice versa). This is actually a long-standing
problem for other new-release containers like Portainer vs Portainer-CE.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>