### PR TITLE
2023-01-22 Pi-hole admin password changes - experimental branch - PR 3 of 3

### DIFF
--- a/.internal/templates/services/pihole/config.js
+++ b/.internal/templates/services/pihole/config.js
@@ -11,22 +11,6 @@ const pihole = () => {
       },
       modifyableEnvironment: [
         {
-          key: 'TZ',
-          value: 'Etc/UTC'
-        },
-        {
-          key: 'WEBPASSWORD',
-          value: 'password'
-        },
-        {
-          key: 'DNS1',
-          value: '8.8.8.8'
-        },
-        {
-          key: 'DNS2',
-          value: '8.8.4.4'
-        },
-        {
           key: 'INTERFACE',
           value: 'eth0'
         }

--- a/.internal/templates/services/pihole/template.yml
+++ b/.internal/templates/services/pihole/template.yml
@@ -2,42 +2,25 @@ pihole:
   container_name: pihole
   image: pihole/pihole:latest
   ports:
-    - "8089:80/tcp"
-    - "53:53/tcp"
-    - "53:53/udp"
-    - "67:67/udp"
-    # - "443:443/tcp"
+  - "8089:80/tcp"
+  - "53:53/tcp"
+  - "53:53/udp"
+  - "67:67/udp"
   environment:
-    - TZ=Etc/UTC
-    - WEBPASSWORD=%randomAdminPassword%
-    - DNS1=8.8.8.8
-    - DNS2=8.8.4.4
-    # - DNSSEC=false
-    # - DNS_BOGUS_PRIV=True
-    # - CONDITIONAL_FORWARDING=False
-    # - CONDITIONAL_FORWARDING_IP=your_router_ip_here (only if CONDITIONAL_FORWARDING=true)
-    # - CONDITIONAL_FORWARDING_DOMAIN=optional
-    # - CONDITIONAL_FORWARDING_REVERSE=optional
-    # - ServerIP=your_Pi's_IP_here  << recommended
-    # - ServerIPv6= your_Pi's_ipv6_here << Required if using ipv6
-    # - VIRTUAL_HOST=$ServerIP
-    # - IPv6=True
-    - INTERFACE=eth0
-    # - DNSMASQ_LISTENING=local
+  - TZ=${TZ:-Etc/UTC}
+  - WEBPASSWORD=
+    # see https://sensorsiot.github.io/IOTstack/Containers/Pi-hole/#adminPassword
+  - INTERFACE=eth0
+    # see https://github.com/pi-hole/docker-pi-hole#environment-variables
   volumes:
-      - ./volumes/pihole/etc-pihole:/etc/pihole
-      - ./volumes/pihole/etc-dnsmasq.d:/etc/dnsmasq.d
+  - ./volumes/pihole/etc-pihole:/etc/pihole
+  - ./volumes/pihole/etc-dnsmasq.d:/etc/dnsmasq.d
   dns:
-    - 127.0.0.1
-    - 1.1.1.1
-  # Recommended but not required (DHCP needs NET_ADMIN)
-  #   https://github.com/pi-hole/docker-pi-hole#note-on-capabilities
+  - 127.0.0.1
+  - 1.1.1.1
   cap_add:
-    - NET_ADMIN
+  - NET_ADMIN
   restart: unless-stopped
-  networks:
-    - iotstack_nw
-    - vpn_nw
   logging:
     options:
       max-size: "5m"


### PR DESCRIPTION
…3 of 3

See #648 for background to this PR.

Consequential changes:

* harmonises template service definition by removing reference to port 443 and re-aligning entries.
* harmonises default environment variables to be the same as master branch (including comments).
* removes obsolete `networks:` clause.
* removes handling for `TZ`, `WEBPASSWORD`, `DNS1` and `DNS2` from the modifiable environment. The DNS pair are a consequence of overall harmonisation.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>