### PR TITLE
2023-05-16 Zigbee2MQTT adaptation to expected kernel change - old-menu branch - PR 2 of 2

### DIFF
--- a/.templates/zigbee2mqtt/service.yml
+++ b/.templates/zigbee2mqtt/service.yml
@@ -2,16 +2,17 @@
     container_name: zigbee2mqtt
     image: koenkk/zigbee2mqtt:latest
     environment:
-      - TZ=Etc/UTC
+      - TZ=${TZ:-Etc/UTC}
       - ZIGBEE2MQTT_CONFIG_MQTT_SERVER=mqtt://mosquitto:1883
       - ZIGBEE2MQTT_CONFIG_FRONTEND=true
       - ZIGBEE2MQTT_CONFIG_ADVANCED_LOG_SYMLINK_CURRENT=true
+      # - DEBUG=zigbee-herdsman*
     ports:
       - "8080:8080"
     volumes:
       - ./volumes/zigbee2mqtt/data:/app/data
     devices:
-      - /dev/ttyAMA0:/dev/ttyACM0
+      - "${ZIGBEE2MQTT_DEVICE_PATH:?eg echo ZIGBEE2MQTT_DEVICE_PATH=/dev/ttyACM0 >>~/IOTstack/.env}:/dev/ttyACM0"
     restart: unless-stopped
     depends_on:
       - mosquitto


### PR DESCRIPTION
Background:

- #690 – Kernel update may remove /dev/ttyAMA0

Changes:

1. Adopts generic syntax for device specification to prompt user to add the relevant key (`ZIGBEE2MQTT_DEVICE_PATH`) and path (eg `/dev/ttyUSB0`) to `.env`. Example:

	```
	$ echo ZIGBEE2MQTT_DEVICE_PATH=/dev/ttyUSB0 >>~/IOTstack/.env
	```

2. Adopts `TZ=${TZ:-Etc/UTC}`
3. Adds (disabled) environment variable to enable debugging.