### PR TITLE
2023-03-29 ZeroTier - master branch - PR 1 of 2

### DIFF
--- a/.templates/zerotier-client/service.yml
+++ b/.templates/zerotier-client/service.yml
@@ -1,12 +1,13 @@
 zerotier-client:
-  image: zyclonite/zerotier
   container_name: zerotier
-  devices:
-    - /dev/net/tun
+  image: "zyclonite/zerotier"
+  restart: unless-stopped
   network_mode: host
   volumes:
-    - /var/lib/zerotier-one:/var/lib/zerotier-one
+  - ./volumes/zerotier-one:/var/lib/zerotier-one
+  devices:
+  - "/dev/net/tun:/dev/net/tun"
   cap_add:
-    - NET_ADMIN
-    - SYS_ADMIN
+  - NET_ADMIN
+  - SYS_ADMIN
 

--- a/.templates/zerotier-router/service.yml
+++ b/.templates/zerotier-router/service.yml
@@ -1,22 +1,24 @@
 zerotier-router:
-  image: zyclonite/zerotier:router
   container_name: zerotier
-  devices:
-    - /dev/net/tun
-  network_mode: host
-  volumes:
-    - /var/lib/zerotier-one:/var/lib/zerotier-one
-  cap_add:
-    - NET_ADMIN
-    - SYS_ADMIN
-    - NET_RAW
+  image: "zyclonite/zerotier:router"
   restart: unless-stopped
   environment:
-    - TZ=Etc/UTC
-    - ZEROTIER_ONE_LOCAL_PHYS=eth0
-  # - ZEROTIER_ONE_NETWORK_IDS=yourNetworkID
-    - ZEROTIER_ONE_USE_IPTABLES_NFT=true
-    - ZEROTIER_ONE_GATEWAY_MODE=both
-    - PUID=1000
-    - PGID=1000
+  - TZ=${TZ:-Etc/UTC}
+  - PUID=1000
+  - PGID=1000
+# - ZEROTIER_ONE_NETWORK_IDS=yourNetworkID
+  - ZEROTIER_ONE_LOCAL_PHYS=eth0 wlan0
+  - ZEROTIER_ONE_USE_IPTABLES_NFT=true
+  - ZEROTIER_ONE_GATEWAY_MODE=both
+  network_mode: host
+  x-ports:
+  - "9993:9993"
+  volumes:
+  - ./volumes/zerotier-one:/var/lib/zerotier-one
+  devices:
+  - "/dev/net/tun:/dev/net/tun"
+  cap_add:
+  - NET_ADMIN
+  - SYS_ADMIN
+  - NET_RAW
 


### PR DESCRIPTION
Corrects a major brain-fade problem created in #595. Implements correct IOTstack-compliant service definitions for:

* ZeroTier client
* ZeroTier router

Documentation:

* adapts YAML line numbers to new service definition
* fixes missing `/0` CIDR notation in definition of default route
* adds section on enabling full tunnelling for remote clients in Topology 4
* adds explanation about host mode and `x-ports` syntax (an issue which can surface if an obsolete version of docker-compose is being used).