### PR TITLE
20220810 domoticz - master branch - PR 1 of 3

### DIFF
--- a/.templates/domoticz/service.yml
+++ b/.templates/domoticz/service.yml
@@ -1,6 +1,6 @@
 domoticz:
   container_name: domoticz
-  image: linuxserver/domoticz:stable
+  image: lscr.io/linuxserver/domoticz:latest
   ports:
     - "8083:8080"
     - "6144:6144"
@@ -8,10 +8,9 @@ domoticz:
   volumes:
     - ./volumes/domoticz/data:/config
   restart: unless-stopped
-  network_mode: bridge
   environment:
     - PUID=1000
     - PGID=1000
-    # - TZ=
+    # - TZ=Etc/UTC
     # - WEBROOT=domoticz
 

--- a/docs/Containers/Domoticz.md
+++ b/docs/Containers/Domoticz.md
@@ -1,0 +1,16 @@
+# Domoticz
+
+## References
+
+- [Domoticz home](https://www.domoticz.com)
+
+	- [User Guide](https://www.domoticz.com/DomoticzManual.pdf) (pdf)
+
+- [GitHub: domoticz/domoticz](https://github.com/domoticz/domoticz)
+- [DockerHub: linuxserver/domoticz](https://hub.docker.com/r/linuxserver/domoticz)
+
+## Invitation
+
+There is no IOTstack documentation for Domoticz.
+
+This is a standing invitation to anyone who is familiar with this container to submit a Pull Request to provide some documentation.


### PR DESCRIPTION
A Discord thread starting at
https://discord.com/channels/638610460567928832/638610461109256194/1005812386688680006
revealed that the Domoticz would not function properly on a clean
install. The symptom was either a 400 or a 404 error, depending on the
URL.

Three issues identified with existing service definition:

1. Wrong image base. Should be "lscr.io/linuxserver/domoticz".
2. Wrong image tag. Should be "latest".
3. `network_mode: bridge`.

It has never been clear what `network_mode: bridge` is intended to do.
It is the only container with this option. While it may once have been
needed, its presence now appears to prevent the container from
responding correctly on port 8083.

No IOTstack documentation exists for this container. This PR adds some
basic documentation in the form of references to the Domoticz home plus
associated GitHub and DockerHub pages, along with an invitation for
someone who is familiar with the container to expand it further.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>