### PR TITLE
2023-06-14 yamllint - old-menu branch - PR 2 of 2

### DIFF
--- a/.templates/adguardhome/service.yml
+++ b/.templates/adguardhome/service.yml
@@ -3,7 +3,7 @@
     image: adguard/adguardhome
     restart: unless-stopped
     environment:
-      - TZ=Etc/UTC
+      - TZ=${TZ:-Etc/UTC}
     # enable host mode to activate DHCP server on ports 67/udp & 68/tcp+udp
     # note that you must also disable all other ports if you enable host mode
     # network_mode: host
@@ -28,5 +28,6 @@
       # - "5443:5443/tcp"
       # - "5443:5443/udp"
     volumes:
-       - ./volumes/adguardhome/workdir:/opt/adguardhome/work
-       - ./volumes/adguardhome/confdir:/opt/adguardhome/conf
+      - ./volumes/adguardhome/workdir:/opt/adguardhome/work
+      - ./volumes/adguardhome/confdir:/opt/adguardhome/conf
+

--- a/.templates/chronograf/service.yml
+++ b/.templates/chronograf/service.yml
@@ -3,17 +3,18 @@
     image: chronograf:latest
     restart: unless-stopped
     environment:
-      - TZ=Etc/UTC
-    # see https://docs.influxdata.com/chronograf/v1.9/administration/config-options/
+      - TZ=${TZ:-Etc/UTC}
+      # see https://docs.influxdata.com/chronograf/v1.9/administration/config-options/
       - INFLUXDB_URL=http://influxdb:8086
-    # - INFLUXDB_USERNAME=
-    # - INFLUXDB_PASSWORD=
-    # - INFLUXDB_ORG=
-    # - KAPACITOR_URL=http://kapacitor:9092
+      # - INFLUXDB_USERNAME=
+      # - INFLUXDB_PASSWORD=
+      # - INFLUXDB_ORG=
+      # - KAPACITOR_URL=http://kapacitor:9092
     ports:
       - "8888:8888"
     volumes:
       - ./volumes/chronograf:/var/lib/chronograf
     depends_on:
       - influxdb
-    # - kapacitor
+      # - kapacitor
+

--- a/.templates/diyhue/service.yml
+++ b/.templates/diyhue/service.yml
@@ -10,5 +10,6 @@
     env_file:
       - ./services/diyhue/diyhue.env
     volumes:
-       - ./volumes/diyhue:/opt/hue-emulator/export
+      - ./volumes/diyhue:/opt/hue-emulator/export
     restart: unless-stopped
+

--- a/.templates/dozzle/service.yml
+++ b/.templates/dozzle/service.yml
@@ -1,9 +1,10 @@
   dozzle:
     container_name: dozzle
-    image: amir20/dozzle:latest 
+    image: amir20/dozzle:latest
     restart: unless-stopped
     network_mode: host
-    #ports:
-    #  - "8888:8080"
+    x-ports:
+      - "8888:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+

--- a/.templates/kapacitor/service.yml
+++ b/.templates/kapacitor/service.yml
@@ -3,17 +3,18 @@
     image: kapacitor:1.5
     restart: unless-stopped
     environment:
-      - TZ=Etc/UTC
-    # see https://docs.influxdata.com/kapacitor/v1.6/administration/configuration/#kapacitor-environment-variables
+      - TZ=${TZ:-Etc/UTC}
+      # see https://docs.influxdata.com/kapacitor/v1.6/administration/configuration/#kapacitor-environment-variables
       - KAPACITOR_INFLUXDB_0_URLS_0=http://influxdb:8086
-    # - KAPACITOR_INFLUXDB_USERNAME=
-    # - KAPACITOR_INFLUXDB_PASSWORD=
-    # - KAPACITOR_HOSTNAME=kapacitor
-    # - KAPACITOR_LOGGING_LEVEL=INFO
-    # - KAPACITOR_REPORTING_ENABLED=false
+      # - KAPACITOR_INFLUXDB_USERNAME=
+      # - KAPACITOR_INFLUXDB_PASSWORD=
+      # - KAPACITOR_HOSTNAME=kapacitor
+      # - KAPACITOR_LOGGING_LEVEL=INFO
+      # - KAPACITOR_REPORTING_ENABLED=false
     ports:
       - "9092:9092"
     volumes:
       - ./volumes/kapacitor:/var/lib/kapacitor
     depends_on:
       - influxdb
+

