### PR TITLE
2022-11-08 Prometheus defaults - old-menu branch - PR 2 of 3

### DIFF
--- a/.templates/prometheus/iotstack_defaults/config.yml
+++ b/.templates/prometheus/iotstack_defaults/config.yml
@@ -7,6 +7,6 @@ scrape_configs:
     static_configs:
       - targets:
         - localhost:9090
-        - cadvisor:8080
-        - nodeexporter:9100
+        - prometheus-cadvisor:8080
+        - prometheus-nodeexporter:9100
 


### PR DESCRIPTION
Per issue #620, the default `config.yml` should reference:

	- `prometheus-cadvisor:8080` not `cadvisor:8080`
	- `prometheus-nodeexporter:9100` not `nodeexporter:9100`

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>