### PR TITLE
2023-06-14 yamllint - master branch - PR 1 of 2

### DIFF
--- a/.templates/adguardhome/service.yml
+++ b/.templates/adguardhome/service.yml
@@ -3,7 +3,7 @@ adguardhome:
   image: adguard/adguardhome
   restart: unless-stopped
   environment:
-    - TZ=Etc/UTC
+    - TZ=${TZ:-Etc/UTC}
   # enable host mode to activate DHCP server on ports 67/udp & 68/tcp+udp
   # note that you must also disable all other ports if you enable host mode
   # network_mode: host
@@ -28,6 +28,6 @@ adguardhome:
     # - "5443:5443/tcp"
     # - "5443:5443/udp"
   volumes:
-     - ./volumes/adguardhome/workdir:/opt/adguardhome/work
-     - ./volumes/adguardhome/confdir:/opt/adguardhome/conf
+    - ./volumes/adguardhome/workdir:/opt/adguardhome/work
+    - ./volumes/adguardhome/confdir:/opt/adguardhome/conf
 

--- a/.templates/chronograf/service.yml
+++ b/.templates/chronograf/service.yml
@@ -3,18 +3,18 @@ chronograf:
   image: chronograf:latest
   restart: unless-stopped
   environment:
-    - TZ=Etc/UTC
-  # see https://docs.influxdata.com/chronograf/v1.9/administration/config-options/
+    - TZ=${TZ:-Etc/UTC}
+    # see https://docs.influxdata.com/chronograf/v1.9/administration/config-options/
     - INFLUXDB_URL=http://influxdb:8086
-  # - INFLUXDB_USERNAME=
-  # - INFLUXDB_PASSWORD=
-  # - INFLUXDB_ORG=
-  # - KAPACITOR_URL=http://kapacitor:9092
+    # - INFLUXDB_USERNAME=
+    # - INFLUXDB_PASSWORD=
+    # - INFLUXDB_ORG=
+    # - KAPACITOR_URL=http://kapacitor:9092
   ports:
     - "8888:8888"
   volumes:
     - ./volumes/chronograf:/var/lib/chronograf
   depends_on:
     - influxdb
-  # - kapacitor
+    # - kapacitor
 

--- a/.templates/diyhue/service.yml
+++ b/.templates/diyhue/service.yml
@@ -10,6 +10,6 @@ diyhue:
     - IP=%LAN_IP_Address%
     - MAC=%LAN_MAC_Address%
   volumes:
-      - ./volumes/diyhue:/opt/hue-emulator/export
+    - ./volumes/diyhue:/opt/hue-emulator/export
   restart: unless-stopped
 

--- a/.templates/docker-compose-base.yml
+++ b/.templates/docker-compose-base.yml
@@ -1,3 +1,5 @@
+---
+
 version: '3.6'
 
 networks:

--- a/.templates/dozzle/service.yml
+++ b/.templates/dozzle/service.yml
@@ -1,6 +1,6 @@
 dozzle:
   container_name: dozzle
-  image: amir20/dozzle:latest 
+  image: amir20/dozzle:latest
   restart: unless-stopped
   ports:
     - "8889:8080"

--- a/.templates/duckdns/service.yml
+++ b/.templates/duckdns/service.yml
@@ -7,8 +7,8 @@ duckdns:
     PUID: 1000
     PGID: 1000
     # Required variables, define here on in docker-compose.override.yml
-    #TOKEN: token from duckdns.org
-    #SUBDOMAINS: your domain added to duckdns.org (without .duckdns.org)
+    #  TOKEN: token from duckdns.org
+    #  SUBDOMAINS: your domain added to duckdns.org (without .duckdns.org)
     # Optional
-    #PRIVATE_SUBDOMAINS: your domain added to duckdns.org (without .duckdns.org)
+    #  PRIVATE_SUBDOMAINS: your domain added to duckdns.org (without .duckdns.org)
 

--- a/.templates/kapacitor/service.yml
+++ b/.templates/kapacitor/service.yml
@@ -3,14 +3,14 @@ kapacitor:
   image: kapacitor:1.5
   restart: unless-stopped
   environment:
-    - TZ=Etc/UTC
-  # see https://docs.influxdata.com/kapacitor/v1.6/administration/configuration/#kapacitor-environment-variables
+    - TZ=${TZ:-Etc/UTC}
+    # see https://docs.influxdata.com/kapacitor/v1.6/administration/configuration/#kapacitor-environment-variables
     - KAPACITOR_INFLUXDB_0_URLS_0=http://influxdb:8086
