### PR TITLE
2024-07-30 Node-RED - old-menu branch - PR 2 of 2

### DIFF
--- a/.templates/nodered/build.sh
+++ b/.templates/nodered/build.sh
@@ -8,7 +8,6 @@ node_selection=$(whiptail --title "Node-RED nodes" --checklist --separate-output
 	"node-red-dashboard" " " "ON" \
 	"node-red-contrib-influxdb" " " "ON" \
 	"node-red-contrib-boolean-logic" " " "ON" \
-	"node-red-node-rbe" " " "ON" \
 	"node-red-configurable-ping" " " "ON" \
 	"node-red-node-openweathermap" " " "OFF" \
 	"node-red-contrib-discord" " " "OFF" \
@@ -46,11 +45,17 @@ node_selection=$(whiptail --title "Node-RED nodes" --checklist --separate-output
 	"node-red-contrib-generic-ble" " " "OFF" \
 	"node-red-contrib-zigbee2mqtt" " " "OFF" \
 	"node-red-contrib-vcgencmd" " " "OFF" \
-	"node-red-contrib-themes/midnight-red" " " "OFF" \
 	"node-red-contrib-tf-function" " " "OFF" \
 	"node-red-contrib-tf-model" " " "OFF" \
 	"node-red-contrib-post-object-detection" " " "OFF" \
 	"node-red-contrib-bert-tokenizer" " " "OFF" \
+	"node-red-contrib-boolean-logic-ultimate" " " "OFF" \
+	"node-red-contrib-chartjs" " " "OFF" \
+	"node-red-contrib-md5" " " "OFF" \
+	"node-red-contrib-pushsafer" " " "OFF" \
+	"node-red-node-tail" " " "OFF" \
+	"@flowfuse/node-red-dashboard" " " "OFF" \
+	"@node-red-contrib-themes/theme-collection" " " "OFF" \
 	3>&1 1>&2 2>&3)
 
 ##echo "$check_selection"
@@ -70,19 +75,15 @@ FROM nodered/node-red:${DOCKERHUB_TAG}
 
 # reference argument - omitted defaults to null
 ARG EXTRA_PACKAGES
-ENV EXTRA_PACKAGES=${EXTRA_PACKAGES}
 
 # default user is node-red - need to be root to install packages
 USER root
 
 # install packages
-RUN apk update && apk add --no-cache eudev-dev ${EXTRA_PACKAGES}
+RUN apk add --no-cache eudev-dev ${EXTRA_PACKAGES}
 
 # switch back to default user
 USER node-red
-
-# variable not needed inside running container
-ENV EXTRA_PACKAGES=
 
 # add-on nodes follow
 


### PR DESCRIPTION
Harmonises list of add-on nodes across old-menu and master branches. This includes removal of `node-red-node-rbe` which has been replaced by the built-in Filter node. See:

- [Release notes](https://nodered.org/blog/2021/07/20/version-2-0-released#renamed-rbe-node-to-filter-node)

Migrate from `node-red-contrib-themes/midnight-red` (deprecated) to `@node-red-contrib-themes/theme-collection` which supports many more themes. See:

- [Node-RED themes list](https://github.com/node-red-contrib-themes/theme-collection#theme-list)

Modify Dockerfile template:

1. No need to declare `EXTRA_PACKAGES` as an environment variable. It isn't needed in the container. The `ARG` reference is sufficient.

2. Remove redundant `apk update` command. The `--no-cache` flag on the `apk add` handles both package-list updates and their removal. It makes for a slightly smaller container.

   I discovered (and tested) this behaviour when posting a reply to:

   - [node-red-docker issue 338](https://github.com/node-red/node-red-docker/issues/338).