### PR TITLE
2024-03-24 docker-compose.yml - master branch - PR 1 of 2

### DIFF
--- a/.templates/docker-compose-base.yml
+++ b/.templates/docker-compose-base.yml
@@ -1,7 +1,5 @@
 ---
 
-version: '3.6'
-
 networks:
   default:
     driver: bridge


### PR DESCRIPTION
From and including `docker-compose-plugin` v2.25.0, the `version:` clause is deprecated. Commands now produce the following warning:

```
WARN[0000] /home/pi/IOTstack/docker-compose.yml: `version` is obsolete
```

This PR removes the `version:` clause from the template.

Most users will likely need to hand-edit their compose files to remove the clause.