### PR TITLE
2023-05-15 Node-RED adaptation to expected kernel change - master branch - PR 1 of 3

### DIFF
--- a/.templates/nodered/service.yml
+++ b/.templates/nodered/service.yml
@@ -3,21 +3,14 @@ nodered:
   build:
     context: ./services/nodered/.
     args:
-    - DOCKERHUB_TAG=latest
-    - EXTRA_PACKAGES=
+      - DOCKERHUB_TAG=latest
+      - EXTRA_PACKAGES=
   restart: unless-stopped
   user: "0"
   environment:
-    - TZ=Etc/UTC
+    - TZ=${TZ:-Etc/UTC}
   ports:
     - "1880:1880"
   volumes:
     - ./volumes/nodered/data:/data
     - ./volumes/nodered/ssh:/root/.ssh
-    - /var/run/docker.sock:/var/run/docker.sock
-    - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
-  devices:
-    - "/dev/ttyAMA0:/dev/ttyAMA0"
-    - "/dev/vcio:/dev/vcio"
-    - "/dev/gpiomem:/dev/gpiomem"
-

--- a/docs/Containers/Node-RED.md
+++ b/docs/Containers/Node-RED.md
@@ -1455,3 +1455,27 @@ All remaining lines of your original *Dockerfile* should be left as-is.
 ### Applying the new syntax { #july2022build }
 
 Run the [re-building the local Node-RED image](#rebuildNodeRed) commands.
+
+## Bluetooth support { #bluetoothSupport }
+
+If you enable the `node-red-contrib-generic-ble` add on node, you will also need to make the following changes to the Node-RED service definition in your `docker-compose.yml`:
+
+* Add the following mapping to the `volumes:` clause:
+
+	```yaml
+	- /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
+	```
+
+* Add the following `devices:` clause:
+
+	```yaml
+	devices:
+	  - "/dev/serial1:/dev/serial1"
+	  - "/dev/vcio:/dev/vcio"
+	  - "/dev/gpiomem:/dev/gpiomem"
+	```
+
+Notes:
+
+* These changes are *specific* to the Raspberry Pi. If you need Bluetooth support on non-Pi hardware, you will need to figure out the details for your chosen platform.
+* Historically, `/dev/ttyAMA0` meant "the serial interface" on Raspberry Pis. Subsequently, it came to mean "the Bluetooth interface" where Bluetooth support was present. Now, `/dev/serial1` is used to mean "the Bluetooth interface".


### PR DESCRIPTION
Background:

- #690 – Kernel update may remove /dev/ttyAMA0

Changes:

1. Removes Bluetooth-specific volumes and devices from template.
2. Updates TZ to `TZ=${TZ:-Etc/UTC}` syntax.
3. Realigns build arguments (yamllint).
4. Adds documentation to Node-RED wiki page (master branch) to explain how to re-add volumes and devices if Bluetooth support is required on a Raspberry Pi:

	- This means Node-RED will launch successfully on non-Pi hardware.
	- Documentation references `/dev/serial1` rather than `/dev/ttyAMA0`.