### PR TITLE
2023-01-29 timescaledb - master branch

### DIFF
--- a/.templates/timescaledb/service.yml
+++ b/.templates/timescaledb/service.yml
@@ -1,13 +1,13 @@
-  timescaledb:
-    container_name: timescaledb
-    image: timescale/timescaledb:latest-pg12
-    restart: unless-stopped
-    environment:
-      - POSTGRES_USER=${IOTSTACK_TIMESCALEDB_USER:-postgres}
-      - POSTGRES_PASSWORD={IOTSTACK_TIMESCALEDB_INITIAL_PASSWORD:-IOtSt4ckTim3Scale}
-      - POSTGRES_DB=postdb
-    ports:
-      - ${IOTSTACK_TIMESCALEDB_PORT_INT:-5433}:5432
-    volumes:
-      - ./volumes/timescaledb/data:/var/lib/postgresql/data
+timescaledb:
+  container_name: timescaledb
+  image: timescale/timescaledb:latest-pg12
+  restart: unless-stopped
+  environment:
+  - POSTGRES_USER=${IOTSTACK_TIMESCALEDB_USER:-postgres}
+  - POSTGRES_PASSWORD={IOTSTACK_TIMESCALEDB_INITIAL_PASSWORD:-IOtSt4ckTim3Scale}
+  - POSTGRES_DB=postdb
+  ports:
+  - ${IOTSTACK_TIMESCALEDB_PORT_INT:-5433}:5432
+  volumes:
+  - ./volumes/timescaledb/data:/var/lib/postgresql/data
 


### PR DESCRIPTION
By convention, master branch service definitions are aligned left. This service definition was conforming with the "indented by two spaces" convention for old-menu.

Realigned.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>