-  # - KAPACITOR_INFLUXDB_USERNAME=
-  # - KAPACITOR_INFLUXDB_PASSWORD=
-  # - KAPACITOR_HOSTNAME=kapacitor
-  # - KAPACITOR_LOGGING_LEVEL=INFO
-  # - KAPACITOR_REPORTING_ENABLED=false
+    # - KAPACITOR_INFLUXDB_USERNAME=
+    # - KAPACITOR_INFLUXDB_PASSWORD=
+    # - KAPACITOR_HOSTNAME=kapacitor
+    # - KAPACITOR_LOGGING_LEVEL=INFO
+    # - KAPACITOR_REPORTING_ENABLED=false
   ports:
     - "9092:9092"
   volumes:

--- a/.templates/mosquitto/service.yml
+++ b/.templates/mosquitto/service.yml
@@ -3,10 +3,10 @@ mosquitto:
   build:
     context: ./.templates/mosquitto/.
     args:
-    - MOSQUITTO_BASE=eclipse-mosquitto:latest
+      - MOSQUITTO_BASE=eclipse-mosquitto:latest
   restart: unless-stopped
   environment:
-    - TZ=Etc/UTC
+    - TZ=${TZ:-Etc/UTC}
   ports:
     - "1883:1883"
   volumes:

--- a/.templates/n8n/service.yml
+++ b/.templates/n8n/service.yml
@@ -1,29 +1,28 @@
 n8n:
-    container_name: "n8n"
-    restart: unless-stopped
-    ports:
-        - "5678:5678"
-    image: n8nio/n8n
-    stdin_open: true
-    volumes:
-        - ./volumes/n8n:/home/node/.n8n
-# Optional DB and Timezone configs.
-#        environment:
-#           - DB_TYPE=mysqldb
-#           - DB_MYSQLDB_DATABASE=<MYSQLDB_DATABASE>
-#           - DB_MYSQLDB_HOST=<MYSQLDB_HOST>
-#           - DB_MYSQLDB_PORT=<MYSQLDB_PORT>
-#           - DB_MYSQLDB_USER=<MYSQLDB_USER>
-#           - DB_MYSQLDB_PASSWORD=<MYSQLDB_PASSWORD>
-#           - GENERIC_TIMEZONE="Europe/Berlin"
-#           - TZ="Europe/Berlin"
-# Uncomment to enable authentication
-#           - N8N_BASIC_AUTH_ACTIVE=true
-#           - N8N_BASIC_AUTH_USER=<USER>
-#           - N8N_BASIC_AUTH_PASSWORD=<PASSWORD>
-
-#            - PGID=1000
-#            - PUID=1000
-#            - USBDEVICES=/dev/ttyAMA0
-#            - PACKAGES=mc
+  container_name: "n8n"
+  restart: unless-stopped
+  ports:
+    - "5678:5678"
+  image: n8nio/n8n
+  stdin_open: true
+  volumes:
+    - ./volumes/n8n:/home/node/.n8n
+  environment:
+    - TZ=${TZ:-Etc/UTC}
+    # - PGID=1000
+    # - PUID=1000
+    # - USBDEVICES=/dev/ttyAMA0
+    # - PACKAGES=mc
+    # Optional DB and Timezone configs.
+    # - DB_TYPE=mysqldb
+    # - DB_MYSQLDB_DATABASE=<MYSQLDB_DATABASE>
+    # - DB_MYSQLDB_HOST=<MYSQLDB_HOST>
+    # - DB_MYSQLDB_PORT=<MYSQLDB_PORT>
+    # - DB_MYSQLDB_USER=<MYSQLDB_USER>
+    # - DB_MYSQLDB_PASSWORD=<MYSQLDB_PASSWORD>
+    # - GENERIC_TIMEZONE=${TZ:-Etc/UTC}
+    # Optional to enable authentication
+    # - N8N_BASIC_AUTH_ACTIVE=true
+    # - N8N_BASIC_AUTH_USER=<USER>
+    # - N8N_BASIC_AUTH_PASSWORD=<PASSWORD>
 

--- a/.templates/openhab/service.yml
+++ b/.templates/openhab/service.yml
@@ -4,17 +4,17 @@ openhab:
   restart: unless-stopped
   network_mode: host
   volumes:
