### PR TITLE
2023-06-15 Pi-hole - old-menu branch - PR 2 of 2

### DIFF
--- a/.templates/pihole/pihole.env
+++ b/.templates/pihole/pihole.env
@@ -2,4 +2,6 @@ TZ=${TZ:-Etc/UTC}
 # see https://sensorsiot.github.io/IOTstack/Containers/Pi-hole/#adminPassword
 WEBPASSWORD=
 INTERFACE=eth0
+FTLCONF_MAXDBDAYS=365
+PIHOLE_DNS_=8.8.8.8;8.8.4.4
 # see https://github.com/pi-hole/docker-pi-hole#environment-variables

--- a/.templates/pihole/service.yml
+++ b/.templates/pihole/service.yml
@@ -9,13 +9,11 @@
     env_file:
       - ./services/pihole/pihole.env
     volumes:
-       - ./volumes/pihole/etc-pihole:/etc/pihole
-       - ./volumes/pihole/etc-dnsmasq.d:/etc/dnsmasq.d
+      - ./volumes/pihole/etc-pihole:/etc/pihole
+      - ./volumes/pihole/etc-dnsmasq.d:/etc/dnsmasq.d
     dns:
       - 127.0.0.1
       - 1.1.1.1
-    # Recommended but not required (DHCP needs NET_ADMIN)
-    #   https://github.com/pi-hole/docker-pi-hole#note-on-capabilities
     cap_add:
       - NET_ADMIN
     restart: unless-stopped


### PR DESCRIPTION
Applies changes recommended by `yamllint`.

Adds `FTLCONF_MAXDBDAYS` to the template environment file with the existing default of 365 days. Master branch documentation explains its use.

Adds `PIHOLE_DNS_` to the template environment file with the existing defaults of 8.8.8.8 and 8.8.4.4. Master branch documentation explains its use.