### PR TITLE
Update Default-Configs.md - add dashmachine

### DIFF
--- a/docs/Basic_setup/Default-Configs.md
+++ b/docs/Basic_setup/Default-Configs.md
@@ -13,6 +13,7 @@ Do note that the ports listed are not all of the ports containers use. They are 
 | -------------- | ---------------- | ---------------- | -------------------------------- | ------------------ |
 | adminer        | *none*           | *none*     | 9080   | No |
 | blynk_server   | *none*           | *none*     | 8180   | No |
+| dashmachine    | *none*           | *none*     | 5000   | No |
 | deconz         | *none*           | IOtSt4ckDec0nZ | 8090 | No |
 | diyhue         | *none*           | *none*     | 8070   | No |
 | domoticz       | *none*           | *none*     | 8883   | No |


### PR DESCRIPTION
Noticed dash machine was not listed in default-configs.md while I was looking to add changedection.io to IOTstack. We should capture that port 5000 has been used.