### PR TITLE
2023-06-24 Telegraf - old-menu branch - PR 2 of 2

### DIFF
--- a/.templates/telegraf/Dockerfile
+++ b/.templates/telegraf/Dockerfile
@@ -6,6 +6,10 @@ RUN apt update && apt install -y rsync
 
 # where IOTstack template files are stored
 ENV IOTSTACK_DEFAULTS_DIR="iotstack_defaults"
+ENV BASELINE_CONFIG=/${IOTSTACK_DEFAULTS_DIR}/telegraf-reference.conf
+ENV IOTSTACK_CONFIG=/${IOTSTACK_DEFAULTS_DIR}/telegraf.conf
+ENV IOTSTACK_ENTRY_POINT="entrypoint.sh"
+ENV BASELINE_ENTRY_POINT="entrypoint-reference.sh"
 
 # copy template files to image
 COPY ${IOTSTACK_DEFAULTS_DIR} /${IOTSTACK_DEFAULTS_DIR}
@@ -14,22 +18,25 @@ COPY ${IOTSTACK_DEFAULTS_DIR} /${IOTSTACK_DEFAULTS_DIR}
 #    a baseline reference for the user, and make it read-only.
 # 2. strip comment lines and blank lines from the baseline reference to
 #    use as the starting point for the IOTstack default configuration.
-# 3. edit the IOTstack default configuration to insert an appropriate
-#    URL for influxdb running in another container in the same stack.
-ENV BASELINE_CONFIG=/${IOTSTACK_DEFAULTS_DIR}/telegraf-reference.conf
-ENV IOTSTACK_CONFIG=/${IOTSTACK_DEFAULTS_DIR}/telegraf.conf
+# 3. append auto-inclusions which, among other things, sets up the
+#    the appropriate URL for influxdb running in another container in
+#    the same stack.
 RUN cp /etc/telegraf/telegraf.conf ${BASELINE_CONFIG} && \
