### PR TITLE
.bash_aliases: auto-remove orphan containers

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -1,7 +1,8 @@
-alias iotstack_up="docker-compose -f ~/IOTstack/docker-compose.yml up -d"
-alias iotstack_down="docker-compose -f ~/IOTstack/docker-compose.yml down"
-alias iotstack_start="docker-compose -f ~/IOTstack/docker-compose.yml start"
-alias iotstack_stop="docker-compose -f ~/IOTstack/docker-compose.yml stop"
-alias iotstack_update="docker-compose -f ~/IOTstack/docker-compose.yml pull"
-alias iotstack_build="docker-compose -f ~/IOTstack/docker-compose.yml build"
-
+IOTSTACK_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+alias iotstack_up="cd "$IOTSTACK_HOME" && docker-compose up -d --remove-orphans"
+alias iotstack_down="cd "$IOTSTACK_HOME" && docker-compose down --remove-orphans"
+alias iotstack_start="cd "$IOTSTACK_HOME" && docker-compose start"
+alias iotstack_stop="cd "$IOTSTACK_HOME" && docker-compose stop"
+alias iotstack_pull="cd "$IOTSTACK_HOME" && docker-compose pull"
+alias iotstack_build="cd "$IOTSTACK_HOME" && docker-compose build --pull --no-cache"
+alias iotstack_update_docker_images='f(){ iotstack_pull "$@" && iotstack_build "$@" && iotstack_up --build "$@"; }; f'

--- a/docs/Basic_setup/Docker.md
+++ b/docs/Basic_setup/Docker.md
@@ -7,15 +7,15 @@ logs internally together with other data associated to the container image.
 
 This has the effect that when recreating or updating a container, logs shown by
 `docker-compose logs` won't show anything associated with the previous
-instance. Use `docker system prune` to remove old instances and free up disc
+instance. Use `docker system prune` to remove old instances and free up disk
 space. Keeping logs only for the latest instance is helpful when testing, but
 may not be desirable for production.
 
-By default there is no limit on the log size. When using a SD-card this is
-exactly what you want. If a runaway container floods the log with output,
-writing will stop when the disc becomes full. Without a mechanism to prevent
-excessive disc-writes, the SD-card would keep being written to until the flash
-hardware [program-erase cycle](
+By default there is no limit on the log size. Surprisingly, when using a
+SD-card this is exactly what you want. If a runaway container floods the log
+with output, writing will stop when the disk becomes full. Without a mechanism
+to prevent such excessive writing, the SD-card would keep being written to
+until the flash hardware [program-erase cycle](
 https://www.techtarget.com/searchstorage/definition/P-E-cycle) limit is
 reached, after which it is permanently broken.
 

--- a/docs/Basic_setup/Docker.md
+++ b/docs/Basic_setup/Docker.md
@@ -34,24 +34,27 @@ concern. Then you can enable log-rotation by either:
 
 ## Aliases
 
-Bash aliases for stopping and starting the stack are in the file
-`.bash_aliases`. To use them immediately and in future logins, run in a
-console:
+Bash aliases for stopping and starting the stack and other common operations
+are in the file `.bash_aliases`. To use them immediately and in future logins,
+run in a console:
 
 ``` console
 $ source ~/IOTstack/.bash_aliases
-$ echo ". ~/IOTstack/.bash_aliases" >> ~/.profile
+$ echo "source ~/IOTstack/.bash_aliases" >> ~/.profile
 ```
 
 These commands no longer need to be executed from the IOTstack directory and can be executed in any directory
 
-``` console
-alias iotstack_up="docker-compose -f ~/IOTstack/docker-compose.yml up -d"
-alias iotstack_down="docker-compose -f ~/IOTstack/docker-compose.yml down"
-alias iotstack_start="docker-compose -f ~/IOTstack/docker-compose.yml start"
-alias iotstack_stop="docker-compose -f ~/IOTstack/docker-compose.yml stop"
-alias iotstack_update="docker-compose -f ~/IOTstack/docker-compose.yml pull"
-alias iotstack_build="docker-compose -f ~/IOTstack/docker-compose.yml build"
+``` bash title=".bash_aliases"
+--8<-- ".bash_aliases"
 ```
 
-You can now type `iotstack_up`, they even accept additional parameters `iotstack_stop portainer`
+You can now type `iotstack_up`. The aliases also accept additional parameters,
+e.g. `iotstack_stop portainer`.
+
+The `iotstack_update_docker_images` alias will [update docker images](
+http://localhost:8000/Updates/#recommended-update-only-docker-images) to newest
+released images, build and recreate containers. Do note that using this will
+result in a broken containers from time to time, as upstream may release faulty
+docker images. Have proper backups, or be prepared to manually pin a previous
+release build by editing `docker-compose.yml`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ markdown_extensions:
   - pymdownx.highlight:
       pygments_lang_class: true
   - admonition
+  - pymdownx.snippets
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid


### PR DESCRIPTION
* fix aliases to work regardless of user's current directory (using the'-f' flag instead of changing the directory would ignore a possibly existing `docker-compose.override.yml')
* fix iotstack_build alias to include "--pull --no-cache", as without these there may be cases where everything isn't fully updated.
* add the iotstack_update_docker_images alias to perform the basic container update
* docs/Docker: reword for clarity & typo fixes