### PR TITLE
2025-04-24 influxdb - old-menu branch - PR 2 of 2

### DIFF
--- a/.templates/influxdb/service.yml
+++ b/.templates/influxdb/service.yml
@@ -1,7 +1,8 @@
   influxdb:
     container_name: influxdb
-    image: "influxdb:1.8"
+    image: "influxdb:1.11"
     restart: unless-stopped
+    user: "0"
     ports:
       - "8086:8086"
       - "8083:8083"


### PR DESCRIPTION
InfluxDB has departed from the pattern established in 2021 whereby pinning to the `1.8` tag was (effectively) a synonym for "the latest release of InfluxDB 1".

At some point in the last few months, the `1.11` tag took on this role. This seems to have happened after a period of experimentation involving variants of `1.9-xx` and `1.10-xx`. It looks like there never were plain `1.9` or `1.10` tags so we (IOTstack) really haven't missed much.

The 1.8 (and earlier) containers launched as root. The 1.11 container launches as root but downgrades its privileges to user ID 1500 (user `influxdb` inside the container). In a clean-slate situation, `docker-compose` will create the persistent store owned by root. In an "upgrade 1.8 to 1.11" situation, the persistent store will be owned by root. Version 1.11 does not appear to contain any self-repair code for dealing with either of these situations, which means the container is unable to access its persistent store, crashes, and goes into a restart loop. Adding a `user: "0"` clause restores the 1.8 behaviour so 1.11 launches properly.

I have been running v1.11 for the last month without issues so I see no reason not to make this the default for IOTstack.