### PR TITLE
Telegraf: fix deprecated options and doc typos

### DIFF
--- a/.templates/telegraf/iotstack_defaults/auto_include/inputs.docker.conf
+++ b/.templates/telegraf/iotstack_defaults/auto_include/inputs.docker.conf
@@ -3,13 +3,12 @@
 [[inputs.docker]]
   endpoint = "unix:///var/run/docker.sock"
   gather_services = false
-  container_names = []
   source_tag = false
   container_name_include = []
   container_name_exclude = []
   timeout = "5s"
   perdevice = false
-  total = true
+  total_include = ["cpu", "blkio", "network"]
   docker_label_include = []
   docker_label_exclude = []
   tag_env = ["HEAP_SIZE"]

--- a/docs/Containers/Telegraf.md
+++ b/docs/Containers/Telegraf.md
@@ -181,7 +181,6 @@ The first time you launch the Telegraf container, the following structure will b
 ```
 ~/IOTstack/volumes/telegraf
 ├── [drwxr-xr-x root    ]  additions
-│   ├── [-rw-r--r-- root    ]  inputs.docker.conf
 │   └── [-rw-r--r-- root    ]  inputs.mqtt_consumer.conf
 ├── [-rw-r--r-- root    ]  telegraf.conf
 └── [-r--r--r-- root    ]  telegraf-reference.conf
@@ -200,7 +199,7 @@ The file:
 	- is created by removing all comment lines and blank lines from `telegraf-reference.conf`, leaving only the "active" configuration options, and then adding options necessary for IOTstack.
 	- is less than 30 lines and is significantly easier to understand than `telegraf-reference.conf`.
 
-* `inputs.docker.conf` – see [Applying optional additions](#optionalAdditions) below.
+* `inputs.mqtt_consumer.conf` – see [Applying optional additions](#optionalAdditions) below.
 
 The intention of this structure is that you:
 
@@ -223,7 +222,7 @@ $ docker-compose restart telegraf
   ``` console
   $ echo $(cat /boot/cmdline.txt) cgroup_memory=1 cgroup_enable=memory | sudo tee /boot/cmdline.txt
   ```
-* `inputs.cpu_temp.conf' collects cpu temperature.
+* `inputs.cpu_temp.conf` collects cpu temperature.
  
 ### Applying optional additions { #optionalAdditions }
 


### PR DESCRIPTION
* Fix default configuration not to use deprecated options (causing warnings in logs). Fixes #556
* Fix small documentation errors

Note: these commits were previously part of #554, but now split into a separate PR, as no-one shouldn't object to them being merged. (as opposed to the dependency-removal)