### PR TITLE
2025-04-24 gitea - old-menu branch - PR 2 of 2

### DIFF
--- a/.templates/gitea/gitea.env
+++ b/.templates/gitea/gitea.env
@@ -1,1 +1,0 @@
-# initially empty

--- a/.templates/gitea/service.yml
+++ b/.templates/gitea/service.yml
@@ -20,7 +20,8 @@
       - GITEA__security__SECRET_KEY=${GITEA_SECRET_KEY}
       - GITEA__security__INTERNAL_TOKEN=${GITEA_INTERNAL_TOKEN}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      test: ["CMD", "curl", "-sf4", "-o", "/dev/null", "http://gitea:3000"]
+    # test: ["CMD", "curl", "-sf4", "--cacert", "/data/git/cert.pem", "-o", "/dev/null", "https://gitea:3000"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/.templates/gitea/service.yml
+++ b/.templates/gitea/service.yml
@@ -1,16 +1,48 @@
   gitea:
     container_name: gitea
-    image: "kunde21/gitea-arm:latest"
+    image: docker.gitea.com/gitea:latest
     restart: unless-stopped
-    ports:
-      - "7920:3000/tcp"
-      - "2222:22/tcp"
+    depends_on:
+      - gitea_db
     environment:
       - USER_UID=1000
       - USER_GID=1000
-    env_file:
-      - ./services/gitea/gitea.env
+      - GITEA__database__DB_TYPE=mysql
+      - GITEA__database__HOST=gitea_db:3306
+      - GITEA__database__NAME=${GITEA_DB_NAME:-gitea}
+      - GITEA__database__USER=${GITEA_DB_USER:-gitea}
+      - GITEA__database__PASSWD=${GITEA_DB_PASSWORD:?eg echo GITEA_DB_PASSWORD=userPassword >>~/IOTstack/.env}
+      - GITEA__server__ROOT_URL=${GITEA_ROOT_URL}
+      - GITEA__security__INSTALL_LOCK=true
+      - GITEA__security__SECRET_KEY=${GITEA_SECRET_KEY}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    ports:
+      - "7920:3000/tcp"
+      - "2222:22/tcp"
     volumes:
       - ./volumes/gitea/data:/data
-      - /etc/timezone:/etc/timezone:ro
-      - /etc/localtime:/etc/localtime:ro
+    networks:
+      - default
+      - nextcloud
+
+  gitea_db:
+    container_name: gitea_db
+    build: ./.templates/mariadb/.
+    restart: unless-stopped
+    environment:
+      - TZ=${TZ:-Etc/UTC}
+      - PUID=1000
+      - PGID=1000
+      - MYSQL_ROOT_PASSWORD=${GITEA_DB_ROOT_PASSWORD:?eg echo GITEA_DB_ROOT_PASSWORD=rootPassword >>~/IOTstack/.env}
+      - MYSQL_DATABASE=${GITEA_DB_NAME:-gitea}
+      - MYSQL_USER=${GITEA_DB_USER:-gitea}
+      - MYSQL_PASSWORD=${GITEA_DB_PASSWORD:?eg echo GITEA_DB_PASSWORD=userPassword >>~/IOTstack/.env}
+    volumes:
+      - ./volumes/gitea/db:/config
+      - ./volumes/gitea/db_backup:/backup
+    networks:
+      - nextcloud

--- a/.templates/gitea/service.yml
+++ b/.templates/gitea/service.yml
@@ -18,6 +18,7 @@
     # - GITEA__server__CERT_FILE=/data/git/cert.pem
       - GITEA__security__INSTALL_LOCK=true
       - GITEA__security__SECRET_KEY=${GITEA_SECRET_KEY}
+      - GITEA__security__INTERNAL_TOKEN=${GITEA_INTERNAL_TOKEN}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000"]
       interval: 30s

--- a/.templates/gitea/service.yml
+++ b/.templates/gitea/service.yml
@@ -12,7 +12,10 @@
       - GITEA__database__NAME=${GITEA_DB_NAME:-gitea}
       - GITEA__database__USER=${GITEA_DB_USER:-gitea}
       - GITEA__database__PASSWD=${GITEA_DB_PASSWORD:?eg echo GITEA_DB_PASSWORD=userPassword >>~/IOTstack/.env}
+      - GITEA__server__PROTOCOL=${GITEA_WEB_PROTOCOL:-http}
       - GITEA__server__ROOT_URL=${GITEA_ROOT_URL}
+    # - GITEA__server__KEY_FILE=/data/git/key.pem
+    # - GITEA__server__CERT_FILE=/data/git/cert.pem
       - GITEA__security__INSTALL_LOCK=true
       - GITEA__security__SECRET_KEY=${GITEA_SECRET_KEY}
     healthcheck:

--- a/.templates/gitea/service.yml
+++ b/.templates/gitea/service.yml
@@ -20,8 +20,8 @@
       - GITEA__security__SECRET_KEY=${GITEA_SECRET_KEY}
       - GITEA__security__INTERNAL_TOKEN=${GITEA_INTERNAL_TOKEN}
     healthcheck:
-      test: ["CMD", "curl", "-sf4", "-o", "/dev/null", "http://gitea:3000"]
-    # test: ["CMD", "curl", "-sf4", "--cacert", "/data/git/cert.pem", "-o", "/dev/null", "https://gitea:3000"]
+      test: ["CMD-SHELL", "curl -sf4 -o /dev/null http://gitea:3000"]
+    # test: ["CMD-SHELL", "curl -sf4 --cacert $$GITEA__server__CERT_FILE -o /dev/null https://gitea:3000"]
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
1. Updates to image which is being actively maintained.

2. Adopts environment variable conventions of new image.

3. Uses custom MariaDB instance as back-end.

4. Removes `/etc/timezone` mapping (without replacing with `TZ`) because new image is built without `tzdata`.

5. Empty `gitea.env` removed in favour of inline environment variables.

6. Basic documentation on master branch.