### PR TITLE
Telegraf: report 'iotstack' as hostname to influx

### DIFF
--- a/.templates/telegraf/service.yml
+++ b/.templates/telegraf/service.yml
@@ -1,6 +1,7 @@
 telegraf:
   container_name: telegraf
   build: ./.templates/telegraf/.
+  hostname: iotstack # optional
   restart: unless-stopped
   environment:
     - TZ=Etc/UTC


### PR DESCRIPTION
If no hostname is set, telegraf will generate a new random one each time it is recreated. It's more beginner and user-friendly to have a persistent non-changing hostname.

The hostname is used for tagging data sent to influxdb. If you have multiple stacks sending measurements to the same influx, this should be changed on at least one of the stacks. But that's expert usage, and not nearly as relevant as the single-stack case. Having many lots of different tagged hostnames may also reduce performance.

Note: this commit was previously part of https://github.com/SensorsIot/IOTstack/pull/554, but now split into a separate PR, as no-one shouldn't object to this being merged. (as opposed to the dependency-removal)