### PR TITLE
2024-04-23 Domoticz - old-menu branch - PR 2 of 2

### DIFF
--- a/.templates/domoticz/service.yml
+++ b/.templates/domoticz/service.yml
@@ -1,16 +1,15 @@
   domoticz:
     container_name: domoticz
-    image: lscr.io/linuxserver/domoticz:latest
-    ports:
-      - "8083:8080"
-      - "6144:6144"
-      - "1443:1443"
-    volumes:
-      - ./volumes/domoticz/data:/config
+    image: domoticz/domoticz:stable
     restart: unless-stopped
     environment:
-      - PUID=1000
-      - PGID=1000
-      # - TZ=Etc/UTC
-      # - WEBROOT=domoticz
-  
+      - TZ=${TZ:-Etc/UTC}
+      # - LOG_PATH=/opt/domoticz/userdata/domoticz.log
+      # - EXTRA_CMD_ARG=
+    ports:
+      - "8083:8080"
+      - "1443:443"
+    volumes:
+      - ./volumes/domoticz:/opt/domoticz/userdata
+    x-devices:
+      - "/dev/serial/by-id/usb-0658_0200-if00-port0:/dev/ttyACM0"


### PR DESCRIPTION
Updates service definition:

- Change image to `domoticz/domoticz:stable`
- Adopt IOTstack convention for `TZ=`
- Support [documented](https://hub.docker.com/r/domoticz/domoticz) environment variables
- Remove mapping for port 6144 (no longer in use)
- Change internal TLS port to 443
- Remove redundant `data` subdirectory from left hand side of volume mapping
- Adopt new image's convention for right hand side of volume mapping