### PR TITLE
2023-03-09 Blynk-server https port - old-menu branch - PR 2 of 3

### DIFF
--- a/.templates/blynk_server/service.yml
+++ b/.templates/blynk_server/service.yml
@@ -12,7 +12,7 @@
     ports:
       - "8180:8080"
       - "8440:8440"
-      - "9443:9443"
+      - "9444:9443"
     volumes:
       - ./volumes/blynk_server/data:/data
       - ./volumes/blynk_server/config:/config

--- a/.templates/portainer-ce/service.yml
+++ b/.templates/portainer-ce/service.yml
@@ -5,6 +5,8 @@
     ports:
       - "8000:8000"
       - "9000:9000"
+      # HTTPS
+      - "9443:9443"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./volumes/portainer-ce/data:/data


### PR DESCRIPTION
Changes external HTTPS port for Blynk Server from 9443 to 9444.

This is a consequence of PR #671 claiming 9443 for Portainer-CE.

Also adds external port 9443 to Portainer-CE on old-menu branch to keep this branch in sync with  the master branch changes made via #671.