### PR TITLE
2023-08-08 Update service.yml for Homebridge

### DIFF
--- a/.templates/homebridge/service.yml
+++ b/.templates/homebridge/service.yml
@@ -1,6 +1,6 @@
 homebridge:
   container_name: homebridge
-  image: oznu/homebridge:latest
+  image: homebridge/homebridge:latest
   restart: unless-stopped
   environment:
     - TZ=Etc/UTC


### PR DESCRIPTION
Change from oznu to homebridge. New version is available only on homebridge.

https://github.com/homebridge/docker-homebridge

> Important Update
> We have moved the hosting of the offical homebridge docker image from oznu/homebridge to homebridge/homebridge. Please update your environments as needed to pickup the latest image.