### PR TITLE
2024-02-14 Heimdall port conflict - master branch - PR 1 of 2

### DIFF
--- a/.templates/heimdall/service.yml
+++ b/.templates/heimdall/service.yml
@@ -4,11 +4,11 @@ heimdall:
   environment:
     - PUID=1000
     - PGID=1000
-    - TZ=Etc/UTC
+    - TZ=${TZ:-Etc/UTC}
   volumes:
     - ./volumes/heimdall/config:/config
   ports:
-    - 8880:80
+    - 8882:80
     - 8883:443
   restart: unless-stopped
 

--- a/docs/Containers/Heimdall.md
+++ b/docs/Containers/Heimdall.md
@@ -1,11 +1,16 @@
 # Heimdall
 
 ## References 
+
 * [Homepage](https://heimdall.site/)
 * [Docker](https://hub.docker.com/r/linuxserver/heimdall/)
 
 ## Web Interface
-The web UI can be found on `"your_ip":8880`
+
+The web UI can be found on:
+
+* HTTP: `"your_ip":8882`
+* HTTPS: `"your_ip":8883`
 
 ## About *Heimdall*
 


### PR DESCRIPTION
Issue #751 reports external port 8880 is used for both Heimdall and Zigbee2MQTT_Assistant. This PR changes the port to 8882:

```
$ git -C ~/IOTstack/.templates grep 8880
heimdall/service.yml:    - 8880:80
zigbee2mqtt_assistant/service.yml:    - "8880:80"
zigbee2mqtt_assistant/service.yml:    - VIRTUAL_PORT=8880
$ git -C ~/IOTstack/.templates grep 8882
$
```

Using port 8882 for HTTP also conveniently aligns with the second Heimdall port-mapping of `8883:443`.

Also takes the opportunity to adopt up-to-date syntax for `TZ=`.

Fixes #751