-  - "/etc/localtime:/etc/localtime:ro"
-  - "/etc/timezone:/etc/timezone:ro"
-  - "./volumes/openhab/addons:/openhab/addons"
-  - "./volumes/openhab/conf:/openhab/conf"
-  - "./volumes/openhab/userdata:/openhab/userdata"
+    - "/etc/localtime:/etc/localtime:ro"
+    - "/etc/timezone:/etc/timezone:ro"
+    - "./volumes/openhab/addons:/openhab/addons"
+    - "./volumes/openhab/conf:/openhab/conf"
+    - "./volumes/openhab/userdata:/openhab/userdata"
   environment:
     - OPENHAB_HTTP_PORT=4050
     - OPENHAB_HTTPS_PORT=4051
     - EXTRA_JAVA_OPTS=-Duser.timezone=Etc/UTC
-# logging:
-#   options:
-#     max-size: "5m"
-#     max-file: "3"
+  x-logging:
+    options:
+      max-size: "5m"
+      max-file: "3"
 

--- a/.templates/pgadmin4/service.yml
+++ b/.templates/pgadmin4/service.yml
@@ -2,11 +2,12 @@ pgadmin4:
   container_name: pgadmin4
   image: gpongelli/pgadmin4-arm:latest-armv7
   platform: linux/arm/v7
-# image: gpongelli/pgadmin4-arm:latest-armv8
+  # image: gpongelli/pgadmin4-arm:latest-armv8
   restart: unless-stopped
   environment:
-  - TZ=${TZ:-Etc/UTC}
+    - TZ=${TZ:-Etc/UTC}
   ports:
-  - "5050:5050"
+    - "5050:5050"
   volumes:
-  - ./volumes/pgadmin4:/pgadmin4
+    - ./volumes/pgadmin4:/pgadmin4
+

--- a/.templates/portainer_agent/service.yml
+++ b/.templates/portainer_agent/service.yml
@@ -2,9 +2,9 @@ portainer_agent:
   image: portainer/agent
   container_name: portainer-agent
   ports:
-  - "9001:9001"
+    - "9001:9001"
   volumes:
-  - /var/run/docker.sock:/var/run/docker.sock
-  - /var/lib/docker/volumes:/var/lib/docker/volumes
+    - /var/run/docker.sock:/var/run/docker.sock
+    - /var/lib/docker/volumes:/var/lib/docker/volumes
   restart: unless-stopped
 

--- a/.templates/postgres/service.yml
+++ b/.templates/postgres/service.yml
@@ -3,12 +3,13 @@ postgres:
   image: postgres
   restart: unless-stopped
   environment:
-  - TZ=${TZ:-Etc/UTC}
-  - POSTGRES_USER=${POSTGRES_USER:-postuser}
-  - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-IOtSt4ckpostgresDbPw}
-  - POSTGRES_DB=${POSTGRES_DB:-postdb}
+    - TZ=${TZ:-Etc/UTC}
+    - POSTGRES_USER=${POSTGRES_USER:-postuser}
+    - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-IOtSt4ckpostgresDbPw}
+    - POSTGRES_DB=${POSTGRES_DB:-postdb}
   ports:
-  - "5432:5432"
+    - "5432:5432"
   volumes:
-  - ./volumes/postgres/data:/var/lib/postgresql/data
-  - ./volumes/postgres/db_backup:/backup
+    - ./volumes/postgres/data:/var/lib/postgresql/data
+    - ./volumes/postgres/db_backup:/backup
+

--- a/.templates/python/service.yml
+++ b/.templates/python/service.yml
@@ -6,8 +6,8 @@ python:
     - TZ=Etc/UTC
     - IOTSTACK_UID=1000
     - IOTSTACK_GID=1000
-  # ports:
-  #   - "external:internal"
+  x-ports:
+    - "external:internal"
   volumes:
     - ./volumes/python/app:/usr/src/app
 

--- a/.templates/qbittorrent/service.yml
+++ b/.templates/qbittorrent/service.yml
@@ -2,16 +2,16 @@ qbittorrent:
   image: linuxserver/qbittorrent
   container_name: qbittorrent
   environment:
-  - PUID=1000
-  - PGID=1000
-  - UMASK_SET=022
-  - WEBUI_PORT=15080
+    - PUID=1000
+    - PGID=1000
+    - UMASK_SET=022
+    - WEBUI_PORT=15080
   volumes:
-  - ./volumes/qbittorrent/config:/config
-  - ./volumes/qbittorrent/downloads:/downloads
+    - ./volumes/qbittorrent/config:/config
+    - ./volumes/qbittorrent/downloads:/downloads
   ports:
-  - "6881:6881"
-  - "6881:6881/udp"
-  - "15080:15080"
-  - "1080:1080"
+    - "6881:6881"
+    - "6881:6881/udp"
+    - "15080:15080"
+    - "1080:1080"
 

