### PR TITLE
2023-04-09 Node-RED pin serial node - old-menu branch - PR 2 of 3

### DIFF
--- a/.templates/nodered/build.sh
+++ b/.templates/nodered/build.sh
@@ -21,7 +21,7 @@ node_selection=$(whiptail --title "Node-RED nodes" --checklist --separate-output
 	"node-red-node-smooth" " " "OFF" \
 	"node-red-node-darksky" " " "OFF" \
 	"node-red-node-sqlite" " " "OFF" \
-	"node-red-node-serialport" " " "OFF" \
+	"node-red-node-serialport@0.15.0" " " "OFF" \
 	"node-red-contrib-config" " " "OFF" \
 	"node-red-contrib-grove" " " "OFF" \
 	"node-red-contrib-diode" " " "OFF" \


### PR DESCRIPTION
Pins `node-red-node-serialport` to version `0.15.0`. This seems to be the only version that works with current Node-RED (3.0.2).

Test case showing version `0.15.0` working included with #681. Also includes links to related issues on other repositories which led to this solution.