--- a/.templates/mosquitto/service.yml
+++ b/.templates/mosquitto/service.yml
@@ -3,10 +3,10 @@
     build:
       context: ./.templates/mosquitto/.
       args:
-      - MOSQUITTO_BASE=eclipse-mosquitto:latest
+        - MOSQUITTO_BASE=eclipse-mosquitto:latest
     restart: unless-stopped
     environment:
-      - TZ=Etc/UTC
+      - TZ=${TZ:-Etc/UTC}
     ports:
       - "1883:1883"
     volumes:
@@ -14,3 +14,4 @@
       - ./volumes/mosquitto/data:/mosquitto/data
       - ./volumes/mosquitto/log:/mosquitto/log
       - ./volumes/mosquitto/pwfile:/mosquitto/pwfile
+

--- a/.templates/openhab/service.yml
+++ b/.templates/openhab/service.yml
@@ -13,7 +13,8 @@
       - OPENHAB_HTTP_PORT=4050
       - OPENHAB_HTTPS_PORT=4051
       - EXTRA_JAVA_OPTS=-Duser.timezone=Etc/UTC
-#   logging:
-#     options:
-#       max-size: "5m"
-#       max-file: "3"
+    x-logging:
+      options:
+        max-size: "5m"
+        max-file: "3"
+

--- a/.templates/pgadmin4/service.yml
+++ b/.templates/pgadmin4/service.yml
@@ -2,11 +2,12 @@
     container_name: pgadmin4
     image: gpongelli/pgadmin4-arm:latest-armv7
     platform: linux/arm/v7
-  # image: gpongelli/pgadmin4-arm:latest-armv8
+    # image: gpongelli/pgadmin4-arm:latest-armv8
     restart: unless-stopped
     environment:
-    - TZ=${TZ:-Etc/UTC}
+      - TZ=${TZ:-Etc/UTC}
     ports:
-    - "5050:5050"
+      - "5050:5050"
     volumes:
-    - ./volumes/pgadmin4:/pgadmin4
+      - ./volumes/pgadmin4:/pgadmin4
+

--- a/.templates/plex/service.yml
+++ b/.templates/plex/service.yml
@@ -6,10 +6,11 @@
       - PUID=1000
       - PGID=1000
       - VERSION=docker
-      #- UMASK_SET=022 #optional
+      # - UMASK_SET=022 #optional
     volumes:
       - ./volumes/plex/config:/config
-      #- ~/mnt/HDD/tvseries:/tv
-      #- ~/mnt/HDD/movies:/movies
+      # - ~/mnt/HDD/tvseries:/tv
+      # - ~/mnt/HDD/movies:/movies
       - ./volumes/plex/transcode:/transcode
     restart: unless-stopped
+

--- a/.templates/python/service.yml
+++ b/.templates/python/service.yml
@@ -3,10 +3,11 @@
     build: ./services/python/.
     restart: unless-stopped
     environment:
-      - TZ=Etc/UTC
+      - TZ=${TZ:-Etc/UTC}
       - IOTSTACK_UID=1000
       - IOTSTACK_GID=1000
-  # ports:
-  #   - "external:internal"
+    x-ports:
+      - "external:internal"
     volumes:
       - ./volumes/python/app:/usr/src/app
+

--- a/.templates/ring-mqtt/service.yml
+++ b/.templates/ring-mqtt/service.yml
@@ -3,15 +3,15 @@
     image: tsightler/ring-mqtt
     restart: unless-stopped
     environment:
-    - TZ=Etc/UTC
-    - DEBUG=ring-*
+      - TZ=${TZ:-Etc/UTC}
+      - DEBUG=ring-*
     ports:
-    - 8554:8554
-    - 55123:55123
+      - "8554:8554"
+      - "55123:55123"
     volumes:
-    - ./volumes/ring-mqtt/data:/data
+      - ./volumes/ring-mqtt/data:/data
     logging:
       options:
         max-size: 10m
         max-file: "3"
-  
+

--- a/.templates/webthings_gateway/service.yml
+++ b/.templates/webthings_gateway/service.yml
@@ -2,10 +2,10 @@
     image: mozillaiot/gateway:arm
     container_name: webthings_gateway
     network_mode: host
