### PR TITLE
20220913 Influx documentation - master branch

### DIFF
--- a/docs/Containers/InfluxDB.md
+++ b/docs/Containers/InfluxDB.md
@@ -61,7 +61,7 @@ The default service definition provided with IOTstack exposes the following envi
 	- `INFLUX_USERNAME=dba`
 	- `INFLUX_PASSWORD=supremo`
 
-	Misunderstanding the purpose and scope of these variables is a common mistake made by new users. Please do not guess! Please read [Authentication](authentication) **before** you enable or change any of these variables. In particular, `dba` and `supremo` are **not** defaults for database access.
+	Misunderstanding the purpose and scope of these variables is a common mistake made by new users. Please do not guess! Please read [Authentication](#authentication) **before** you enable or change any of these variables. In particular, `dba` and `supremo` are **not** defaults for database access.
 
 - UDP data acquisition variables:
 
@@ -276,7 +276,7 @@ $
 
 ### activate authentication { #authStep4 }
 
-Make sure you read the [warning](#activateWithCare) above, then edit the InfluxDB environment variables to enable this key:
+Make sure you read the [warning](#authWarning) above, then edit the InfluxDB environment variables to enable this key:
 
 ``` yaml
 - INFLUXDB_HTTP_AUTH_ENABLED=true


### PR DESCRIPTION
Fixes the problem reported by #599.

This is an unfortunate, predictable and predicted side-effect of moving from this style of anchored title:

```
## <a name="authentication"></a>Authentication
```

to this style:

```
## Authentication { #authentication }
```

The former style is testable by generating HTML from the Markdown and running it through a validator. The latter style isn't amenable to that approach because anchor generation is done "just in time" by mkdocs. Until we find some way to test mkdocs output in a systematic way, fairly trivial semantic errors (like the missing "#" in this case) will occasionally slip through the cracks.

Also fixed another broken link (`#authWarning`).

Fixes #599.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>