### PR TITLE
2023-05-16 OctoPrint adaptation to expected kernel change - old-menu branch - PR 2 of 2

### DIFF
--- a/.templates/octoprint/service.yml
+++ b/.templates/octoprint/service.yml
@@ -3,15 +3,15 @@
     image: octoprint/octoprint
     restart: unless-stopped
     environment:
-      - TZ=Etc/UTC
-    # - ENABLE_MJPG_STREAMER=true
-    # - MJPG_STREAMER_INPUT=-r 640x480 -f 10 -y
-    # - CAMERA_DEV=/dev/video0
+      - TZ=${TZ:-Etc/UTC}
+      # - ENABLE_MJPG_STREAMER=true
+      # - MJPG_STREAMER_INPUT=-r 640x480 -f 10 -y
+      # - CAMERA_DEV=/dev/video0
     ports:
       - "9980:80"
     devices:
-      - /dev/ttyAMA0:/dev/ttyACM0
-    # - /dev/video0:/dev/video0
+      - "${OCTOPRINT_DEVICE_PATH:?eg echo OCTOPRINT_DEVICE_PATH=/dev/serial0 >>~/IOTstack/.env}:/dev/ttyACM0"
+      # - /dev/video0:/dev/video0
     volumes:
       - ./volumes/octoprint:/octoprint
 


### PR DESCRIPTION
Background:

- #690 – Kernel update may remove /dev/ttyAMA0

Changes:

1. Adopts generic syntax for device specification to prompt user to add the relevant key (`OCTOPRINT_DEVICE_PATH`) and path (eg `/dev/ttyUDB0`) to `.env`. Example:

	```
	$ echo OCTOPRINT_DEVICE_PATH=/dev/ttyUSB0 >>~/IOTstack/.env
	```

2. Adopts `TZ=${TZ:-Etc/UTC}`
3. Corrects YAML "errors" identified by `yamllint`.