### PR TITLE
fix(nodered): fix FileNotFoundError and PermissionError in preBuild

### DIFF
--- a/.templates/nodered/build.py
+++ b/.templates/nodered/build.py
@@ -111,11 +111,10 @@ def main():
     with open(r'%s/Dockerfile.template' % serviceTemplate, 'r') as dockerTemplate:
       templateData = dockerTemplate.read()
 
-    with open(r'%s' % addonsFile) as objAddonsFile:
-      addonsSelected = yaml.load(objAddonsFile)
-
     addonsInstallCommands = ""
     if os.path.exists(addonsFile):
+      with open(r'%s' % addonsFile) as objAddonsFile:
+        addonsSelected = yaml.load(objAddonsFile)
       installCommand = addonsSelected["dockerFileInstallCommand"]
       for (index, addonName) in enumerate(addonsSelected["addons"]):
         if (addonName == 'node-red-node-sqlite'): # SQLite requires a special param
@@ -125,8 +124,15 @@ def main():
 
     templateData = templateData.replace(dockerfileTemplateReplace, addonsInstallCommands)
 
-    with open(r'%s/Dockerfile' % serviceService, 'w') as dockerTemplate:
-      dockerTemplate.write(templateData)
+    dockerfilePath = r'%s/Dockerfile' % serviceService
+    try:
+      with open(dockerfilePath, 'w') as dockerTemplate:
+        dockerTemplate.write(templateData)
+    except PermissionError:
+      print("Error: Permission denied writing '{path}'.".format(path=dockerfilePath))
+      print("This can happen if a previous build was run as root.")
+      print("Fix with: sudo chown $USER:$USER {path}".format(path=dockerfilePath))
+      return False
     print("Finished NodeRed Build script")
     time.sleep(0.3)
     return True


### PR DESCRIPTION
## Problem

Two bugs were found in `.templates/nodered/build.py` during a fresh Node-RED setup:

### Bug 1 — FileNotFoundError on first-time setup
`addons_list.yml` is optional and is generated via the Options menu. However, `open(addonsFile)` was called unconditionally **before** the `os.path.exists()` check, causing an immediate crash when the file does not yet exist:

> `FileNotFoundError: [Errno 2] No such file or directory: './services/nodered/addons_list.yml'`

### Bug 2 — PermissionError when Dockerfile was previously created as root
If the user ran `menu.sh` with `sudo` at any point, the generated `Dockerfile` is owned by `root`. On the next build run as a regular user, writing the Dockerfile fails with:

> `PermissionError: [Errno 13] Permission denied: './services/nodered/Dockerfile'`

There was no actionable error message — the user had no way to know what went wrong or how to fix it.

## Fix

- **Bug 1:** Moved `open(addonsFile)` inside the `os.path.exists()` guard so the file is only opened when it actually exists.
- **Bug 2:** Wrapped the Dockerfile write in a `try/except PermissionError` block that prints a clear message with the exact `chown` command needed to resolve the issue.

## Testing

Reproduced both errors on a Raspberry Pi running IOTstack. Applied the fix and confirmed clean builds with and without `addons_list.yml` present.