--- a/.templates/ring-mqtt/service.yml
+++ b/.templates/ring-mqtt/service.yml
@@ -3,13 +3,13 @@ ring-mqtt:
   image: tsightler/ring-mqtt
   restart: unless-stopped
   environment:
-  - TZ=Etc/UTC
-  - DEBUG=ring-*
+    - TZ=${TZ:-Etc/UTC}
+    - DEBUG=ring-*
   ports:
-  - 8554:8554
-  - 55123:55123
+    - "8554:8554"
+    - "55123:55123"
   volumes:
-  - ./volumes/ring-mqtt/data:/data
+    - ./volumes/ring-mqtt/data:/data
   logging:
     options:
       max-size: 10m

--- a/.templates/rtl_433/service.yml
+++ b/.templates/rtl_433/service.yml
@@ -1,10 +1,10 @@
 rtl_433:
   container_name: rtl_433
   build: ./services/rtl_433/.
-  depends_on: 
+  depends_on:
     - mosquitto
   environment:
-    - TZ=Etc/UTC
+    - TZ=${TZ:-Etc/UTC}
     - MQTT_ADDRESS=mosquitto
     - MQTT_PORT=1883
     - MQTT_TOPIC=RTL_433

--- a/.templates/scrypted/service.yml
+++ b/.templates/scrypted/service.yml
@@ -3,15 +3,16 @@ scrypted:
   image: koush/scrypted
   restart: unless-stopped
   environment:
-  - SCRYPTED_WEBHOOK_UPDATE_AUTHORIZATION=Bearer ${SCRYPTED_WEBHOOK_UPDATE_AUTHORIZATION:?see instructions for generating a token}
-  - SCRYPTED_WEBHOOK_UPDATE=http://localhost:10444/v1/update
+    - SCRYPTED_WEBHOOK_UPDATE_AUTHORIZATION=Bearer ${SCRYPTED_WEBHOOK_UPDATE_AUTHORIZATION:?see instructions for generating a token}
+    - SCRYPTED_WEBHOOK_UPDATE=http://localhost:10444/v1/update
   network_mode: host
   x-ports:
-  - "10443:10443"
+    - "10443:10443"
   volumes:
-  - ./volumes/scrypted:/server/volume
+    - ./volumes/scrypted:/server/volume
   logging:
     driver: "json-file"
     options:
       max-size: "10m"
       max-file: "10"
+

--- a/.templates/syncthing/service.yml
+++ b/.templates/syncthing/service.yml
@@ -1,19 +1,19 @@
 syncthing:
   image: linuxserver/syncthing:latest
   container_name: syncthing
-  hostname: raspberrypi #optional
+  hostname: raspberrypi  # optional
   environment:
-  - PUID=1000
-  - PGID=1000
-  - HOME=/app
-  - TZ=${TZ:-Etc/UTC}
+    - PUID=1000
+    - PGID=1000
+    - HOME=/app
+    - TZ=${TZ:-Etc/UTC}
   volumes:
-  - ./volumes/syncthing/config:/config
-  - ./volumes/syncthing/data:/app
+    - ./volumes/syncthing/config:/config
+    - ./volumes/syncthing/data:/app
   x-ports:
-  - 8384:8384 # Web UI
-  - 22000:22000/tcp # TCP file transfers
-  - 22000:22000/udp # QUIC file transfers
-  - 21027:21027/udp # Receive local discovery broadcasts
+    - "8384:8384"  # Web UI
+    - "22000:22000/tcp"  # TCP file transfers
+    - "22000:22000/udp"  # QUIC file transfers
+    - "21027:21027/udp"  # Receive local discovery broadcasts
   network_mode: host
 

--- a/.templates/telegraf/service.yml
+++ b/.templates/telegraf/service.yml
@@ -1,10 +1,10 @@
 telegraf:
   container_name: telegraf
   build: ./.templates/telegraf/.
-  hostname: iotstack # optional
+  hostname: iotstack  # optional
   restart: unless-stopped
   environment:
-    - TZ=Etc/UTC
+    - TZ=${TZ:-Etc/UTC}
   ports:
     - "8092:8092/udp"
     - "8094:8094/tcp"

--- a/.templates/timescaledb/service.yml
+++ b/.templates/timescaledb/service.yml
@@ -3,11 +3,11 @@ timescaledb:
   image: timescale/timescaledb:latest-pg12
   restart: unless-stopped
   environment:
