### PR TITLE
2024-04-02 missing port-mapping quotes - master branch - PR 1 of 2

### DIFF
--- a/.templates/dashmachine/service.yml
+++ b/.templates/dashmachine/service.yml
@@ -4,6 +4,6 @@ dashmachine:
   volumes:
     - ./volumes/dashmachine/user_data:/dashmachine/dashmachine/user_data
   ports:
-    - 5000:5000
+    - "5000:5000"
   restart: unless-stopped
 

--- a/.templates/heimdall/service.yml
+++ b/.templates/heimdall/service.yml
@@ -8,7 +8,7 @@ heimdall:
   volumes:
     - ./volumes/heimdall/config:/config
   ports:
-    - 8882:80
-    - 8883:443
+    - "8882:80"
+    - "8883:443"
   restart: unless-stopped
 


### PR DESCRIPTION
Following on from discussion in #761, this adds quotes to port mappings as recommended in docker-compose
[documentation](https://docs.docker.com/compose/compose-file/05-services/#short-syntax-3):

> HOST:CONTAINER should always be specified as a (quoted) string, to avoid conflicts with [yaml base-60 float](https://yaml.org/type/float.html)