### PR TITLE
2023-01-29 duckdns - master branch

### DIFF
--- a/.templates/duckdns/service.yml
+++ b/.templates/duckdns/service.yml
@@ -1,13 +1,14 @@
-  duckdns:
-    container_name: duckdns
-    build: https://github.com/ukkopahis/docker-duckdns.git
-    network_mode: host
-    restart: unless-stopped
-    environment:
-      PUID: 1000
-      PGID: 1000
-      # Required variables, define here on in docker-compose.override.yml
-      #TOKEN: token from duckdns.org
-      #SUBDOMAINS: your domain added to duckdns.org (without .duckdns.org)
-      # Optional
-      #PRIVATE_SUBDOMAINS: your domain added to duckdns.org (without .duckdns.org)
+duckdns:
+  container_name: duckdns
+  build: https://github.com/ukkopahis/docker-duckdns.git
+  network_mode: host
+  restart: unless-stopped
+  environment:
+    PUID: 1000
+    PGID: 1000
+    # Required variables, define here on in docker-compose.override.yml
+    #TOKEN: token from duckdns.org
+    #SUBDOMAINS: your domain added to duckdns.org (without .duckdns.org)
+    # Optional
+    #PRIVATE_SUBDOMAINS: your domain added to duckdns.org (without .duckdns.org)
+


### PR DESCRIPTION
By convention, master branch service definitions are aligned left. This service definition was conforming with the "indented by two spaces" convention for old-menu.

Realigned.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>