-    #ports:
-    # - 8080:8080
-    # - 4443:4443
-    #devices:
-    # - /dev/ttyACM0:/dev/ttyACM0
+    x-ports:
+      - "8080:8080"
+      - "4443:4443"
+    devices:
+      - "${WEBTHINGS_DEVICE_PATH:?eg echo WEBTHINGS_DEVICE_PATH=/dev/serial0 >>~/IOTstack/.env}:/dev/ttyACM0"
     volumes:
       - ./volumes/webthings_gateway/share:/home/node/.mozilla-iot

--- a/.templates/zerotier-client/service.yml
+++ b/.templates/zerotier-client/service.yml
@@ -4,10 +4,10 @@
     restart: unless-stopped
     network_mode: host
     volumes:
-    - ./volumes/zerotier-one:/var/lib/zerotier-one
+      - ./volumes/zerotier-one:/var/lib/zerotier-one
     devices:
-    - "/dev/net/tun:/dev/net/tun"
+      - "/dev/net/tun:/dev/net/tun"
     cap_add:
-    - NET_ADMIN
-    - SYS_ADMIN
+      - NET_ADMIN
+      - SYS_ADMIN
 

--- a/.templates/zerotier-router/service.yml
+++ b/.templates/zerotier-router/service.yml
@@ -3,22 +3,22 @@
     image: "zyclonite/zerotier:router"
     restart: unless-stopped
     environment:
-    - TZ=${TZ:-Etc/UTC}
-    - PUID=1000
-    - PGID=1000
-#   - ZEROTIER_ONE_NETWORK_IDS=yourNetworkID
-    - ZEROTIER_ONE_LOCAL_PHYS=eth0 wlan0
-    - ZEROTIER_ONE_USE_IPTABLES_NFT=true
-    - ZEROTIER_ONE_GATEWAY_MODE=both
+      - TZ=${TZ:-Etc/UTC}
+      - PUID=1000
+      - PGID=1000
+      # - ZEROTIER_ONE_NETWORK_IDS=yourNetworkID
+      - ZEROTIER_ONE_LOCAL_PHYS=eth0 wlan0
+      - ZEROTIER_ONE_USE_IPTABLES_NFT=true
+      - ZEROTIER_ONE_GATEWAY_MODE=both
     network_mode: host
     x-ports:
-    - "9993:9993"
+      - "9993:9993"
     volumes:
-    - ./volumes/zerotier-one:/var/lib/zerotier-one
+      - ./volumes/zerotier-one:/var/lib/zerotier-one
     devices:
-    - "/dev/net/tun:/dev/net/tun"
+      - "/dev/net/tun:/dev/net/tun"
     cap_add:
-    - NET_ADMIN
-    - SYS_ADMIN
-    - NET_RAW
+      - NET_ADMIN
+      - SYS_ADMIN
+      - NET_RAW
 

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,11 @@
+---
+
+extends: default
+
+rules:
+  empty-lines:
+    max: 2
+    max-start: 0
+    max-end: 1
+  line-length:
+    max: 200

--- a/menu.sh
+++ b/menu.sh
@@ -486,7 +486,8 @@ case $mainmenu_selection in
 	if [ -n "$container_selection" ]; then
 		touch $TMP_DOCKER_COMPOSE_YML
 
-		echo "version: '$COMPOSE_VERSION'" > $TMP_DOCKER_COMPOSE_YML
+		echo "---" > $TMP_DOCKER_COMPOSE_YML
+		echo "version: '$COMPOSE_VERSION'" >> $TMP_DOCKER_COMPOSE_YML
 		echo "services:" >> $TMP_DOCKER_COMPOSE_YML
 
 		#set the ACL for the stack


### PR DESCRIPTION
Applies changes recommended by `yamllint`, subject to the following alterations to the default ruleset:

```yml
---

extends: default

rules:
  empty-lines:
    max: 2
    max-start: 0
    max-end: 1
  line-length:
    max: 200
```

Opportunistic changes:

- adopt `TZ=${TZ:-Etc/UTC}`:

	- `adguardhome'
	- `chronograf`
	- `dozzle`
	- `kapacitor`
	- `mosquitto`
	- `python`
	- `ring-mqtt`

- wrap port specs in quotes:

	- `ring-mqtt`
	- `webthings_gateway`

- adopt `x-ports` syntax:

	- `python`
	- `webthings_gateway`

- replace commented-out `logging` clause with `x-logging`

	- `openhab`

- Switch `webthings_gateway` from `/dev/ttyACM0` to prompt-style replacement for `/dev/serial0`.

Also changes `menu.sh` to prepend triple-hyphen YAML marker when generating the compose file.