### PR TITLE
2023-01-29 syncthing - master branch

### DIFF
--- a/.templates/syncthing/service.yml
+++ b/.templates/syncthing/service.yml
@@ -1,20 +1,19 @@
-  syncthing:
-    image: linuxserver/syncthing:latest
-    container_name: syncthing
-    hostname: raspberrypi #optional
-    environment:
-      - PUID=1000
-      - PGID=1000
-      - HOME=/app
-      - TZ=Etc/UTC
-    volumes:
-      - ./volumes/syncthing/config:/config
-      - ./volumes/syncthing/data:/app
-    #ports:
-    #  - 8384:8384 # Web UI
-    #  - 22000:22000/tcp # TCP file transfers
-    #  - 22000:22000/udp # QUIC file transfers
-    #  - 21027:21027/udp # Receive local discovery broadcasts
-    network_mode: host
-
+syncthing:
+  image: linuxserver/syncthing:latest
+  container_name: syncthing
+  hostname: raspberrypi #optional
+  environment:
+  - PUID=1000
+  - PGID=1000
+  - HOME=/app
+  - TZ=${TZ:-Etc/UTC}
+  volumes:
+  - ./volumes/syncthing/config:/config
+  - ./volumes/syncthing/data:/app
+  x-ports:
+  - 8384:8384 # Web UI
+  - 22000:22000/tcp # TCP file transfers
+  - 22000:22000/udp # QUIC file transfers
+  - 21027:21027/udp # Receive local discovery broadcasts
+  network_mode: host
 


### PR DESCRIPTION
By convention, master branch service definitions are aligned left. This service definition was conforming with the "indented by two spaces" convention for old-menu.

Realigned. Also takes opportunity to:

* Adopt `TZ=${TZ:-Etc/UTC}`
* Adopt `x-ports:` clause to document ports in use for host-mode container.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>