### PR TITLE
2023-02-07 pgadmin4 - experimental branch

### DIFF
--- a/.internal/templates/services/pgadmin4/template.yml
+++ b/.internal/templates/services/pgadmin4/template.yml
@@ -1,0 +1,12 @@
+pgadmin4:
+  container_name: pgadmin4
+  image: gpongelli/pgadmin4-arm:latest-armv7
+  platform: linux/arm/v7
+# image: gpongelli/pgadmin4-arm:latest-armv8
+  restart: unless-stopped
+  environment:
+  - TZ=${TZ:-Etc/UTC}
+  ports:
+  - "5050:5050"
+  volumes:
+  - ./volumes/pgadmin4:/pgadmin4

--- a/.internal/templates/services/postgres/template.yml
+++ b/.internal/templates/services/postgres/template.yml
@@ -3,15 +3,15 @@ postgres:
   image: postgres
   restart: unless-stopped
   environment:
-    - POSTGRES_USER=postuser
-    - POSTGRES_PASSWORD=Unset
-    - POSTGRES_DB=postdb
+    - TZ=${TZ:-Etc/UTC}
+    - POSTGRES_USER=${POSTGRES_USER:-postuser}
+    - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-IOtSt4ckpostgresDbPw}
+    - POSTGRES_DB=${POSTGRES_DB:-postdb}
   ports:
     - "5432:5432"
   volumes:
     - ./volumes/postgres/data:/var/lib/postgresql/data
-  networks:
-    - iotstack_nw
+    - ./volumes/postgres/db_backup:/backup
   logging:
     options:
       max-size: "5m"


### PR DESCRIPTION
1. Adds pgAdmin4:

	- service definition

2. Consequential changes to PostgreSQL container:

	- Adopted modern syntax for environment variables (`.env` support).
	- Removed obsolete `iotstack_nw` definition.
	- Added volume path for backup folder to support IOTstackBackup.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>