### PR TITLE
2024-03-24 docker-compose.yml - old-menu branch - PR 2 of 2

### DIFF
--- a/menu.sh
+++ b/menu.sh
@@ -14,7 +14,6 @@ DOCKER_COMPOSE_YML=./docker-compose.yml
 DOCKER_COMPOSE_OVERRIDE_YML=./compose-override.yml
 
 # Minimum Software Versions
-COMPOSE_VERSION="3.6"
 REQ_DOCKER_VERSION=18.2.0
 REQ_PYTHON_VERSION=3.6.9
 REQ_PYYAML_VERSION=5.3.1
@@ -489,7 +488,6 @@ case $mainmenu_selection in
 		touch $TMP_DOCKER_COMPOSE_YML
 
 		echo "---" > $TMP_DOCKER_COMPOSE_YML
-		echo "version: '$COMPOSE_VERSION'" >> $TMP_DOCKER_COMPOSE_YML
 		echo "services:" >> $TMP_DOCKER_COMPOSE_YML
 
 		#set the ACL for the stack


### PR DESCRIPTION
From and including `docker-compose-plugin` v2.25.0, the `version:` clause is deprecated. Commands now produce the following warning:

```
WARN[0000] /home/pi/IOTstack/docker-compose.yml: `version` is obsolete
```

This PR removes from the menu, the lines of code involved in generating the `version:` clause.

Most users will likely need to hand-edit their compose files to remove the clause.