### PR TITLE
2022-10-28 tasmoadmin - experimental branch - PR 3 of 3

### DIFF
--- a/.internal/templates/services/tasmoadmin/template.yml
+++ b/.internal/templates/services/tasmoadmin/template.yml
@@ -1,13 +1,13 @@
 tasmoadmin:
   container_name: tasmoadmin
-  image: raymondmm/tasmoadmin
+  image: ghcr.io/tasmoadmin/tasmoadmin:latest
   restart: unless-stopped
+  environment:
+    - TZ=Etc/UTC
   ports:
     - "8088:80"
   volumes:
     - ./volumes/tasmoadmin/data:/data
-  networks:
-    - iotstack_nw
   logging:
     options:
       max-size: "5m"


### PR DESCRIPTION
`raymondmm/tasmoadmin` on DockerHub was last updated two years ago.

Switches image to `ghcr.io/tasmoadmin/tasmoadmin:latest`.

Also adds `TZ` to template.

Removes reference to `iotstack_nw`.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>