### PR TITLE
20220708 Node-RED - old-menu branch - PR 2 of 2

### DIFF
--- a/.templates/nodered/service.yml
+++ b/.templates/nodered/service.yml
@@ -1,6 +1,10 @@
   nodered:
     container_name: nodered
-    build: ./services/nodered/.
+    build:
+      context: ./services/nodered/.
+      args:
+      - DOCKERHUB_TAG=latest
+      - EXTRA_PACKAGES=
     restart: unless-stopped
     user: "0"
     env_file: ./services/nodered/nodered.env

--- a/scripts/nodered_list_installed_nodes.sh
+++ b/scripts/nodered_list_installed_nodes.sh
@@ -1,41 +1,47 @@
 #!/usr/bin/env bash
 
-INTERNAL="/usr/src/node-red/node_modules"
-EXTERNAL="$HOME/IOTstack/volumes/nodered/data/node_modules"
+# where Dockerfile installs components INSIDE the container
+DOCKERFILE="/usr/src/node-red"
 
-echo -e "\nNodes installed by Dockerfile INSIDE the container at $INTERNAL"
+# paths to the persistent store
+PERSISTENT_INTERNAL="/data"
+PERSISTENT_EXTERNAL="$HOME/IOTstack/volumes/nodered/data"
 
-CANDIDATES=$(docker exec nodered bash -c "ls -1d $INTERNAL/node-red-*")
+# the folder in each case containing node modules
+MODULES="node_modules"
 
-for C in $CANDIDATES; do
+# fetch what npm knows about components that form part of the image
+echo -e "\nFetching list of candidates installed via Dockerfile"
+CANDIDATES=$(docker exec nodered bash -c "cd \"$DOCKERFILE\" ; npm list --depth=0 --parseable")
 
-   NODE=$(basename "$C")
-
-   # is a node of the same name also present externally
-   if [ -d "$EXTERNAL/$NODE" ] ; then
-
-      # yes! the internal node is blocked by the external node
-      echo " BLOCKED: $NODE"
-
-   else
-
-      # no! so that means it's active
-      echo "  ACTIVE: $NODE"
-
+# report
+echo -e "\nComponents built into the image (via Dockerfile)"
+PARENT=$(basename "$DOCKERFILE")
+for CANDIDATE in $CANDIDATES; do
+   COMPONENT=$(basename "$CANDIDATE")
+   if [ "$COMPONENT" != "$PARENT" ] ; then
+      if [ -d "$PERSISTENT_EXTERNAL/$MODULES/$COMPONENT" ] ; then
+         # yes! the internal node is blocked by the external node
+         echo "  BLOCKED: $COMPONENT"
+      else
+         # no! so that means it's active
+         echo "   ACTIVE: $COMPONENT"
+      fi
    fi
-
 done
 
-echo -e "\nNodes installed by Manage Palette OUTSIDE the container at $EXTERNAL"
+# fetch what npm knows about components that are in the persistent store
+echo -e "\nFetching list of candidates installed via Manage Palette or npm"
+CANDIDATES=$(docker exec nodered bash -c "cd \"$PERSISTENT_INTERNAL\" ; npm list --depth=0 --parseable")
 
-CANDIDATES=$(ls -1d "$EXTERNAL/node-red-"*)
-
-for C in $CANDIDATES; do
-
-   NODE=$(basename "$C")
-
-   echo " $NODE"
-
+# report
+echo -e "\nComponents in persistent store at\n $PERSISTENT_EXTERNAL/$MODULES"
+PARENT=$(basename "$PERSISTENT_INTERNAL")
+for CANDIDATE in $CANDIDATES; do
+   COMPONENT=$(basename "$CANDIDATE")
+   if [ "$COMPONENT" != "$PARENT" ] ; then
+      echo "  $COMPONENT"
+   fi
 done
 
 echo ""


### PR DESCRIPTION
Adopts build-argument syntax in template service definition.

In `build.sh`:

* Harmonises list of add-on nodes (and default on/off states) to be
consistent with master branch.
* Constructs Dockerfile header as a "here" document to make future
maintenance easier. Identical to `Dockerfile.template` on master branch.

All documentation on master branch.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>