+    cat /${IOTSTACK_DEFAULTS_DIR}/auto_include/*.conf >> ${BASELINE_CONFIG} && \
+    rm -r /${IOTSTACK_DEFAULTS_DIR}/auto_include && \
     chmod 444 ${BASELINE_CONFIG} && \
-    grep -v -e "^[ ]*#" -e "^[ ]*$" ${BASELINE_CONFIG} >${IOTSTACK_CONFIG} && \
-    sed -i '/^\[\[outputs.influxdb\]\]/a\ \ urls = ["http://influxdb:8086"]' ${IOTSTACK_CONFIG}
-ENV BASELINE_CONFIG=
-ENV IOTSTACK_CONFIG=
+    grep -v -e "^[ ]*#" -e "^[ ]*$" ${BASELINE_CONFIG} >${IOTSTACK_CONFIG}
 
 # replace the docker entry-point script with a self-repairing version
-ENV IOTSTACK_ENTRY_POINT="entrypoint.sh"
+RUN cp /${IOTSTACK_ENTRY_POINT} /${BASELINE_ENTRY_POINT}
 COPY ${IOTSTACK_ENTRY_POINT} /${IOTSTACK_ENTRY_POINT}
 RUN chmod 755 /${IOTSTACK_ENTRY_POINT}
+
+# undefine variables not needed at runtime
+ENV BASELINE_CONFIG=
+ENV IOTSTACK_CONFIG=
 ENV IOTSTACK_ENTRY_POINT=
+ENV BASELINE_ENTRY_POINT=
 
 # IOTstack declares this path for persistent storage
 VOLUME ["/etc/telegraf"]

--- a/.templates/telegraf/entrypoint.sh
+++ b/.templates/telegraf/entrypoint.sh
@@ -9,10 +9,28 @@ fi
 U="$(id -u)"
 T="/etc/telegraf"
 if [ "$U" = '0' -a -d "$T" ]; then
+   echo "Performing IOTstack self repair"
    rsync -arp --ignore-existing /${IOTSTACK_DEFAULTS_DIR}/ "$T"
    chown -R "$U:$U" "$T"
 fi
 
+if [ $EUID -eq 0 ]; then
+
+    # Allow telegraf to send ICMP packets and bind to privliged ports
+    setcap cap_net_raw,cap_net_bind_service+ep /usr/bin/telegraf || echo "Failed to set additional capabilities on /usr/bin/telegraf"
+
+    # note: at this point, the default version of this file runs:
+    #
+    #          exec setpriv --reuid telegraf --init-groups "$@"
+    #
+    #       Inside the container, user "telegraf" is userID 999, which
+    #       isn't a member of the "docker" group outside container-space
+    #       so the practical effect of downgrading privileges in this
+    #       way is to deny access to /var/run/docker.sock, and then you
+    #       get a mess. It's not clear whether the setcap is necessary
+    #       on a Raspberry Pi but it has been left in place in case it
+    #       turns out to be useful in other Docker environments.
+
+fi
+
 exec "$@"
-
-

--- a/.templates/telegraf/iotstack_defaults/auto_include/inputs.cpu_temp.conf
+++ b/.templates/telegraf/iotstack_defaults/auto_include/inputs.cpu_temp.conf
@@ -1,0 +1,5 @@
+[[inputs.file]]
+  files = ["/sys/class/thermal/thermal_zone0/temp"]
+  name_override = "cpu_temperature"
+  data_format = "value"
+  data_type = "integer"

--- a/.templates/telegraf/iotstack_defaults/auto_include/inputs.docker.conf
+++ b/.templates/telegraf/iotstack_defaults/auto_include/inputs.docker.conf
@@ -3,13 +3,12 @@
 [[inputs.docker]]
   endpoint = "unix:///var/run/docker.sock"
   gather_services = false
-  container_names = []
   source_tag = false
   container_name_include = []
   container_name_exclude = []
   timeout = "5s"
   perdevice = false
-  total = true
+  total_include = ["cpu", "blkio", "network"]
   docker_label_include = []
   docker_label_exclude = []
   tag_env = ["HEAP_SIZE"]

--- a/.templates/telegraf/iotstack_defaults/auto_include/outputs.influxdb.conf
+++ b/.templates/telegraf/iotstack_defaults/auto_include/outputs.influxdb.conf
@@ -1,0 +1,3 @@
+[[outputs.influxdb]]
+urls = ["http://influxdb:8086"]
+


### PR DESCRIPTION
Issue reported on
[Discord](https://discord.com/channels/638610460567928832/638610461109256194/1121820918210121838) led to the discovery of several problems with Telegraf:

1. Default configuration had been amended to:

	- Add support for both InfluxDB 1.8 and InfluxDB 2; and
	- Comment-out both InfluxDB outputs.

	The practical consequences were:

	- The Dockerfile `sed` command could not find `[outputs.influxdb]`, so the `urls = ["http://influxdb:8086"]` could not be inserted, so telegraf could not write to any database; and
	- The container went into a restart loop.

2. The default `entrypoint.sh` script had been amended to invoke telegraf via:

	```
	exec setpriv --reuid telegraf --init-groups "$@"
	```

	Inside the container, user "telegraf" is userID 999. Outside
	container space, user 999 is not a member of the `docker` group so
	it doesn't have access to `/var/run/docker.sock`.

	The practical consequence was the telegraf process inside the
	container endlessly complaining:

	```
	E! [inputs.docker] Error in plugin: permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock
	```

Problem 1 has been addressed by removing the `sed` logic and adding `outputs.influxdb.conf` to the `auto_include` folder:

```
[[outputs.influxdb]]
urls = ["http://influxdb:8086"]
```

This defaults to the `telegraf` database and is sufficient for telegraf to get going.

Problem 2 has been addressed by not downgrading privileges. The alternative of changing the documentation to require the user to add userID 999 to the `docker` group is sub-optimal and not really in the spirit of IOTstack where, to the maximum extent possible, containers should "just work".

Also, old-menu branch had become out-of-sync with master branch. That has been rectified.