### PR TITLE
2023-05-16 Wireguard conformance - old-menu branch - PR 2 of 2

### DIFF
--- a/.templates/wireguard/service.yml
+++ b/.templates/wireguard/service.yml
@@ -3,23 +3,21 @@
     image: ghcr.io/linuxserver/wireguard
     restart: unless-stopped
     environment:
-    - PUID=1000
-    - PGID=1000
-    - TZ=Etc/UTC
-    - SERVERURL=your.dynamic.dns.name
-    - SERVERPORT=51820
-    - PEERS=laptop,phone,tablet
-    - PEERDNS=auto
-    - ALLOWEDIPS=0.0.0.0/0
+      - PUID=1000
+      - PGID=1000
+      - TZ=${TZ:-Etc/UTC}
+      - SERVERURL=your.dynamic.dns.name
+      - SERVERPORT=51820
+      - PEERS=laptop,phone,tablet
+      - PEERDNS=auto
+      - ALLOWEDIPS=0.0.0.0/0
     ports:
-    - "51820:51820/udp"
+      - "51820:51820/udp"
     volumes:
-    - ./volumes/wireguard/config:/config
-    - ./volumes/wireguard/custom-cont-init.d:/custom-cont-init.d
-    - ./volumes/wireguard/custom-services.d:/custom-services.d
-    - /lib/modules:/lib/modules:ro
+      - ./volumes/wireguard/config:/config
+      - ./volumes/wireguard/custom-cont-init.d:/custom-cont-init.d
+      - ./volumes/wireguard/custom-services.d:/custom-services.d
     cap_add:
-    - NET_ADMIN
-    - SYS_MODULE
+      - NET_ADMIN
     sysctls:
-    - net.ipv4.conf.all.src_valid_mark=1
+      - net.ipv4.conf.all.src_valid_mark=1


### PR DESCRIPTION
Brings service definition into line with
[linuxserver.io recommendations](https://github.com/linuxserver/docker-wireguard/pkgs/container/wireguard#usage).

Changes:

1. Corrects YAML "errors" identified by `yamllint`.
2. Adopts `TZ=${TZ:-Etc/UTC}`
3. Removes `/lib/modules` volume mapping (per linuxserver.io)
4. Removes `SYS_MODULE` capability (per linuxserver.io)