### PR TITLE
20220810 domoticz - old-menu branch - PR 2 of 3

### DIFF
--- a/.templates/domoticz/domoticz.env
+++ b/.templates/domoticz/domoticz.env
@@ -1,4 +1,0 @@
-PUID=1000
-PGID=1000
-#TZ=
-#WEBROOT=domoticz #optional

--- a/.templates/domoticz/service.yml
+++ b/.templates/domoticz/service.yml
@@ -1,14 +1,16 @@
   domoticz:
     container_name: domoticz
-    image: linuxserver/domoticz:stable
+    image: lscr.io/linuxserver/domoticz:latest
     ports:
-      - "8080:8080"
+      - "8083:8080"
       - "6144:6144"
       - "1443:1443"
     volumes:
       - ./volumes/domoticz/data:/config
-    env_file:
-      - ./services/domoticz/domoticz.env      
     restart: unless-stopped
-    network_mode: bridge
-    
+    environment:
+      - PUID=1000
+      - PGID=1000
+      # - TZ=Etc/UTC
+      # - WEBROOT=domoticz
+  

--- a/docs/Containers/Domoticz.md
+++ b/docs/Containers/Domoticz.md
@@ -1,0 +1,6 @@
+# Domoticz
+
+Please refer to the [documentation on the master branch](https://github.com/SensorsIot/IOTstack/blob/master/docs/Containers/Domoticz.md).
+
+> There is not much there…
+


### PR DESCRIPTION
A Discord thread starting at
https://discord.com/channels/638610460567928832/638610461109256194/1005812386688680006
revealed that the Domoticz would not function properly on a clean
install. The symptom was either a 400 or a 404 error, depending on the
URL.

Three issues identified with existing service definition:

1. Wrong image base. Should be "lscr.io/linuxserver/domoticz".
2. Wrong image tag. Should be "latest".
3. `network_mode: bridge`.

It has never been clear what `network_mode: bridge` is intended to do.
It is the only container with this option. While it may once have been
needed, its presence now appears to prevent the container from
responding correctly on port 8083.

No IOTstack documentation exists for this container. A related PR adds
basic documentation. This PR adds a stub pointing to master branch.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>