### PR TITLE
2026-04-07 installer - master branch - don't create treeless clone

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # version - MUST be exactly 7 characters!
-UPDATE="2026v01"
+UPDATE="2026v02"
 
 #----------------------------------------------------------------------
 # The intention of this script is that it should be able to be run
@@ -33,12 +33,6 @@ IOTSTACK_ENV="$IOTSTACK/.env"
 IOTSTACK_MENU_REQUIREMENTS="$IOTSTACK/requirements-menu.txt"
 IOTSTACK_MENU_VENV_DIR="$IOTSTACK/.virtualenv-menu"
 IOTSTACK_INSTALLER_HINT="$IOTSTACK/.new_install"
-
-# git cloning options which can be overridden
-# (needs special handling for the null case)
-if [[ ! -v GIT_CLONE_OPTIONS ]] ; then
-	GIT_CLONE_OPTIONS="--filter=tree:0"
-fi
 
 # the expected installation location of docker-compose-plugin is
 COMPOSE_PLUGIN_PATH="/usr/libexec/docker/cli-plugins/docker-compose"
@@ -443,13 +437,8 @@ fi
 # does the IOTstack folder already exist?
 if [ ! -d "$IOTSTACK" ] ; then
 	# no! clone from GitHub
-	if [ -n "$GIT_CLONE_OPTIONS" ] ; then
-		echo -e "\nCloning the IOTstack repository from GitHub using options $GIT_CLONE_OPTIONS"
-		git clone "$GIT_CLONE_OPTIONS" https://github.com/SensorsIot/IOTstack.git "$IOTSTACK"
-	else
-		echo -e "\nCloning the full IOTstack repository from GitHub"
-		git clone https://github.com/SensorsIot/IOTstack.git "$IOTSTACK"
-	fi
+	echo -e "\nCloning IOTstack repository from GitHub"
+	git clone https://github.com/SensorsIot/IOTstack.git "$IOTSTACK"
 	if [ $? -eq 0 -a -d "$IOTSTACK" ] ; then
 		echo "IOTstack cloned successfully into $IOTSTACK"
 	else


### PR DESCRIPTION
Discussion occurring around
[IOTstack PR740](https://github.com/SensorsIot/IOTstack/pull/740) led to `install.sh` cloning IOTstack using the `tree:0` filter, thereby producing a so-called *treeless clone.* This change was also mirrored in PiBuilder.

PiBuilder is typically used where the starting point is a clean installation of the operating system (eg Raspberry Pi OS or Debian). The IOTstack directory won't exist so PiBuilder will always create a treeless clone.

The `install.sh` script is slightly different. If a maker clones IOTstack from GitHub and then runs the installer (either directly or when prompted by the menu), the starting point is still a full clone. The only time you would expect to see the installer create a treeless clone is where the IOTstack directory doesn't exist and the maker is following the instruction to run:

```
curl -fsSL https://raw.githubusercontent.com/SensorsIot/IOTstack/master/install.sh | bash
```

Treeless clones *mostly* work but occasionally prove problematic. The two situations I have run into are:

* If Git needs to fetch missing information, it can take an *interminable* time for operations to complete, and involves a significant amount of comms traffic. Git *is* working but gives every appearance of being stuck in a loop, thereby inviting a <kbd>control</kbd>+<kbd>c</kbd> and the risk of a mess.

* Adding a parallel remote and then pulling from that parallel remote can abort with cryptic errors.

Basically, any efficiency gains you might have made at the time the treeless clone was created are lost, in spades, as soon as you strike a problem.

It seems that I am not alone in viewing treeless clones with a bent eye. Per [github blog](https://github.blog/open-source/git/get-up-to-speed-with-partial-clone-and-shallow-clone/):

> We strongly recommend that developers do not use treeless clones for
  their daily work. Treeless clones are really only helpful for
  automated builds when you want to quickly clone, compile a project,
  then throw away the repository. In environments like GitHub Actions
  using public runners, you want to minimize your clone time so you can
  spend your machine time actually building your software! Treeless
  clones might be an excellent option for those environments

I think this is good advice! Accordingly, this PR restores the pre-PR740 situation and always creates full clones.

See also [upgrading a "treeless" Git clone](https://github.com/Paraphraser/PiBuilder/blob/master/docs/upgrade-treeless-clone.md).