### PR TITLE
2023-05-16 Home Assistant adaptation to expected kernel change - old-menu branch - PR 2 of 2

### DIFF
--- a/.templates/home_assistant/service.yml
+++ b/.templates/home_assistant/service.yml
@@ -1,10 +1,9 @@
   home_assistant:
     container_name: home_assistant
     image: ghcr.io/home-assistant/home-assistant:stable
-    #image: ghcr.io/home-assistant/raspberrypi3-homeassistant:stable
-    #image: ghcr.io/home-assistant/raspberrypi4-homeassistant:stable
     restart: unless-stopped
     network_mode: host
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - ./volumes/home_assistant:/config
+    privileged: true


### PR DESCRIPTION
Background:

- #690 – Kernel update may remove /dev/ttyAMA0
- [Home Assistant documentation](https://www.home-assistant.io/installation/raspberrypi#docker-compose)

Changes:

1. Removes Bluetooth-specific volumes and devices from template.
2. Removes hardware-specific image options (still available but no longer mentioned in the Home Assistant documentation; and not relevant where IOTstack may be deployed on non-Pi hardware).
3. Adds privileged flag (present on master branch and specified in the Home Assistant documentation).