### PR TITLE
2025-04-24 mariadb - old-menu branch - PR 2 of 2

### DIFF
--- a/.templates/mariadb/Dockerfile
+++ b/.templates/mariadb/Dockerfile
@@ -8,6 +8,8 @@ ENV CANDIDATES="/defaults/my.cnf /defaults/custom.cnf"
 #   
 #   https://discord.com/channels/638610460567928832/638610461109256194/825049573520965703
 #   https://stackoverflow.com/questions/61809270/how-to-discover-why-mariadb-crashes
+#   as at 2025-04-23, thread_cache_size is ignored (at least for MariaDB versions 10.6.9
+#   through 11.4.5 where it always has the value 100). It could probably be removed.
 RUN for CNF in ${CANDIDATES} ; do [ -f ${CNF} ] && break ; done ; \
     sed -i.bak \
         -e "s/^thread_cache_size/# thread_cache_size/" \
@@ -15,7 +17,7 @@ RUN for CNF in ${CANDIDATES} ; do [ -f ${CNF} ] && break ; done ; \
         ${CNF}
 
 # copy the health-check script into place
-ENV HEALTHCHECK_SCRIPT "iotstack_healthcheck.sh"
+ENV HEALTHCHECK_SCRIPT="iotstack_healthcheck.sh"
 COPY ${HEALTHCHECK_SCRIPT} /usr/local/bin/${HEALTHCHECK_SCRIPT}
 
 # define the health check
@@ -29,3 +31,4 @@ HEALTHCHECK \
 ENV CANDIDATES=
 
 # EOF
+


### PR DESCRIPTION
1. Dockerfile syntax deprecates `ENV key value` in favour of `ENV key=value`.

2. Adjust health-check script to deal with two problems:

	a. An issue where `MYSQL_ROOT_PASSWORD` does not result in a root
	   password being set on a newly-initialised database.
	   See [docker-mariadb issue 163](https://github.com/linuxserver/docker-mariadb/issues/163)

	b. Steady deprecation of `mysqladmin` in favour of `mariadb-admin`.