### PR TITLE
2025-05-31 mariadb - master branch - PR 1 of 2

### DIFF
--- a/.templates/mariadb/Dockerfile
+++ b/.templates/mariadb/Dockerfile
@@ -16,6 +16,10 @@ RUN for CNF in ${CANDIDATES} ; do [ -f ${CNF} ] && break ; done ; \
         -e "s/^read_buffer_size/# read_buffer_size/" \
         ${CNF}
 
+# copy the root password check+fix into place
+# https://github.com/linuxserver/docker-mariadb/issues/163
+COPY iotstack_check-root-password.sh /etc/periodic/15min/iotstack_check-root-password.sh
+
 # copy the health-check script into place
 ENV HEALTHCHECK_SCRIPT="iotstack_healthcheck.sh"
 COPY ${HEALTHCHECK_SCRIPT} /usr/local/bin/${HEALTHCHECK_SCRIPT}

--- a/.templates/mariadb/iotstack_check-root-password.sh
+++ b/.templates/mariadb/iotstack_check-root-password.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# https://github.com/linuxserver/docker-mariadb/issues/163
+# assumed installation path is /etc/periodic/15min/iotstack_check-root-password.sh
+
+# marker file
+MARKER="/tmp/root-password-checked"
+
+# sense marker already exists
+[ -f "${MARKER}" ] && exit 0
+
+# create the marker
+touch "${MARKER}"
+
+# sense root password not defined yet.
+# (defining the var necessarily causes a recreate)
+[ -z "${MYSQL_ROOT_PASSWORD}" ] && exit 0
+
+# can we execute a trivial command as root but WITHOUT a password?
+if $(mariadb -u root -e 'quit' &> /dev/null) ; then
+   # yes! Set the password now
+   mariadb-admin -u root password "${MYSQL_ROOT_PASSWORD}"
+   echo "root password was not set - is now set" >"${MARKER}"
+else
+   echo "root password checked - already set" >"${MARKER}"
+fi
+
+exit 0

--- a/docs/Containers/Gitea.md
+++ b/docs/Containers/Gitea.md
@@ -45,7 +45,7 @@ Environment variables need to be set in several stages:
 		$ echo "GITEA_DB_ROOT_PASSWORD=$(uuidgen)" >>~/IOTstack.env
 		```
 
-		If omitted, the container will not start. See [note below](#rootpw).
+		If omitted, the container will not start.
 
 	You (the human user) will **never** need to know the username and passwords set here. You will not need to use these values in practice.
 
@@ -169,24 +169,6 @@ Environment variables need to be set in several stages:
 		In words, run the command "at five minutes after midnight on the first of January and the first of July".
 
 	* Gitea also supports LetsEncrypt. See [using ACME with Let's Encrypt](https://docs.gitea.com/administration/https-setup#using-acme-default-lets-encrypt).
-
-## database root password  { #rootpw }
-
-At the time of writing (April 2025), the MariaDB instance was not respecting the environment variable being used to pass the root password into the container.
-
-> See [MariaDB issue 163](https://github.com/linuxserver/docker-mariadb/issues/163)
-
-You can ensure that the root password is set by running the following command:
-
-``` console
-$ docker exec gitea_db bash -c 'mariadb-admin -u root password $MYSQL_ROOT_PASSWORD'
-```
-
-If this command returns an error, it means that the root password was already set (presumably because Issue 163 has been resolved).
-
-If this command succeeds without error, it means that the root password was not set but is now set.
-
-Also notice that you did not need to know or copy/paste the root password to run the above command. It was sufficient to know the name of the environment variable containing the database root password.
 
 ## default ports
 


### PR DESCRIPTION
When I filed
[docker-mariadb issue 163](https://github.com/linuxserver/docker-mariadb/issues/163) I had hoped for a fairly quick fix.

The problem (for IOTstack) is not so much about the root password not being set on newly-initialised mariadb containers but how mariadb commands react when the root password has not been set.

In particular, the IOTstackBackup routines that handle instances of MariaDB trigger backups like this:

```
docker exec mariadb bash -c mariadb-dump --single-transaction -p\$MYSQL_ROOT_PASSWORD \$MYSQL_DATABASE >/backup/backup.sql"
```

That command will fail if the root password was not set when the persistent store was initialised. Unless the user notices the resulting log message and interprets it correctly, the user will likely assume that database backups are occurring when, in fact, they are not.

This problem affects gitea, nextcloud and wordpress, as well as pure instances of mariadb.

The "solution" proposed here is to leverage the existing `cron` periodic jobs structure inside mariadb containers. Every 15 minutes a script will run to check whether the root password has been set, and set it if it has not been. The body of the script really only runs once per container launch, thereafter sensing it has already run and taking an early exit.

This strategy will continue to work once Issue 163 is resolved. It will just become a no-op which can be removed safely at a later date. The approach is also unlikely to interfere with however a fix for Issue 163 is implemented.

The Gitea documentation has been updated to remove the "how to" instructions which only worked for *that* container-pair, in favour of this solution which will work for *all* relevant containers.