### PR TITLE
2022-10-11 Node-RED version-check script - old-menu branch - PR 2 of 3

### DIFF
--- a/scripts/nodered_version_check.sh
+++ b/scripts/nodered_version_check.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# the name of this script is
+SCRIPT=$(basename "$0")
+
+# default image is
+DEFAULTIMAGE="iotstack-nodered:latest"
+
+# zero or one arguments supported
+if [ "$#" -gt 1 ]; then
+    echo "Usage: $SCRIPT {image:tag}"
+    echo "   eg: $SCRIPT $DEFAULTIMAGE"
+    exit -1
+fi
+
+# image can be passed as first argument, else default
+IMAGE=${1:-"$DEFAULTIMAGE"}
+
+# fetch latest version details from GitHub
+LATEST=$(wget -O - -q https://raw.githubusercontent.com/node-red/node-red-docker/master/package.json | jq -r .version)
+
+# figure out the version in the local image
+INSTALLED=$(docker image inspect "$IMAGE" | jq -r .[0].Config.Labels[\"org.label-schema.version\"])
+
+# compare versions and report result
+if [ "$INSTALLED" = "$LATEST" ] ; then 
+
+   echo "Node-Red is up-to-date (version $INSTALLED)"
+
+else
+
+/bin/cat <<-COLLECT_TEXT
+
+	====================================================================
+	Node-Red version number has changed on GitHub:
+
+	    Local Version: $INSTALLED
+	   GitHub Version: $LATEST
+	
+	This means a new version MIGHT be available on Dockerhub. Check here:
+
+	   https://hub.docker.com/r/nodered/node-red/tags?page=1&ordering=last_updated
+
+	When an updated version is actually avaliable, proceed like this:
+
+	   $ REBUILD nodered
+	   $ UP nodered
+	   $ docker system prune
+	====================================================================
+
+COLLECT_TEXT
+
+fi
+


### PR DESCRIPTION
Adds `nodered_version_check.sh` script to scripts folder (previously available via
[gist](https://gist.github.com/Paraphraser/c8939213faf2de8a10f2a1f67452b0c1#-useful-script-nodered_version_check-)).

Documentation added to master branch.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>