### PR TITLE
2024-02-14 Heimdall port conflict - old-menu branch - PR 2 of 2

### DIFF
--- a/.templates/heimdall/service.yml
+++ b/.templates/heimdall/service.yml
@@ -6,6 +6,6 @@
     volumes:
       - ./volumes/heimdall/config:/config
     ports:
-      - 8880:80
+      - 8882:80
       - 8883:443
     restart: unless-stopped

--- a/docs/Containers/Heimdall.md
+++ b/docs/Containers/Heimdall.md
@@ -1,16 +1,3 @@
 # Heimdall
 
-## References 
-* [Homepage](https://heimdall.site/)
-* [Docker](https://hub.docker.com/r/linuxserver/heimdall/)
-
-## Web Interface
-The web UI can be found on `"your_ip":8880`
-
-## About *Heimdall*
-
-From the [Heimdall website](https://heimdall.site/):
-
-> Heimdall Application Dashboard is a dashboard for all your web applications. It doesn't need to be limited to applications though, you can add links to anything you like. There are no iframes here, no apps within apps, no abstraction of APIs. if you think something should work a certain way, it probably does.
-
-Within the context of IOTstack, the Heimdall Application Dashboard can help you organize your deployed services.
+Documentation can be found at [IOTstack Wiki](https://sensorsiot.github.io/IOTstack/Containers/Heimdall/).


### PR DESCRIPTION
Issue #751 reports external port 8880 is used for both Heimdall and Zigbee2MQTT_Assistant. This PR changes the port to 8882:

```
$ git -C ~/IOTstack/.templates grep 8880
heimdall/service.yml:    - 8880:80
zigbee2mqtt_assistant/service.yml:    - "8880:80"
zigbee2mqtt_assistant/service.yml:    - VIRTUAL_PORT=8880
$ git -C ~/IOTstack/.templates grep 8882
$
```

Using port 8882 for HTTP also conveniently aligns with the second Heimdall mapping of `8883:443`.

Old-menu documentation reduced to a stub pointing to the Wiki.