### PR TITLE
20220708 Node-RED - master branch - PR 1 of 2

### DIFF
--- a/.templates/nodered/Dockerfile.template
+++ b/.templates/nodered/Dockerfile.template
@@ -1,6 +1,25 @@
-FROM nodered/node-red:latest-12
+# reference argument - omitted defaults to latest
+ARG DOCKERHUB_TAG=latest
+
+# Download base image
+FROM nodered/node-red:${DOCKERHUB_TAG}
+
+# reference argument - omitted defaults to null
+ARG EXTRA_PACKAGES
+ENV EXTRA_PACKAGES=${EXTRA_PACKAGES}
+
+# default user is node-red - need to be root to install packages
 USER root
-RUN apk update && apk add --no-cache eudev-dev
+
+# install packages
+RUN apk update && apk add --no-cache eudev-dev ${EXTRA_PACKAGES}
+
+# switch back to default user
 USER node-red
+
+# variable not needed inside running container
+ENV EXTRA_PACKAGES=
+
+# add-on nodes follow
 
 %run npm install modules list%

--- a/.templates/nodered/service.yml
+++ b/.templates/nodered/service.yml
@@ -1,6 +1,10 @@
 nodered:
   container_name: nodered
-  build: ./services/nodered/.
+  build:
+    context: ./services/nodered/.
+    args:
+    - DOCKERHUB_TAG=latest
+    - EXTRA_PACKAGES=
   restart: unless-stopped
   user: "0"
   environment:

