### PR TITLE
2022-10-11 Node-RED version-check script - master branch - PR 1 of 3

### DIFF
--- a/docs/Containers/Node-RED.md
+++ b/docs/Containers/Node-RED.md
@@ -435,7 +435,7 @@ You have several options:
 	
 	Note:
 	
-	* The `-it` flag is *optional*. It means "interactive terminal". Its presence tells Docker that the command may need user interaction, such as entering a password or typing "yes" to a question.
+	* The `-it` flags are *optional*. They mean "interactive" and "allocate pseudo-TTY". Their presence tells Docker that the command may need user interaction, such as entering a password or typing "yes" to a question.
 	
 2. You can open a shell into the container, run as many commands as you like inside the container, and then exit. For example:
 

--- a/docs/Containers/Node-RED.md
+++ b/docs/Containers/Node-RED.md
@@ -873,10 +873,27 @@ Think of these commands as "re-running the *Dockerfile*". The only time a *base*
 
 Your existing Node-RED container continues to run while the rebuild proceeds. Once the freshly-built *local* image is ready, the `up` tells `docker-compose` to do a new-for-old swap. There is barely any downtime for your Node-RED service.
 
+### Checking for Node-RED updates { #updateNodeRed }
+
+IOTstack provides a convenience script which can help you work out if a new version of Node-RED is available. You can run it like this:
+
+``` console
+$ ~/IOTstack/scripts/nodered_version_check.sh
+```
+
+The script is not infallible. It works by comparing the version number in the Node-RED image on your system with a version number stored on GitHub.
+
+GitHub is always updated *before* a new image appears on *DockerHub*. Sometimes there is a delay of weeks between the two events. For that reason, the script should be viewed more like a meteorological forecast than hard fact.
+
+The script assumes that your local image builds as `iotstack-nodered:latest`. If you use different tags, you can pass that information to the script. Example:
+
+``` console
+$ ~/IOTstack/scripts/nodered_version_check.sh iotstack-nodered:3.0.2
+```
 
 ### Upgrading Node-RED { #upgradeNodeRed }
 
-The only way to know when an update to Node-RED is available is to check the [nodered/node-red tags page](https://hub.docker.com/r/nodered/node-red/tags?page=1&ordering=last_updated) on *DockerHub*.
+The only way to know, for certain, when an update to Node-RED is available is to check the [nodered/node-red tags page](https://hub.docker.com/r/nodered/node-red/tags?page=1&ordering=last_updated) on *DockerHub*.
 
 Once a new version appears on [*DockerHub*](https://hub.docker.com), you can upgrade Node-RED like this:
 

--- a/scripts/nodered_version_check.sh
+++ b/scripts/nodered_version_check.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# the name of this script is
+SCRIPT=$(basename "$0")
+
+# default image is
+DEFAULTIMAGE="iotstack-nodered:latest"
+
+# zero or one arguments supported
+if [ "$#" -gt 1 ]; then
+    echo "Usage: $SCRIPT {image:tag}"
+    echo "   eg: $SCRIPT $DEFAULTIMAGE"
+    exit -1
+fi
+
+# image can be passed as first argument, else default
+IMAGE=${1:-"$DEFAULTIMAGE"}
+
+# fetch latest version details from GitHub
+LATEST=$(wget -O - -q https://raw.githubusercontent.com/node-red/node-red-docker/master/package.json | jq -r .version)
+
+# figure out the version in the local image
+INSTALLED=$(docker image inspect "$IMAGE" | jq -r .[0].Config.Labels[\"org.label-schema.version\"])
+
+# compare versions and report result
+if [ "$INSTALLED" = "$LATEST" ] ; then 
+
+   echo "Node-Red is up-to-date (version $INSTALLED)"
+
+else
+
+/bin/cat <<-COLLECT_TEXT
+
+	====================================================================
+	Node-Red version number has changed on GitHub:
+
+	    Local Version: $INSTALLED
+	   GitHub Version: $LATEST
+	
+	This means a new version MIGHT be available on Dockerhub. Check here:
+
+	   https://hub.docker.com/r/nodered/node-red/tags?page=1&ordering=last_updated
+
+	When an updated version is actually avaliable, proceed like this:
+
+	   $ REBUILD nodered
+	   $ UP nodered
+	   $ docker system prune
+	====================================================================
+
+COLLECT_TEXT
+
+fi
+


### PR DESCRIPTION
Adds `nodered_version_check.sh` script to scripts folder (previously available via
[gist](https://gist.github.com/Paraphraser/c8939213faf2de8a10f2a1f67452b0c1#-useful-script-nodered_version_check-)).

Adds documentation to Node-RED wiki page.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>