### PR TITLE
2025-03-05 Chronograf - master branch - PR 1 of 2

### DIFF
--- a/.templates/chronograf/Dockerfile
+++ b/.templates/chronograf/Dockerfile
@@ -1,0 +1,8 @@
+FROM chronograf:alpine
+
+# see https://github.com/influxdata/influxdata-docker/pull/781
+# this patch can be withdrawn if/when PR781 is applied.
+
+COPY entrypoint.sh /entrypoint.sh
+
+# EOF

--- a/.templates/chronograf/entrypoint.sh
+++ b/.templates/chronograf/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+    set -- chronograf "$@"
+fi
+
+if [ "$1" = 'chronograf' ]; then
+  export BOLT_PATH=${BOLT_PATH:-/var/lib/chronograf/chronograf-v1.db}
+fi
+
+if [ $(id -u) -eq 0 ] ; then
+  if [ "${CHRONOGRAF_AS_ROOT}" != "true" ] ; then
+    chown -Rc chronograf:chronograf /var/lib/chronograf
+    exec su-exec chronograf "$@"
+  fi
+  chown -Rc root:root /var/lib/chronograf
+else
+  if [ ! -w /var/lib/chronograf ] ; then
+    echo "You need to change ownership on chronograf's persistent store. Run:"
+    echo "  sudo chown -R $(id -u):$(id -u) /path/to/persistent/store"
+  fi
+fi
+
+exec "$@"

--- a/.templates/chronograf/service.yml
+++ b/.templates/chronograf/service.yml
@@ -1,6 +1,7 @@
 chronograf:
   container_name: chronograf
-  image: chronograf:latest
+  build:
+    context: ./.templates/chronograf/.
   restart: unless-stopped
   environment:
     - TZ=${TZ:-Etc/UTC}
@@ -10,6 +11,7 @@ chronograf:
     # - INFLUXDB_PASSWORD=
     # - INFLUXDB_ORG=
     # - KAPACITOR_URL=http://kapacitor:9092
+    # - CHRONOGRAF_AS_ROOT=true
   ports:
     - "8888:8888"
   volumes:
@@ -17,4 +19,3 @@ chronograf:
   depends_on:
     - influxdb
     # - kapacitor
-

--- a/docs/Containers/Chronograf.md
+++ b/docs/Containers/Chronograf.md
@@ -45,6 +45,8 @@ In words:
 * `docker-compose up -d` causes any newly-downloaded images to be instantiated as containers (replacing the old containers); and
 * the `prune` gets rid of the outdated images.
 
+See also [2025-03-04 patch](#patch1).
+
 ### Chronograf version pinning
 
 If you need to pin to a particular version:
@@ -69,3 +71,45 @@ If you need to pin to a particular version:
 	$ docker-compose up -d chronograf
 	$ docker system prune
 	```
+
+<a name="patch1"></a>
+## 2025-03-04 patch
+
+Chronograf does not start properly from a clean slate. The cause is explained [here](https://github.com/influxdata/influxdata-docker/pull/781).
+
+You can solve the problem in two ways:
+
+1. You can set the correct permissions yourself:
+
+	``` console
+	$ cd ~/IOTstack
+	$ docker-compose down chronograf
+	$ sudo chown -R 999:999 ./volumes/chronograf
+	$ docker-compose up -d chronograf
+	```
+	
+	Generally, this is a one-time fix. You will only need to repeat it if you start Chronograf from a clean slate.
+	
+2. You can adopt the updated service definition, either by:
+
+ 	- using the menu to delete then reinstall `chronograf`; or by
+ 	- using a text editor to hand-merge the contents of:
+
+		```
+		~/IOTstack/.templates/chronograf/service.yml
+		```
+		
+		with:
+		
+		```
+		~/IOTstack/docker-compose.yml
+		```
+
+If you adopt the updated service definition then the process for keeping Chronograf up-to-date becomes:
+
+``` console
+$ cd ~/IOTstack
+$ docker-compose build --no-cache --pull chronograf
+$ docker-compose up -d chronograf
+$ docker system prune
+```


### PR DESCRIPTION
[PR 781](https://github.com/influxdata/influxdata-docker/pull/781) was submitted on 2025-01-21 but is has now been over 40 days without any response. It isn't clear whether it is simply taking the time it needs to take, or if this is a signal that it will never be processed.

The basic problem occurs with Docker "bind mounts" which are the convention for IOTstack containers. If Chronograf launches from a clean slate, Docker will create `./volumes/chronograf` with root ownership. Although the container *launches* as root, it does not take the opportunity to enforce its ownership conventions prior to downgrading its privileges to that of (internal) user `chronograf` (ID=999). The result is the container can't write to its persistent store, crashes and goes into a restart loop.

This PR provides an augmented entry point script which sets ownership correctly prior to launching the `chronograf` process.

This PR applies the patch for IOTstack users via a local Dockerfile.

It can be unwound if/when PR781 is processed.