### PR TITLE
2023-10-24 mjpg-streamer container - old-menu branch - PR 2 of 2

### DIFF
--- a/.templates/mjpg-streamer/Dockerfile
+++ b/.templates/mjpg-streamer/Dockerfile
@@ -1,0 +1,68 @@
+# supported build argument
+ARG DEBIAN_VARIANT=bullseye-slim
+
+# Download base image
+FROM debian:${DEBIAN_VARIANT}
+
+# re-reference supported argument and copy to environment var
+ARG DEBIAN_VARIANT
+ENV DEBIAN_VARIANT=${DEBIAN_VARIANT}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
+# Refer https://github.com/jacksonliam/mjpg-streamer/issues/386
+# This assumes a Debian build and references:
+#     libjpeg62-turbo-dev
+# For Ubuntu, replace with:
+#     libjpeg8-dev
+
+# acknowledgement: mostly borrowed from https://github.com/Cossey/docker
+RUN apt-get -q -y update \
+ && apt-get -q -y -o "DPkg::Options::=--force-confold" -o "DPkg::Options::=--force-confdef" install apt-utils \
+ && rm -rf /etc/dpkg/dpkg.cfg.d/excludes \
+ && apt-get -q -y -o "DPkg::Options::=--force-confold" -o "DPkg::Options::=--force-confdef" install \
+       cmake \
+       git \
+       gcc \
+       g++ \
+       libjpeg62-turbo-dev \
+       tzdata \
+       uuid-runtime \
+ && apt-get -q -y autoremove \
+ && apt-get -q -y clean \
+ && rm -rf /var/lib/apt/lists/* \
+ && git clone https://github.com/jacksonliam/mjpg-streamer.git /usr/src/mjpg-streamer \
+ && make -C /usr/src/mjpg-streamer/mjpg-streamer-experimental \
+ && make -C /usr/src/mjpg-streamer/mjpg-streamer-experimental install \
+ && rm -rf /usr/src/mjpg-streamer \
+ && apt-get -q -y -o "DPkg::Options::=--force-confold" -o "DPkg::Options::=--force-confdef" purge \
+       cmake \
+       git \
+       gcc \
+       g++
+
+# set up the container start point
+ENV ENTRYPOINT_SCRIPT="docker-entrypoint.sh"
+COPY docker-entrypoint.sh /usr/local/bin
+RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
+
+# starting point - self-repair (if ever needed) and launch
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+# the streamer invocation
+CMD mjpg_streamer \
+    -i "/usr/local/lib/mjpg-streamer/input_uvc.so -d ${MJPG_STREAMER_INTERNAL_DEVICE} -n -f ${MJPG_STREAMER_FPS} -r ${MJPG_STREAMER_SIZE}" \
+    -o "/usr/local/lib/mjpg-streamer/output_http.so -p 80 -w /usr/local/share/mjpg-streamer/www ${MJPG_STREAMER_CREDENTIALS}"
+
+# set root's home directory as default (probably unnecessary)
+WORKDIR /root
+
+# port
+EXPOSE "80"
+
+# set container metadata
+LABEL com.github.SensorsIot.IOTstack.Dockerfile.build-args="${DEBIAN_VARIANT}"
+LABEL com.github.SensorsIot.IOTstack.Dockerfile.maintainer="Paraphraser <34226495+Paraphraser@users.noreply.github.com>"
+
+# EOF

--- a/.templates/mjpg-streamer/docker-entrypoint.sh
+++ b/.templates/mjpg-streamer/docker-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+# sensible defaults for supported variables
+export MJPG_STREAMER_SIZE=${MJPG_STREAMER_SIZE:-640x480}
+export MJPG_STREAMER_FPS=${MJPG_STREAMER_FPS:-5}
+export MJPG_STREAMER_INTERNAL_DEVICE=${MJPG_STREAMER_INTERNAL_DEVICE:-/dev/video0}
+
+# form credential string (if the user does not pass a username, the
+# username will be the container name - change on each recreate; if
+# the user does not pass a password, the password will be a uuid and
+# will change on every launch).
+MJPG_STREAMER_USERNAME=${MJPG_STREAMER_USERNAME:-$(hostname -s)}
+MJPG_STREAMER_PASSWORD=${MJPG_STREAMER_PASSWORD:-$(uuidgen)}
+export MJPG_STREAMER_CREDENTIALS="-c ${MJPG_STREAMER_USERNAME}:${MJPG_STREAMER_PASSWORD}"
+
+# are we running as root?
+if [ "$(id -u)" = '0' ] ; then
+
+	echo "MJPG Streamer launched at $(date)"
+
+	# any self-repair code goes here - there is no persistent storage
+	# at the moment so this is irrelevant.
+
+fi
+
+# away we go
+exec "$@"

--- a/.templates/mjpg-streamer/service.yml
+++ b/.templates/mjpg-streamer/service.yml
@@ -1,0 +1,15 @@
+  mjpg-streamer:
+    container_name: mjpg-streamer
+    build: ./.templates/mjpg-streamer/.
+    restart: unless-stopped
+    environment:
+      - TZ=${TZ:-Etc/UTC}
+      - MJPG_STREAMER_USERNAME=${MJPG_STREAMER_USERNAME:-}
+      - MJPG_STREAMER_PASSWORD=${MJPG_STREAMER_PASSWORD:-}
+      - MJPG_STREAMER_SIZE=${MJPG_STREAMER_SIZE:-}
+      - MJPG_STREAMER_FPS=${MJPG_STREAMER_FPS:-}
+    ports:
+      - "8980:80"
+    devices:
+      - "${MJPG_STREAMER_EXTERNAL_DEVICE:-/dev/video0}:/dev/video0"
+

--- a/menu.sh
+++ b/menu.sh
@@ -66,6 +66,7 @@ declare -A cont_array=(
 	[heimdall]="Heimdall Application Dashboard"
 	[dashmachine]="DashMachine"
 	[homer]="Homer"
+	[mjpg-streamer]="MJPG Streamer"
 	[home_assistant]="Home Assistant Container"
 	# add yours here
 )
@@ -116,6 +117,7 @@ declare -a keylist=(
 	"heimdall"
 	"dashmachine"
 	"homer"
+	"mjpg-streamer"
 	"home_assistant"
 	# add yours here
 )


### PR DESCRIPTION
Adds `mjpg-streamer` service definition. The container is designed to work with MotionEye. It provides a way to connect both "ribbon" and USB-connected web cams. From the perspective of MotionEye, all cameras are "networked" and accessed via HTTP. Streamer containers can be running on the same or different hosts as MotionEye. While the most common home arrangement is likely to be a single MotionEye instance taking feeds from multiple streamers, there can also be many-to-many relationships between streamer containers and MotionEye containers.

Documentation added to master branch.