### PR TITLE
Homer: Fix Template

### DIFF
--- a/.templates/homer/service.yml
+++ b/.templates/homer/service.yml
@@ -2,8 +2,8 @@ homer:
   image: b4bz/homer:latest
   container_name: homer
   environment:
-    - UID=1000
-    - GID=1000
+    - INIT_ASSETS=1
+  user: $UID:$GID
   volumes:
     - ./volumes/homer/assets:/www/assets
   ports:


### PR DESCRIPTION
# Summary 
Updated template to latest defaults and recommendations, including:
- Added initial assets env variable so the service won't error out for first time users (like me)
- Changed user id & group id to use docker user function (see below explanation)

## Detailed Explanation
I discovered that the Homer wouldn't start with the default template as it had no assets defined. Adding the INIT_ASSETS env variable fixed this, but had permissions errors. In v2022.02.2 the method of assigning UID and GID was changed to user the docker user option (and not env var). These changes are discussed in [Homer Issue 441](https://github.com/bastienwirtz/homer/issues/441) and [Homer Issue 459](https://github.com/bastienwirtz/homer/issues/459), and [Homer's troubleshooting page](https://github.com/bastienwirtz/homer/blob/main/docs/troubleshooting.md) was also updated to reflect the new changes. Setting user to 1000:1000 did not work, but setting it to $UID:$GID, as mentioned in Issue 459, did assign the correct user to Homer 