### PR TITLE
2023-10-26 NextCloud - old-menu branch - PR 2 of 2

### DIFF
--- a/.templates/nextcloud/service.yml
+++ b/.templates/nextcloud/service.yml
@@ -3,12 +3,14 @@
     image: nextcloud
     restart: unless-stopped
     environment:
+      - TZ=${TZ:-Etc/UTC}
       - MYSQL_HOST=nextcloud_db
       - MYSQL_PASSWORD=user_password
       - MYSQL_DATABASE=nextcloud
       - MYSQL_USER=nextcloud
     ports:
       - "9321:80"
+      - "9343:443"
     volumes:
       - ./volumes/nextcloud/html:/var/www/html
     depends_on:
@@ -22,7 +24,7 @@
     build: ./.templates/mariadb/.
     restart: unless-stopped
     environment:
-      - TZ=Etc/UTC
+      - TZ=${TZ:-Etc/UTC}
       - PUID=1000
       - PGID=1000
       - MYSQL_ROOT_PASSWORD=root_password
@@ -34,3 +36,4 @@
       - ./volumes/nextcloud/db_backup:/backup
     networks:
       - nextcloud
+


### PR DESCRIPTION
Adds TZ to NextCloud (which now seems to support timezones).

Adds port mapping 9343:443 to reserve 9343 for HTTPS access in the IOTstack context.

Makes NextCloud_DB container's TZ variable conform with current syntax.