### PR TITLE
2023-01-22 Pi-hole admin password changes - old-menu branch - PR 2 of 3

### DIFF
--- a/.templates/pihole/pihole.env
+++ b/.templates/pihole/pihole.env
@@ -1,16 +1,5 @@
-#TZ=America/Chicago
-WEBPASSWORD=pihole
-#DNS1=8.8.8.8
-#DNS2=8.8.4.4
-#DNSSEC=false
-#DNS_BOGUS_PRIV=True
-#CONDITIONAL_FORWARDING=False
-#CONDITIONAL_FORWARDING_IP=your_router_ip_here (only if CONDITIONAL_FORWARDING=true)
-#CONDITIONAL_FORWARDING_DOMAIN=optional
-#CONDITIONAL_FORWARDING_REVERSE=optional
-#ServerIP=your_Pi's_IP_here  << recommended
-#ServerIPv6= your_Pi's_ipv6_here << Required if using ipv6
-#VIRTUAL_HOST=$ServerIP
-#IPv6=True
+TZ=${TZ:-Etc/UTC}
+# see https://sensorsiot.github.io/IOTstack/Containers/Pi-hole/#adminPassword
+WEBPASSWORD=
 INTERFACE=eth0
-#DNSMASQ_LISTENING=local
+# see https://github.com/pi-hole/docker-pi-hole#environment-variables

--- a/.templates/pihole/service.yml
+++ b/.templates/pihole/service.yml
@@ -6,7 +6,6 @@
       - "53:53/udp"
       - "67:67/udp"
       - "8089:80/tcp"
-      #- "443:443/tcp"
     env_file:
       - ./services/pihole/pihole.env
     volumes:


### PR DESCRIPTION
See #648 for background to this PR.

Consequential changes:

* harmonises template service definition by removing reference to port 443 but does not re-align other entries (did not seem worthwhile).
* harmonises default environment variables file so it is identical to the inline environment variables on master branch. This includes new-style TZ syntax and comments directing users to IOTstack wiki doco on the admin password, and Pi-hole doco on supported environment variables.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>