### PR TITLE
2023-01-29 portainer_agent - master branch

### DIFF
--- a/.templates/portainer_agent/service.yml
+++ b/.templates/portainer_agent/service.yml
@@ -1,10 +1,10 @@
-  portainer_agent:
-    image: portainer/agent
-    container_name: portainer-agent
-    ports:
-      - "9001:9001"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - /var/lib/docker/volumes:/var/lib/docker/volumes
-    restart: unless-stopped
+portainer_agent:
+  image: portainer/agent
+  container_name: portainer-agent
+  ports:
+  - "9001:9001"
+  volumes:
+  - /var/run/docker.sock:/var/run/docker.sock
+  - /var/lib/docker/volumes:/var/lib/docker/volumes
+  restart: unless-stopped
 


### PR DESCRIPTION
By convention, master branch service definitions are aligned left. This service definition was conforming with the "indented by two spaces" convention for old-menu.

Realigned.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>