### PR TITLE
2024-04-02 missing port-mapping quotes - old-menu branch - PR 2 of 2

### DIFF
--- a/.templates/dashmachine/service.yml
+++ b/.templates/dashmachine/service.yml
@@ -4,5 +4,5 @@
     volumes:
       - ./volumes/dashmachine/user_data:/dashmachine/dashmachine/user_data
     ports:
-      - 5000:5000
+      - "5000:5000"
     restart: unless-stopped

--- a/.templates/heimdall/service.yml
+++ b/.templates/heimdall/service.yml
@@ -6,6 +6,6 @@
     volumes:
       - ./volumes/heimdall/config:/config
     ports:
-      - 8882:80
-      - 8883:443
+      - "8882:80"
+      - "8883:443"
     restart: unless-stopped

--- a/.templates/homer/service.yml
+++ b/.templates/homer/service.yml
@@ -6,5 +6,5 @@
     volumes:
       - ./volumes/homer/assets:/www/assets
     ports:
-      - 8881:8080
+      - "8881:8080"
     restart: unless-stopped

--- a/.templates/portainer_agent/service.yml
+++ b/.templates/portainer_agent/service.yml
@@ -2,7 +2,7 @@
     image: portainer/agent
     container_name: portainer-agent
     ports:
-      - 9002:9001
+      - "9002:9001"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/lib/docker/volumes:/var/lib/docker/volumes

--- a/.templates/qbittorrent/service.yml
+++ b/.templates/qbittorrent/service.yml
@@ -10,7 +10,7 @@
       - ./volumes/qbittorrent/config:/config
       - ./volumes/qbittorrent/downloads:/downloads
     ports:
-      - 6881:6881
-      - 6881:6881/udp
-      - 15080:15080
-      - 1080:1080
+      - "6881:6881"
+      - "6881:6881/udp"
+      - "15080:15080"
+      - "1080:1080"


### PR DESCRIPTION
Following on from discussion in #761, this adds quotes to port mappings as recommended in docker-compose
[documentation](https://docs.docker.com/compose/compose-file/05-services/#short-syntax-3):

> HOST:CONTAINER should always be specified as a (quoted) string, to avoid conflicts with [yaml base-60 float](https://yaml.org/type/float.html)