### PR TITLE
2023-04-09 Node-RED pin serial node - experimental branch - PR 3 of 3

### DIFF
--- a/.internal/templates/services/nodered/buildFiles/addons.json
+++ b/.internal/templates/services/nodered/buildFiles/addons.json
@@ -46,7 +46,7 @@
         "node-red-node-smooth",
         "node-red-node-darksky",
         "node-red-node-sqlite",
-        "node-red-node-serialport",
+        "node-red-node-serialport@0.15.0",
         "node-red-contrib-config",
         "node-red-contrib-grove",
         "node-red-contrib-diode",


### PR DESCRIPTION
Pins `node-red-node-serialport` to version `0.15.0`. This seems to be the only version that works with current Node-RED (3.0.2).

Test case showing version `0.15.0` working included with #681. Also includes links to related issues on other repositories which led to this solution.