### PR TITLE
2023-10-26 NextCloud - master branch - PR 1 of 2

### DIFF
--- a/.templates/nextcloud/service.yml
+++ b/.templates/nextcloud/service.yml
@@ -3,12 +3,14 @@ nextcloud:
   image: nextcloud
   restart: unless-stopped
   environment:
+    - TZ=${TZ:-Etc/UTC}
     - MYSQL_HOST=nextcloud_db
     - MYSQL_PASSWORD=%randomMySqlPassword%
     - MYSQL_DATABASE=nextcloud
     - MYSQL_USER=nextcloud
   ports:
     - "9321:80"
+    - "9343:443"
   volumes:
     - ./volumes/nextcloud/html:/var/www/html
   depends_on:
@@ -22,7 +24,7 @@ nextcloud_db:
   build: ./.templates/mariadb/.
   restart: unless-stopped
   environment:
-    - TZ=Etc/UTC
+    - TZ=${TZ:-Etc/UTC}
     - PUID=1000
     - PGID=1000
     - MYSQL_ROOT_PASSWORD=%randomPassword%


### PR DESCRIPTION
Adds TZ to NextCloud (which now seems to support timezones).

Adds port mapping 9343:443 to reserve 9343 for HTTPS access in the IOTstack context.

Makes NextCloud_DB container's TZ variable conform with current syntax.

Numerous behavioural changes are apparent in current versions of NextCloud. In particular, these problems seem to have gone away:

1. Mal-formed URLs and the requirement to pick an access method and stick to it during setup.
2. The "Access through untrusted domains" issue.
3. Dislike of being reached via a a URL containing a DNS alias (CNAME) record.

Appropriate changes to the documentation will be pushed to #737 shortly.