-  - POSTGRES_USER=${IOTSTACK_TIMESCALEDB_USER:-postgres}
-  - POSTGRES_PASSWORD={IOTSTACK_TIMESCALEDB_INITIAL_PASSWORD:-IOtSt4ckTim3Scale}
-  - POSTGRES_DB=postdb
+    - POSTGRES_USER=${IOTSTACK_TIMESCALEDB_USER:-postgres}
+    - POSTGRES_PASSWORD={IOTSTACK_TIMESCALEDB_INITIAL_PASSWORD:-IOtSt4ckTim3Scale}
+    - POSTGRES_DB=postdb
   ports:
-  - ${IOTSTACK_TIMESCALEDB_PORT_INT:-5433}:5432
+    - "${IOTSTACK_TIMESCALEDB_PORT_INT:-5433}:5432"
   volumes:
-  - ./volumes/timescaledb/data:/var/lib/postgresql/data
+    - ./volumes/timescaledb/data:/var/lib/postgresql/data
 

--- a/.templates/webthingsio_gateway/service.yml
+++ b/.templates/webthingsio_gateway/service.yml
@@ -2,9 +2,9 @@ webthingsio_gateway:
   image: webthingsio/gateway:latest
   container_name: webthingsio_gateway
   network_mode: host
-  #ports:
-  #- "4060:4060"
-  #- "4061:4061"
+  x-ports:
+    - "4060:4060"
+    - "4061:4061"
   volumes:
     - ./volumes/webthingsio_gateway/share:/home/node/.mozilla-iot
 

--- a/.templates/zerotier-client/service.yml
+++ b/.templates/zerotier-client/service.yml
@@ -4,10 +4,10 @@ zerotier-client:
   restart: unless-stopped
   network_mode: host
   volumes:
-  - ./volumes/zerotier-one:/var/lib/zerotier-one
+    - ./volumes/zerotier-one:/var/lib/zerotier-one
   devices:
-  - "/dev/net/tun:/dev/net/tun"
+    - "/dev/net/tun:/dev/net/tun"
   cap_add:
-  - NET_ADMIN
-  - SYS_ADMIN
+    - NET_ADMIN
+    - SYS_ADMIN
 

--- a/.templates/zerotier-router/service.yml
+++ b/.templates/zerotier-router/service.yml
@@ -3,22 +3,22 @@ zerotier-router:
   image: "zyclonite/zerotier:router"
   restart: unless-stopped
   environment:
-  - TZ=${TZ:-Etc/UTC}
-  - PUID=1000
-  - PGID=1000
-# - ZEROTIER_ONE_NETWORK_IDS=yourNetworkID
-  - ZEROTIER_ONE_LOCAL_PHYS=eth0 wlan0
-  - ZEROTIER_ONE_USE_IPTABLES_NFT=true
-  - ZEROTIER_ONE_GATEWAY_MODE=both
+    - TZ=${TZ:-Etc/UTC}
+    - PUID=1000
+    - PGID=1000
+    # - ZEROTIER_ONE_NETWORK_IDS=yourNetworkID
+    - ZEROTIER_ONE_LOCAL_PHYS=eth0 wlan0
+    - ZEROTIER_ONE_USE_IPTABLES_NFT=true
+    - ZEROTIER_ONE_GATEWAY_MODE=both
   network_mode: host
   x-ports:
-  - "9993:9993"
+    - "9993:9993"
   volumes:
-  - ./volumes/zerotier-one:/var/lib/zerotier-one
+    - ./volumes/zerotier-one:/var/lib/zerotier-one
   devices:
-  - "/dev/net/tun:/dev/net/tun"
+    - "/dev/net/tun:/dev/net/tun"
   cap_add:
-  - NET_ADMIN
-  - SYS_ADMIN
-  - NET_RAW
+    - NET_ADMIN
+    - SYS_ADMIN
+    - NET_RAW
 

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,11 @@
+---
+
+extends: default
+
+rules:
+  empty-lines:
+    max: 2
+    max-start: 0
+    max-end: 1
+  line-length:
+    max: 200


### PR DESCRIPTION
Applies changes recommended by `yamllint`, subject to the following alterations to the default ruleset:

```yml
---

extends: default

rules:
  empty-lines:
    max: 2
    max-start: 0
    max-end: 1
  line-length:
    max: 200
```

Opportunistic changes:

- adopt `TZ=${TZ:-Etc/UTC}`:

	- `adguardhome`
	- `chronograf`
	- `kapacitor`
	- `mosquitto`
	- `n8n`
	- `ring-mqtt`
	- `rtl_433`
	- `telegraf`

- wrap port specs in quotes:

	- `ring-mqtt`
	- `syncthing`
	- `timescaledb`

- adopt `x-ports` syntax:

	- `python`
	- `webthingsio_gateway`

Also changes `docker-compose-base.yml` to prepend triple-hyphen YAML marker.