### PR TITLE
2023-05-15 Node-RED adaptation to expected kernel change - experimental branch - PR 3 of 3

### DIFF
--- a/.internal/templates/services/nodered/template.yml
+++ b/.internal/templates/services/nodered/template.yml
@@ -1,24 +1,16 @@
 nodered:
   container_name: nodered
-  build: ./services/nodered/.
+  build:
+    context: ./services/nodered/.
+    args:
+      - DOCKERHUB_TAG=latest
+      - EXTRA_PACKAGES=
   restart: unless-stopped
   user: "0"
   environment:
-    - TZ=Etc/UTC
+    - TZ=${TZ:-Etc/UTC}
   ports:
     - "1880:1880"
   volumes:
     - ./volumes/nodered/data:/data
     - ./volumes/nodered/ssh:/root/.ssh
-    - /var/run/docker.sock:/var/run/docker.sock
-    - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
-  devices:
-    - "/dev/ttyAMA0:/dev/ttyAMA0"
-    - "/dev/vcio:/dev/vcio"
-    - "/dev/gpiomem:/dev/gpiomem"
-  networks:
-    - iotstack_nw
-  logging:
-    options:
-      max-size: "5m"
-      max-file: "3"


### PR DESCRIPTION
Background:

- #690 – Kernel update may remove /dev/ttyAMA0

Changes:

1. Removes Bluetooth-specific volumes and devices from template.
2. Updates TZ to `TZ=${TZ:-Etc/UTC}` syntax.
3. Realigns build arguments (yamllint).
4. Removes `networks` and `logging` clauses (now harmonised with master and old-menu branches).

Documentation on this branch not changed.