### PR TITLE
2023-02-14 MariaDB Dockerfile - old-menu branch - PR 2 of 3

### DIFF
--- a/.templates/mariadb/Dockerfile
+++ b/.templates/mariadb/Dockerfile
@@ -1,14 +1,18 @@
 # Download base image
 FROM ghcr.io/linuxserver/mariadb
 
+# candidates for customisation are
+ENV CANDIDATES="/defaults/my.cnf /defaults/custom.cnf"
+
 # apply stability patches recommended in
 #   
 #   https://discord.com/channels/638610460567928832/638610461109256194/825049573520965703
 #   https://stackoverflow.com/questions/61809270/how-to-discover-why-mariadb-crashes
-RUN sed -i.bak \
-  -e "s/^thread_cache_size/# thread_cache_size/" \
-  -e "s/^read_buffer_size/# read_buffer_size/" \
-  /defaults/my.cnf
+RUN for CNF in ${CANDIDATES} ; do [ -f ${CNF} ] && break ; done ; \
+    sed -i.bak \
+        -e "s/^thread_cache_size/# thread_cache_size/" \
+        -e "s/^read_buffer_size/# read_buffer_size/" \
+        ${CNF}
 
 # copy the health-check script into place
 ENV HEALTHCHECK_SCRIPT "iotstack_healthcheck.sh"
@@ -21,5 +25,7 @@ HEALTHCHECK \
    --timeout=10s \
    --retries=3 \
    CMD ${HEALTHCHECK_SCRIPT} || exit 1
+
+ENV CANDIDATES=
 
 # EOF


### PR DESCRIPTION
Adjusts Dockerfile to cope with rename of internal file path `/defaults/my.cnf` to `/defaults/custom.cnf`.

Strategy is to check for the presence of both files and then apply the stability patches to the first match. This should mean that the Dockerfile is backwards compatible with images that use `my.cnf`.

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>