### PR TITLE
2023-10-09 Mosquitto entry-point script - master branch - PR 1 of 2

### DIFF
--- a/.templates/mosquitto/docker-entrypoint.sh
+++ b/.templates/mosquitto/docker-entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/ash
 set -e
 
+PWFILE="/mosquitto/pwfile/pwfile"
+
 # Set permissions
 user="$(id -u)"
 if [ "$user" = '0' -a -d "/mosquitto" ]; then
@@ -9,7 +11,12 @@ if [ "$user" = '0' -a -d "/mosquitto" ]; then
 
    rsync -arpv --ignore-existing /${IOTSTACK_DEFAULTS_DIR}/ "/mosquitto"
 
+   # general ownership assuming mode as set in template
    chown -Rc mosquitto:mosquitto /mosquitto
+
+   # specific requirements for the password file
+   chown -c root:root "$PWFILE"
+   chmod -c 600 "$PWFILE"
 
    echo "[IOTstack] end self-repair"
    


### PR DESCRIPTION
The folder structure for a newly-created or self-repaired persistent store assumes ownership of id 1883 (which is "mosquitto" inside the container) and file/folder modes copied from the `iotstack_defaults` folder hierarchy.

Investigations during #731 revealed that Mosquitto now wants the password file to be owned by root with a mode of 600.

Although the mode requirement could be accommodated by changing the `iotstack_defaults` structure, the ownership requirement can't be met that way.

This fix adds the necessary `chown` and `chmod` commands to the entry-point script.