--- a/docs/Containers/Node-RED.md
+++ b/docs/Containers/Node-RED.md
@@ -1135,39 +1135,13 @@ Components in persistent store at
   node-red-contrib-pushsafer
 ```
 
-Notice how `node-red-node-email` appears in both lists. To fix this problem:
+Notice how the `node-red-node-email` instance installed in the Dockerfile is being blocked. To fix this problem:
 
-1. Move into the correct external directory:
-
-	``` console
-	$ cd ~/IOTstack/volumes/nodered/data/node_modules
-	```
-	
-2. Create a sub-directory to be the equivalent of a local trash can:
-
-	``` console
-	$ sudo mkdir duplicates
-	```
-	
-3. Move each duplicate node into the `duplicates` directory. For example, to move `node-red-node-email` you would:
-
-	``` console
-	$ sudo mv node-red-node-email duplicates
-	```
-	
-4. Tell Node-RED to restart. This causes it to forget about the nodes which have just been moved out of the way:
-
-	``` console
-	$ docker-compose -f ~/IOTstack/docker-compose.yml restart nodered
-	```
-	
-5. Finish off by erasing the `duplicates` folder:
-
-	``` console
-	$ sudo rm -rf duplicates
-	```
-
-	Always be extremely careful with any `rm -rf`, particularly when it is coupled with a `sudo`. Double-check your work **before** you press <kbd>return</kbd>.
+``` console
+$ cd ~/IOTstack
+$ docker exec -w /data nodered npm uninstall node-red-node-email
+$ docker-compose restart nodered
+```
 
 
 ## Package management { #packageManagement }

--- a/scripts/nodered_list_installed_nodes.sh
+++ b/scripts/nodered_list_installed_nodes.sh
@@ -1,41 +1,47 @@
 #!/usr/bin/env bash
 
-INTERNAL="/usr/src/node-red/node_modules"
-EXTERNAL="$HOME/IOTstack/volumes/nodered/data/node_modules"
+# where Dockerfile installs components INSIDE the container
+DOCKERFILE="/usr/src/node-red"
 
-echo -e "\nNodes installed by Dockerfile INSIDE the container at $INTERNAL"
+# paths to the persistent store
+PERSISTENT_INTERNAL="/data"
+PERSISTENT_EXTERNAL="$HOME/IOTstack/volumes/nodered/data"
 
-CANDIDATES=$(docker exec nodered bash -c "ls -1d $INTERNAL/node-red-*")
+# the folder in each case containing node modules
+MODULES="node_modules"
 
-for C in $CANDIDATES; do
+# fetch what npm knows about components that form part of the image
+echo -e "\nFetching list of candidates installed via Dockerfile"
+CANDIDATES=$(docker exec nodered bash -c "cd \"$DOCKERFILE\" ; npm list --depth=0 --parseable")
 
-   NODE=$(basename "$C")
-
-   # is a node of the same name also present externally
-   if [ -d "$EXTERNAL/$NODE" ] ; then
-
-      # yes! the internal node is blocked by the external node
-      echo " BLOCKED: $NODE"
-
-   else
-
-      # no! so that means it's active
-      echo "  ACTIVE: $NODE"
-
+# report
+echo -e "\nComponents built into the image (via Dockerfile)"
+PARENT=$(basename "$DOCKERFILE")
+for CANDIDATE in $CANDIDATES; do
+   COMPONENT=$(basename "$CANDIDATE")
+   if [ "$COMPONENT" != "$PARENT" ] ; then
+      if [ -d "$PERSISTENT_EXTERNAL/$MODULES/$COMPONENT" ] ; then
+         # yes! the internal node is blocked by the external node
+         echo "  BLOCKED: $COMPONENT"
+      else
+         # no! so that means it's active
+         echo "   ACTIVE: $COMPONENT"
+      fi
    fi
-
 done
 
-echo -e "\nNodes installed by Manage Palette OUTSIDE the container at $EXTERNAL"
+# fetch what npm knows about components that are in the persistent store
+echo -e "\nFetching list of candidates installed via Manage Palette or npm"
+CANDIDATES=$(docker exec nodered bash -c "cd \"$PERSISTENT_INTERNAL\" ; npm list --depth=0 --parseable")
 
-CANDIDATES=$(ls -1d "$EXTERNAL/node-red-"*)
-
-for C in $CANDIDATES; do
-
-   NODE=$(basename "$C")
-
-   echo " $NODE"
-
+# report
+echo -e "\nComponents in persistent store at\n $PERSISTENT_EXTERNAL/$MODULES"
+PARENT=$(basename "$PERSISTENT_INTERNAL")
+for CANDIDATE in $CANDIDATES; do
+   COMPONENT=$(basename "$CANDIDATE")
+   if [ "$COMPONENT" != "$PARENT" ] ; then
+      echo "  $COMPONENT"
+   fi
 done
 
 echo ""


### PR DESCRIPTION
Adopts build-argument syntax in the template service definition +
template Dockerfile to pass an image tag plus an optional list of
extra packages to the Dockerfile at build time.

Pinning to a specific base image can now be accomplished in the Compose
file. This places Node-RED on equal footing with containers that do not
use local Dockerfiles (and Mosquitto which already has similar
build-argument syntax).

Together, the changes mean user customisations to the first part of the
Dockerfile are no longer at risk of being overwritten by menu runs to
change the list of add-on nodes.

For any given IOTstack installation, there is some possibility of a
hybrid result, depending on how and when the user runs the menu, or
which techniques each user employs to manage their Compose file and
Node-RED Dockerfile. The intention is to either fail safe or at least
fail sensibly:

* old Compose + old Dockerfile = no change.
* old Compose + new Dockerfile will adopt `latest` so `node.js` *may*
change from 12.x to 14.x on the next `--build` but this will depend on
whether the user ever explicitly set `latest-14` in their old Dockerfile.
* new Compose + old Dockerfile = no change. The service definition build
arguments will be ignored and the user may be confused until consulting
the documentation, but the container will still build as before.
* new Compose + new Dockerfile will behave as per the revised
documentation. Absent any user changes to the service definition, the
resulting container will be based on `latest` (which implies `node.js`
14.x) and there will no packages other than `eudev-dev` (the existing
Dockerfile default).

Worst case is an existing user adopting all-new syntax without realising
the old Dockerfile specified `latest-12`, thereby advancing to `node.js`
14.x unexpectedly, perhaps also losing additional packages along the
way. The fix is to specify `DOCKERHUB_TAG=latest-12`, append any lost
packages to `EXTRA_PACKAGES=`, and rebuild.

Personally, I switched to `-14` a good six months ago. It worked
out-of-the-box with zero migration issues and I've never looked back.
While that's only n=1, I don't feel there's sufficient risk to warrant
IOTstack continuing to default to `-12`. We have to change sometime, or
we'll be back where we were when images based on `-10` were no longer
being offered as Node-RED marched forward.

Using `node.js` version 14 is the implicit recommendation (ie `latest`
and `latest-14` are currently synonyms). Version 16 is available but is
known to throw up some migration issues. IOTstack started defaulting to
version 12 in March 2021 (when version 10 was deprecated).

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>