### PR TITLE
2026-05-29 InfluxDB - old-menu branch - PR 2 of 2

### DIFF
--- a/.templates/influxdb/service.yml
+++ b/.templates/influxdb/service.yml
@@ -1,6 +1,6 @@
   influxdb:
     container_name: influxdb
-    image: "influxdb:1.11"
+    image: "influxdb:1.12"
     restart: unless-stopped
     user: "0"
     ports:

--- a/.templates/influxdb2/service.yml
+++ b/.templates/influxdb2/service.yml
@@ -1,6 +1,6 @@
   influxdb2:
     container_name: influxdb2
-    image: "influxdb:latest"
+    image: "influxdb:2"
     restart: unless-stopped
     environment:
       - TZ=${TZ:-Etc/UTC}


### PR DESCRIPTION
This is a followup to a [Discord post](https://discord.com/channels/638610460567928832/638610461109256194/1509231923527155742)

Changes InfluxDB image tag pins:

* InfluxDB 1.x from `:1.11` to `:1.12`.
* InfluxDB 2.x from `:latest` to `:2`.

I have been using 1.12 for some time without issue.

[DockerHub](https://hub.docker.com/_/influxdb) contains the following statement:

> On May 27, 2026, the latest tag for InfluxDB will point to InfluxDB 3
  Core. To avoid unexpected upgrades, use specific version tags in your
  deployments.

As of this writing (May 29), the following [tags](https://hub.docker.com/_/influxdb/tags) all point to the same image IDs:

* `:latest`
* `:2.9.1`
* `:2.9`
* `:2`

It seems reasonable to infer that `:2` will continue to imply "the latest stable release of InfluxDB 2" and, accordingly, will be the appropriate tag for IOTstack.

As a note for the future, come the day when (if) InfluxDB 3 support is added to IOTstack, the appropriate tag will be `:3-core` rather than `:latest`.