### PR TITLE
2025-03-05 Chronograf - old-menu branch - PR 2 of 2

### DIFF
--- a/.templates/chronograf/Dockerfile
+++ b/.templates/chronograf/Dockerfile
@@ -1,0 +1,8 @@
+FROM chronograf:alpine
+
+# see https://github.com/influxdata/influxdata-docker/pull/781
+# this patch can be withdrawn if/when PR781 is applied.
+
+COPY entrypoint.sh /entrypoint.sh
+
+# EOF

--- a/.templates/chronograf/entrypoint.sh
+++ b/.templates/chronograf/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+if [ "${1:0:1}" = '-' ]; then
+    set -- chronograf "$@"
+fi
+
+if [ "$1" = 'chronograf' ]; then
+  export BOLT_PATH=${BOLT_PATH:-/var/lib/chronograf/chronograf-v1.db}
+fi
+
+if [ $(id -u) -eq 0 ] ; then
+  if [ "${CHRONOGRAF_AS_ROOT}" != "true" ] ; then
+    chown -Rc chronograf:chronograf /var/lib/chronograf
+    exec su-exec chronograf "$@"
+  fi
+  chown -Rc root:root /var/lib/chronograf
+else
+  if [ ! -w /var/lib/chronograf ] ; then
+    echo "You need to change ownership on chronograf's persistent store. Run:"
+    echo "  sudo chown -R $(id -u):$(id -u) /path/to/persistent/store"
+  fi
+fi
+
+exec "$@"

--- a/.templates/chronograf/service.yml
+++ b/.templates/chronograf/service.yml
@@ -1,6 +1,7 @@
   chronograf:
     container_name: chronograf
-    image: chronograf:latest
+    build:
+      context: ./.templates/chronograf/.
     restart: unless-stopped
     environment:
       - TZ=${TZ:-Etc/UTC}
@@ -10,6 +11,7 @@
       # - INFLUXDB_PASSWORD=
       # - INFLUXDB_ORG=
       # - KAPACITOR_URL=http://kapacitor:9092
+      # - CHRONOGRAF_AS_ROOT=true
     ports:
       - "8888:8888"
     volumes:
@@ -17,4 +19,3 @@
     depends_on:
       - influxdb
       # - kapacitor
-


### PR DESCRIPTION
[PR 781](https://github.com/influxdata/influxdata-docker/pull/781) was submitted on 2025-01-21 but is has now been over 40 days without any response. It isn't clear whether it is simply taking the time it needs to take, or if this is a signal that it will never be processed.

The basic problem occurs with Docker "bind mounts" which are the convention for IOTstack containers. If Chronograf launches from a clean slate, Docker will create `./volumes/chronograf` with root ownership. Although the container *launches* as root, it does not take the opportunity to enforce its ownership conventions prior to downgrading its privileges to that of (internal) user `chronograf` (ID=999). The result is the container can't write to its persistent store, crashes and goes into a restart loop.

This PR provides an augmented entry point script which sets ownership correctly prior to launching the `chronograf` process.

This PR applies the patch for IOTstack users via a local Dockerfile.

It can be unwound if/when PR781 is processed.