### PR TITLE
2022-10-28 tasmoadmin - old-menu branch - PR 2 of 3

### DIFF
--- a/.templates/tasmoadmin/service.yml
+++ b/.templates/tasmoadmin/service.yml
@@ -1,8 +1,11 @@
   tasmoadmin:
     container_name: tasmoadmin
-    image: raymondmm/tasmoadmin
+    image: ghcr.io/tasmoadmin/tasmoadmin:latest
     restart: unless-stopped
+    environment:
+      - TZ=Etc/UTC
     ports:
       - "8088:80"
     volumes:
       - ./volumes/tasmoadmin/data:/data
+  


### PR DESCRIPTION
`raymondmm/tasmoadmin` on DockerHub was last updated two years ago.

Switches image to `ghcr.io/tasmoadmin/tasmoadmin:latest`.

Also adds `TZ` to template.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>